### PR TITLE
Add service image management

### DIFF
--- a/src/app/api/admin/service-images/[serviceId]/route.ts
+++ b/src/app/api/admin/service-images/[serviceId]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(req: Request, { params }: { params: { serviceId: string } }) {
+  const images = await prisma.serviceImage.findMany({
+    where: { serviceId: params.serviceId },
+    orderBy: { id: 'asc' },
+  })
+  return NextResponse.json(images)
+}
+
+export async function POST(req: Request, { params }: { params: { serviceId: string } }) {
+  const data = await req.json()
+  const image = await prisma.serviceImage.create({
+    data: {
+      serviceId: params.serviceId,
+      imageUrl: data.imageUrl,
+      caption: data.caption || null,
+    },
+  })
+  return NextResponse.json(image)
+}
+
+export async function PUT(req: Request, { params }: { params: { serviceId: string } }) {
+  const data = await req.json()
+  const image = await prisma.serviceImage.update({
+    where: { id: data.id },
+    data: {
+      imageUrl: data.imageUrl,
+      caption: data.caption || null,
+    },
+  })
+  return NextResponse.json(image)
+}
+
+export async function DELETE(req: Request, { params }: { params: { serviceId: string } }) {
+  const { id } = await req.json()
+  await prisma.serviceImage.delete({ where: { id } })
+  return NextResponse.json({ success: true })
+}


### PR DESCRIPTION
## Summary
- add API endpoints for service images CRUD
- extend admin services page with image management modal

## Testing
- `npm run lint` *(fails: various lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6873a299bf9083258e4884e72f677791