### PR TITLE
Fix closing brace and JSX map typo

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -369,14 +369,14 @@ export default function HomePage() {
                                   </div>
                                   <Link href={`/services/${svc.id}`} className="text-green-400 underline text-sm">View Details</Link>
                                 </div>
-                              ))}
+                              ))
                             </div>
                           </motion.div>
                         )}
                       </AnimatePresence>
                     </motion.div>
                   )
-                })}
+                })
               </AnimatePresence>
             </div>
           </div>
@@ -578,3 +578,4 @@ export default function HomePage() {
       </footer>
     </main>
   )
+}


### PR DESCRIPTION
## Summary
- fix JSX map closing typo in `page.tsx`
- close `HomePage` component function properly

## Testing
- `npx prettier src/app/page.tsx --parser babel-ts` *(fails: Adjacent JSX elements must be wrapped in an enclosing tag)*

------
https://chatgpt.com/codex/tasks/task_e_687397a4c938832587cec3da8d194b77