### PR TITLE
Fix staff cards and removed filter

### DIFF
--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -72,7 +72,6 @@ export async function POST(req: Request) {
             phone: customerPhone,
             gender: customerGender || null,
             role: 'customer',
-            active: true,
           }
         });
       } else {

--- a/src/app/api/staff.ts
+++ b/src/app/api/staff.ts
@@ -6,7 +6,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method !== "GET") return res.status(405).end();
   try {
     const staff = await prisma.user.findMany({
-      where: { role: "staff", active: true }, // Add 'active' if needed
+      where: { role: "staff", removed: false },
       select: { id: true, name: true },
       orderBy: { name: "asc" },
     });

--- a/src/app/api/staff/route.ts
+++ b/src/app/api/staff/route.ts
@@ -8,27 +8,15 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const branchId = searchParams.get('branchId');
 
-    if (!branchId) {
-      return Response.json({ success: false, error: 'Missing branchId' }, { status: 400 });
-    }
+    const where: any = { role: 'staff' };
+    if (branchId) where.branchId = branchId;
 
     const staff = await prisma.user.findMany({
-      where: {
-        role: 'STAFF',
-        branchId: branchId,
-        removed: false,
+      where,
+      include: {
+        branch: { select: { id: true, name: true } },
       },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        phone: true,
-        gender: true,
-        designation: true,
-      },
-      orderBy: {
-        name: 'asc',
-      },
+      orderBy: { name: 'asc' },
     });
 
     return Response.json({ success: true, staff });

--- a/src/app/api/staff/toggle/route.ts
+++ b/src/app/api/staff/toggle/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
 export async function POST(req: Request) {
-  const { id, active } = await req.json();
+  const { id, removed } = await req.json();
   try {
     await prisma.user.update({
       where: { id },
-      data: { active },
+      data: { removed },
     });
     return NextResponse.json({ success: true });
   } catch (e) {


### PR DESCRIPTION
## Summary
- include branch and removed status when listing staff
- toggle the `removed` flag instead of nonexistent active field
- update staff management page to show cards and filter on removed state

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68737c1b308c83259363a17a2360099e