### PR TITLE
Improve home page and add login flow

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function AdminDashboard() {
+  return (
+    <div className="p-8 text-green-100">
+      <h1 className="text-3xl font-bold mb-6 text-primary">Admin Dashboard</h1>
+      <ul className="space-y-2">
+        <li>
+          <Link href="/admin/service-categories" className="underline hover:text-primary">Manage Service Categories</Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@
 import './globals.css'
 import React from 'react'
 import { Providers } from './providers'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
 import "react-datepicker/dist/react-datepicker.css";
 
 export const metadata = {
@@ -66,8 +68,14 @@ export default function RootLayout({
           }
         `}</style>
       </head>
-      <body>
-        <Providers>{children}</Providers>
+      <body className="min-h-screen flex flex-col">
+        <Providers>
+          <Header />
+          <main className="flex-1">
+            {children}
+          </main>
+          <Footer />
+        </Providers>
       </body>
     </html>
   )

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,21 +1,29 @@
 'use client'
-import { signIn } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 
 export default function LoginPage() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setTimeout(() => {
+      router.push('/admin')
+    }, 500)
+  }
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100 p-6">
-      <div className="bg-white shadow-md p-8 rounded-lg w-full max-w-md">
-        <h1 className="text-2xl font-semibold mb-4 text-center">Login to Greens Salon</h1>
-
-        <button
-          onClick={() => signIn('google')}
-          className="w-full bg-green-600 text-white py-2 rounded hover:bg-green-700 transition"
-        >
-          Sign in with Google
+      <form onSubmit={handleSubmit} className="bg-white shadow-md p-8 rounded-lg w-full max-w-md space-y-4">
+        <h1 className="text-2xl font-semibold text-center text-green-700">Admin Login</h1>
+        <input type="text" placeholder="Username" className="w-full border border-gray-300 p-2 rounded" required />
+        <input type="password" placeholder="Password" className="w-full border border-gray-300 p-2 rounded" required />
+        <button type="submit" className="w-full bg-green-600 text-white py-2 rounded hover:bg-green-700 transition">
+          {loading ? 'Logging in...' : 'Login'}
         </button>
-
-        <p className="text-sm text-center mt-6 text-gray-500">More login options coming soon</p>
-      </div>
+      </form>
     </div>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -103,23 +103,6 @@ export default function HomePage() {
   // ---- PAGE STARTS HERE ----
   return (
     <main className="bg-[#052b1e] min-h-screen font-sans text-green-50">
-      {/* HEADER */}
-      <header className="sticky top-0 z-50 bg-[#03150d] bg-opacity-98 shadow flex items-center justify-between px-3 py-2">
-        <a href="/" className="flex items-center">
-          <img src="/logo.png" alt="Greens Beauty Salon Logo" className="w-auto h-11" />
-        </a>
-        <div className="flex items-center gap-3">
-          <a href="tel:+918891467678" className="flex items-center gap-1 bg-[#052b1e] hover:bg-primary/10 px-3 py-2 rounded-full text-green-100 font-medium shadow transition">
-            <FiPhone className="text-lg" /> Call
-          </a>
-          <a href="/cart" className="relative">
-            <FiShoppingCart className="text-2xl text-primary" />
-            {cart.length > 0 && (
-              <span className="absolute -top-2 -right-2 text-xs bg-yellow-400 text-black rounded-full px-1 font-bold">{cart.length}</span>
-            )}
-          </a>
-        </div>
-      </header>
 
       {/* HERO SECTION WITH VIDEO */}
 <section className="relative min-h-[420px] md:min-h-[520px] flex items-center justify-center overflow-hidden">
@@ -155,6 +138,9 @@ export default function HomePage() {
         className="px-6 py-2 rounded-full bg-primary text-[#03150d] font-medium hover:bg-opacity-90 transition-colors text-center"
       >
         Book Now
+      </a>
+      <a href="/login" className="px-6 py-2 rounded-full bg-[#052b1e] text-primary font-medium hover:bg-[#0c422d] transition-colors text-center">
+        Login
       </a>
     </div>
   </div>
@@ -605,10 +591,6 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ---- FOOTER ---- */}
-      <footer className="text-center py-5 text-green-200 text-xs bg-[#082012]">
-        &copy; {new Date().getFullYear()} Greens Beauty Salon. All rights reserved.
-      </footer>
       <style>{`
         .text-primary { color: #41eb70 !important; }
         .bg-primary { background: #41eb70 !important; }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,8 @@
+"use client";
+export default function Footer() {
+  return (
+    <footer className="bg-[#082012] text-green-200 text-xs text-center py-5 mt-auto">
+      &copy; {new Date().getFullYear()} Greens Beauty Salon. All rights reserved.
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,31 +1,70 @@
-import { FiShoppingCart, FiUser, FiPhone } from "react-icons/fi";
-import { FaCut } from "react-icons/fa";
+"use client";
+import Link from "next/link";
+import { useState } from "react";
+import { FiShoppingCart, FiPhone, FiMenu } from "react-icons/fi";
 
 export default function Header({ cartCount = 0 }: { cartCount?: number }) {
+  const [open, setOpen] = useState(false);
   return (
-    <header className="sticky top-0 z-50 bg-[#03150d] bg-opacity-98 shadow flex items-center justify-between px-3 py-2">
-      <a href="/" className="flex items-center">
-        {/* Logo image */}
-        <img src="/logo.png" alt="Greens Beauty Salon Logo" className="w-auto h-11" />
-      </a>
+    <header className="sticky top-0 z-50 bg-[#03150d] text-green-100 shadow flex items-center justify-between px-4 py-3">
+      <Link href="/" className="flex items-center gap-2">
+        <img src="/logo.png" alt="Greens Beauty Salon Logo" className="h-10 w-auto" />
+        <span className="font-bold text-xl text-primary hidden sm:block">Greens</span>
+      </Link>
+      <nav className="hidden md:flex items-center gap-6 text-sm">
+        <Link href="/" className="hover:text-primary">Home</Link>
+        <Link href="/booking" className="hover:text-primary">Booking</Link>
+        <Link href="/cart" className="hover:text-primary flex items-center gap-1">
+          <FiShoppingCart /> Cart{cartCount > 0 && (
+            <span className="ml-1 bg-yellow-400 text-black rounded-full px-1 text-xs font-bold">{cartCount}</span>
+          )}
+        </Link>
+        <div className="relative group">
+          <span className="cursor-pointer group-hover:text-primary">Customer ▾</span>
+          <div className="absolute left-0 mt-2 hidden group-hover:block bg-[#03150d] border border-[#24432a] rounded shadow p-2 w-40 text-sm">
+            <Link href="/customer/dashboard" className="block px-2 py-1 hover:text-primary">Dashboard</Link>
+            <Link href="/customer/profile" className="block px-2 py-1 hover:text-primary">Profile</Link>
+            <Link href="/customer/my-bookings" className="block px-2 py-1 hover:text-primary">My Bookings</Link>
+          </div>
+        </div>
+        <div className="relative group">
+          <span className="cursor-pointer group-hover:text-primary">Admin ▾</span>
+          <div className="absolute left-0 mt-2 hidden group-hover:block bg-[#03150d] border border-[#24432a] rounded shadow p-2 w-40 text-sm">
+            <Link href="/admin" className="block px-2 py-1 hover:text-primary">Dashboard</Link>
+            <Link href="/admin/service-categories" className="block px-2 py-1 hover:text-primary">Categories</Link>
+          </div>
+        </div>
+      </nav>
       <div className="flex items-center gap-3">
-        {/* Call button */}
         <a
           href="tel:+918891467678"
-          className="flex items-center gap-1 bg-[#052b1e] hover:bg-primary/10 px-3 py-2 rounded-full text-green-100 font-medium shadow transition"
+          className="hidden sm:flex items-center gap-1 bg-[#052b1e] hover:bg-primary/10 px-3 py-2 rounded-full text-green-100 font-medium shadow transition"
         >
           <FiPhone className="text-lg" /> Call
         </a>
-        {/* Cart icon */}
-        <a href="/cart" className="relative">
-          <FiShoppingCart className="text-2xl text-primary" />
-          {cartCount > 0 && (
-            <span className="absolute -top-2 -right-2 text-xs bg-yellow-400 text-black rounded-full px-1 font-bold">
-              {cartCount}
-            </span>
-          )}
-        </a>
+        <Link href="/login" className="bg-primary text-black font-semibold px-4 py-2 rounded-full hover:bg-green-400 transition">Login</Link>
+        <button onClick={() => setOpen(!open)} className="md:hidden p-2">
+          <FiMenu />
+        </button>
       </div>
+      {open && (
+        <div className="absolute top-full left-0 right-0 bg-[#03150d] border-t border-[#24432a] flex flex-col items-start p-4 md:hidden text-sm">
+          <Link href="/" className="py-1" onClick={() => setOpen(false)}>Home</Link>
+          <Link href="/booking" className="py-1" onClick={() => setOpen(false)}>Booking</Link>
+          <Link href="/cart" className="py-1 flex items-center gap-1" onClick={() => setOpen(false)}>
+            <FiShoppingCart /> Cart{cartCount > 0 && (
+              <span className="ml-1 bg-yellow-400 text-black rounded-full px-1 text-xs font-bold">{cartCount}</span>
+            )}
+          </Link>
+          <div className="mt-2 font-semibold">Customer</div>
+          <Link href="/customer/dashboard" className="py-1 pl-3" onClick={() => setOpen(false)}>Dashboard</Link>
+          <Link href="/customer/profile" className="py-1 pl-3" onClick={() => setOpen(false)}>Profile</Link>
+          <Link href="/customer/my-bookings" className="py-1 pl-3" onClick={() => setOpen(false)}>My Bookings</Link>
+          <div className="mt-2 font-semibold">Admin</div>
+          <Link href="/admin" className="py-1 pl-3" onClick={() => setOpen(false)}>Dashboard</Link>
+          <Link href="/admin/service-categories" className="py-1 pl-3" onClick={() => setOpen(false)}>Categories</Link>
+        </div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- create global header and footer components
- include header and footer in site layout
- redesign home page hero area and add prominent login button
- implement a dummy login page that redirects to the admin dashboard
- add a simple admin dashboard page with link to service categories

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873368c29e48325b2453ffb711c4517