### PR TITLE
Add service tier admin

### DIFF
--- a/src/app/api/admin/service-new/[id]/route.ts
+++ b/src/app/api/admin/service-new/[id]/route.ts
@@ -1,0 +1,24 @@
+import { PrismaClient } from '@prisma/client'
+import { NextResponse } from 'next/server'
+
+const prisma = new PrismaClient()
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json()
+  const service = await prisma.serviceNew.update({
+    where: { id: params.id },
+    data: {
+      name: data.name,
+      caption: data.caption || null,
+      description: data.description || null,
+      imageUrl: data.imageUrl || null,
+    },
+  })
+  return NextResponse.json(service)
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  await prisma.serviceTier.deleteMany({ where: { serviceId: params.id } })
+  await prisma.serviceNew.delete({ where: { id: params.id } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/service-tiers/[serviceId]/route.ts
+++ b/src/app/api/admin/service-tiers/[serviceId]/route.ts
@@ -1,0 +1,43 @@
+import { PrismaClient } from '@prisma/client'
+import { NextResponse } from 'next/server'
+
+const prisma = new PrismaClient()
+
+export async function GET(req: Request, { params }: { params: { serviceId: string } }) {
+  const tiers = await prisma.serviceTier.findMany({ where: { serviceId: params.serviceId }, orderBy: { name: 'asc' } })
+  return NextResponse.json(tiers)
+}
+
+export async function POST(req: Request, { params }: { params: { serviceId: string } }) {
+  const data = await req.json()
+  const tier = await prisma.serviceTier.create({
+    data: {
+      serviceId: params.serviceId,
+      name: data.name,
+      actualPrice: Number(data.actualPrice || 0),
+      offerPrice: data.offerPrice === null || data.offerPrice === undefined ? null : Number(data.offerPrice),
+      duration: data.duration ? Number(data.duration) : null,
+    },
+  })
+  return NextResponse.json(tier)
+}
+
+export async function PUT(req: Request, { params }: { params: { serviceId: string } }) {
+  const data = await req.json()
+  const tier = await prisma.serviceTier.update({
+    where: { id: data.id },
+    data: {
+      name: data.name,
+      actualPrice: Number(data.actualPrice || 0),
+      offerPrice: data.offerPrice === null || data.offerPrice === undefined ? null : Number(data.offerPrice),
+      duration: data.duration ? Number(data.duration) : null,
+    },
+  })
+  return NextResponse.json(tier)
+}
+
+export async function DELETE(req: Request, { params }: { params: { serviceId: string } }) {
+  const { id } = await req.json()
+  await prisma.serviceTier.delete({ where: { id } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/services-new/[categoryId]/route.ts
+++ b/src/app/api/admin/services-new/[categoryId]/route.ts
@@ -1,0 +1,35 @@
+import { PrismaClient } from '@prisma/client'
+import { NextResponse } from 'next/server'
+
+const prisma = new PrismaClient()
+
+export async function GET(req: Request, { params }: { params: { categoryId: string } }) {
+  const services = await prisma.serviceNew.findMany({
+    where: { categoryId: params.categoryId },
+    include: { tiers: true },
+    orderBy: { name: 'asc' },
+  })
+  return NextResponse.json(services)
+}
+
+export async function POST(req: Request, { params }: { params: { categoryId: string } }) {
+  const data = await req.json()
+  const service = await prisma.serviceNew.create({
+    data: {
+      categoryId: params.categoryId,
+      name: data.name,
+      caption: data.caption || null,
+      description: data.description || null,
+      imageUrl: data.imageUrl || null,
+    },
+  })
+  return NextResponse.json(service)
+}
+
+export async function PUT(req: Request, { params }: { params: { categoryId: string } }) {
+  const newOrder: { id: string; order: number }[] = await req.json()
+  for (const s of newOrder) {
+    await prisma.serviceNew.update({ where: { id: s.id }, data: { order: s.order } })
+  }
+  return NextResponse.json({ success: true })
+}


### PR DESCRIPTION
## Summary
- add admin API to manage `ServiceNew` and related tiers
- support editing and listing tiers with new admin page

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68739e937db48325a30a670dd498b2ce