### PR TITLE
Revamp admin UI with light theme

### DIFF
--- a/src/app/admin/appointments/page.tsx
+++ b/src/app/admin/appointments/page.tsx
@@ -34,24 +34,24 @@ export default function AppointmentPage() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Appointment Requests</h1>
-      <table className="w-full text-sm text-left">
-        <thead>
+      <table className="w-full text-sm text-left bg-white rounded shadow border">
+        <thead className="bg-gray-50">
           <tr>
-            <th>Date</th>
-            <th>Customer</th>
-            <th>Service</th>
-            <th>Status</th>
+            <th className="px-3 py-2">Date</th>
+            <th className="px-3 py-2">Customer</th>
+            <th className="px-3 py-2">Service</th>
+            <th className="px-3 py-2">Status</th>
           </tr>
         </thead>
         <tbody>
           {bookings.map(b => (
-            <tr key={b.id} className="border-t border-gray-700">
-              <td>{new Date(b.date).toLocaleString()}</td>
-              <td>{b.user?.name || '—'}</td>
-              <td>{b.service.name}</td>
+            <tr key={b.id} className="border-t">
+              <td className="px-3 py-2">{new Date(b.date).toLocaleString()}</td>
+              <td className="px-3 py-2">{b.user?.name || '—'}</td>
+              <td className="px-3 py-2">{b.service.name}</td>
               <td>
                 <select
-                  className="bg-gray-800 p-1 rounded"
+                  className="p-1 rounded border"
                   value={b.status}
                   onChange={e => update(b.id, e.target.value)}
                 >

--- a/src/app/admin/branches/page.tsx
+++ b/src/app/admin/branches/page.tsx
@@ -55,30 +55,30 @@ export default function BranchesAdmin() {
   return (
     <div className="max-w-3xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Branch Management</h1>
-      <form onSubmit={save} className="space-y-2 bg-black p-4 rounded mb-6">
-        <input className="w-full p-2 rounded bg-gray-800" placeholder="Name" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
-        <input className="w-full p-2 rounded bg-gray-800" placeholder="Address" value={form.address} onChange={e => setForm({ ...form, address: e.target.value })} required />
-        <input className="w-full p-2 rounded bg-gray-800" placeholder="Phone" value={form.phone} onChange={e => setForm({ ...form, phone: e.target.value })} required />
-        <input className="w-full p-2 rounded bg-gray-800" placeholder="UPI ID" value={form.upiId} onChange={e => setForm({ ...form, upiId: e.target.value })} />
-        <input className="w-full p-2 rounded bg-gray-800" placeholder="QR URL" value={form.qrUrl} onChange={e => setForm({ ...form, qrUrl: e.target.value })} />
-        <button className="bg-green-600 px-4 py-2 rounded" type="submit">{editing ? 'Update' : 'Add'} Branch</button>
+      <form onSubmit={save} className="space-y-2 bg-white p-4 rounded shadow border mb-6">
+        <input className="w-full p-2 rounded border" placeholder="Name" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
+        <input className="w-full p-2 rounded border" placeholder="Address" value={form.address} onChange={e => setForm({ ...form, address: e.target.value })} required />
+        <input className="w-full p-2 rounded border" placeholder="Phone" value={form.phone} onChange={e => setForm({ ...form, phone: e.target.value })} required />
+        <input className="w-full p-2 rounded border" placeholder="UPI ID" value={form.upiId} onChange={e => setForm({ ...form, upiId: e.target.value })} />
+        <input className="w-full p-2 rounded border" placeholder="QR URL" value={form.qrUrl} onChange={e => setForm({ ...form, qrUrl: e.target.value })} />
+        <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">{editing ? 'Update' : 'Add'} Branch</button>
       </form>
-      <table className="w-full text-left text-sm">
-        <thead>
+      <table className="w-full text-left text-sm bg-white rounded shadow border">
+        <thead className="bg-gray-50">
           <tr>
-            <th>Name</th>
-            <th>Phone</th>
-            <th>Actions</th>
+            <th className="px-3 py-2">Name</th>
+            <th className="px-3 py-2">Phone</th>
+            <th className="px-3 py-2">Actions</th>
           </tr>
         </thead>
         <tbody>
           {branches.map(b => (
-            <tr key={b.id} className="border-t border-gray-700">
-              <td>{b.name}</td>
-              <td>{b.phone}</td>
-              <td className="space-x-2">
+            <tr key={b.id} className="border-t">
+              <td className="px-3 py-2">{b.name}</td>
+              <td className="px-3 py-2">{b.phone}</td>
+              <td className="space-x-2 px-3 py-2">
                 <button className="underline" onClick={() => edit(b)}>Edit</button>
-                <button className="underline text-red-400" onClick={() => del(b.id)}>Delete</button>
+                <button className="underline text-red-600" onClick={() => del(b.id)}>Delete</button>
               </td>
             </tr>
           ))}

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -22,20 +22,20 @@ export default function DashboardPage() {
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Admin Dashboard</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="bg-gray-800 p-4 rounded">
-          <div className="text-sm text-gray-400">Bookings</div>
+        <div className="bg-white p-4 rounded shadow border">
+          <div className="text-sm text-gray-500">Bookings</div>
           <div className="text-2xl font-bold">{data.bookings}</div>
         </div>
-        <div className="bg-gray-800 p-4 rounded">
-          <div className="text-sm text-gray-400">Services</div>
+        <div className="bg-white p-4 rounded shadow border">
+          <div className="text-sm text-gray-500">Services</div>
           <div className="text-2xl font-bold">{data.services}</div>
         </div>
-        <div className="bg-gray-800 p-4 rounded">
-          <div className="text-sm text-gray-400">Staff</div>
+        <div className="bg-white p-4 rounded shadow border">
+          <div className="text-sm text-gray-500">Staff</div>
           <div className="text-2xl font-bold">{data.staff}</div>
         </div>
-        <div className="bg-gray-800 p-4 rounded">
-          <div className="text-sm text-gray-400">Branches</div>
+        <div className="bg-white p-4 rounded shadow border">
+          <div className="text-sm text-gray-500">Branches</div>
           <div className="text-2xl font-bold">{data.branches}</div>
         </div>
       </div>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,22 +2,40 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import React from 'react'
+import {
+  MdDashboard,
+  MdEvent,
+  MdSchedule,
+  MdPeople,
+  MdStore,
+  MdCategory,
+  MdDesignServices,
+  MdHistory,
+} from 'react-icons/md'
+import type { IconType } from 'react-icons'
 
-const sections = [
+const sections: {
+  heading: string
+  items: { href: string; label: string; icon: IconType }[]
+}[] = [
   {
     heading: 'Dashboard',
-    items: [{ href: '/admin/dashboard', label: 'Dashboard' }],
+    items: [{ href: '/admin/dashboard', label: 'Dashboard', icon: MdDashboard }],
   },
   {
     heading: 'Salon Management',
     items: [
-      { href: '/admin/appointments', label: 'Appointments' },
-      { href: '/admin/scheduling', label: 'Scheduling' },
-      { href: '/admin/staff', label: 'Staff' },
-      { href: '/admin/branches', label: 'Branches' },
-      { href: '/admin/service-categories', label: 'Service Categories' },
-      { href: '/admin/services', label: 'Services' },
-      { href: '/admin/price-history', label: 'Price History' },
+      { href: '/admin/appointments', label: 'Appointments', icon: MdEvent },
+      { href: '/admin/scheduling', label: 'Scheduling', icon: MdSchedule },
+      { href: '/admin/staff', label: 'Staff', icon: MdPeople },
+      { href: '/admin/branches', label: 'Branches', icon: MdStore },
+      {
+        href: '/admin/service-categories',
+        label: 'Service Categories',
+        icon: MdCategory,
+      },
+      { href: '/admin/services', label: 'Services', icon: MdDesignServices },
+      { href: '/admin/price-history', label: 'Price History', icon: MdHistory },
     ],
   },
 ]
@@ -25,19 +43,20 @@ const sections = [
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   return (
-    <div className="min-h-screen flex">
-      <nav className="w-60 bg-gray-900 text-gray-200 p-4 space-y-4 overflow-y-auto">
+    <div className="min-h-screen flex text-gray-900 bg-gray-50">
+      <nav className="w-60 bg-white border-r border-gray-200 p-4 space-y-4 overflow-y-auto">
         {sections.map(sec => (
           <div key={sec.heading}>
-            <div className="uppercase text-xs text-gray-400 mb-1">{sec.heading}</div>
+            <div className="uppercase text-xs text-gray-500 mb-1">{sec.heading}</div>
             <div className="space-y-1">
               {sec.items.map(item => (
                 <Link
                   key={item.href}
                   href={item.href}
-                  className={`block px-3 py-2 rounded hover:bg-gray-800 ${pathname === item.href ? 'bg-gray-800 font-semibold' : ''}`}
+                  className={`flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 ${pathname === item.href ? 'bg-gray-100 font-semibold' : ''}`}
                 >
-                  {item.label}
+                  <item.icon className="text-lg" />
+                  <span>{item.label}</span>
                 </Link>
               ))}
             </div>

--- a/src/app/admin/price-history/page.tsx
+++ b/src/app/admin/price-history/page.tsx
@@ -82,10 +82,10 @@ export default function PriceHistoryPage() {
       </select>
       {selected && (
         <div className="space-y-4">
-          <form onSubmit={save} className="space-y-2 bg-black p-4 rounded">
+          <form onSubmit={save} className="space-y-2 bg-white p-4 rounded shadow border">
             <input
               type="number"
-              className="w-full p-2 rounded bg-gray-800"
+              className="w-full p-2 rounded border"
               placeholder="Actual price"
               value={form.actualPrice ?? 0}
               onChange={e => setForm({ ...form, actualPrice: parseFloat(e.target.value) })}
@@ -93,48 +93,48 @@ export default function PriceHistoryPage() {
             />
             <input
               type="number"
-              className="w-full p-2 rounded bg-gray-800"
+              className="w-full p-2 rounded border"
               placeholder="Offer price"
               value={form.offerPrice ?? ''}
               onChange={e => setForm({ ...form, offerPrice: e.target.value })}
             />
             <input
               type="date"
-              className="w-full p-2 rounded bg-gray-800"
+              className="w-full p-2 rounded border"
               value={form.offerStartDate || ''}
               onChange={e => setForm({ ...form, offerStartDate: e.target.value })}
             />
             <input
               type="date"
-              className="w-full p-2 rounded bg-gray-800"
+              className="w-full p-2 rounded border"
               value={form.offerEndDate || ''}
               onChange={e => setForm({ ...form, offerEndDate: e.target.value })}
             />
-            <button className="bg-green-600 px-4 py-2 rounded" type="submit">
+            <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">
               {editing ? 'Update' : 'Add'} Entry
             </button>
           </form>
           {entries.length > 0 && (
-            <table className="w-full text-sm text-left">
-              <thead>
+            <table className="w-full text-sm text-left bg-white rounded shadow border">
+              <thead className="bg-gray-50">
                 <tr>
-                  <th>Actual</th>
-                  <th>Offer</th>
-                  <th>Start</th>
-                  <th>End</th>
-                  <th></th>
+                  <th className="px-3 py-2">Actual</th>
+                  <th className="px-3 py-2">Offer</th>
+                  <th className="px-3 py-2">Start</th>
+                  <th className="px-3 py-2">End</th>
+                  <th className="px-3 py-2"></th>
                 </tr>
               </thead>
               <tbody>
                 {entries.map(e => (
-                  <tr key={e.id} className="border-t border-gray-700">
-                    <td>{e.actualPrice}</td>
-                    <td>{e.offerPrice ?? '—'}</td>
-                    <td>{e.offerStartDate ? new Date(e.offerStartDate).toLocaleDateString() : '—'}</td>
-                    <td>{e.offerEndDate ? new Date(e.offerEndDate).toLocaleDateString() : '—'}</td>
-                    <td className="space-x-2">
+                  <tr key={e.id} className="border-t">
+                    <td className="px-3 py-2">{e.actualPrice}</td>
+                    <td className="px-3 py-2">{e.offerPrice ?? '—'}</td>
+                    <td className="px-3 py-2">{e.offerStartDate ? new Date(e.offerStartDate).toLocaleDateString() : '—'}</td>
+                    <td className="px-3 py-2">{e.offerEndDate ? new Date(e.offerEndDate).toLocaleDateString() : '—'}</td>
+                    <td className="space-x-2 px-3 py-2">
                       <button className="underline" onClick={() => edit(e)}>Edit</button>
-                      <button className="underline text-red-400" onClick={() => del(e.id)}>Delete</button>
+                      <button className="underline text-red-600" onClick={() => del(e.id)}>Delete</button>
                     </td>
                   </tr>
                 ))}

--- a/src/app/admin/scheduling/page.tsx
+++ b/src/app/admin/scheduling/page.tsx
@@ -42,30 +42,30 @@ export default function SchedulingPage() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Schedule Appointments</h1>
-      <select className="bg-gray-800 p-2 rounded mb-4" value={branch} onChange={e => setBranch(e.target.value)}>
+      <select className="p-2 rounded border mb-4" value={branch} onChange={e => setBranch(e.target.value)}>
         <option value="">Select branch</option>
         {branches.map(b => (
           <option key={b.id} value={b.id}>{b.name}</option>
         ))}
       </select>
       {bookings.length > 0 && (
-        <table className="w-full text-sm text-left">
-          <thead>
+        <table className="w-full text-sm text-left bg-white rounded shadow border">
+          <thead className="bg-gray-50">
             <tr>
-              <th>Date</th>
-              <th>Customer</th>
-              <th>Service</th>
-              <th>Assign</th>
+              <th className="px-3 py-2">Date</th>
+              <th className="px-3 py-2">Customer</th>
+              <th className="px-3 py-2">Service</th>
+              <th className="px-3 py-2">Assign</th>
             </tr>
           </thead>
           <tbody>
             {bookings.map(b => (
-              <tr key={b.id} className="border-t border-gray-700">
-                <td>{new Date(b.date).toLocaleString()}</td>
-                <td>{b.user.name}</td>
-                <td>{b.service.name}</td>
+              <tr key={b.id} className="border-t">
+                <td className="px-3 py-2">{new Date(b.date).toLocaleString()}</td>
+                <td className="px-3 py-2">{b.user.name}</td>
+                <td className="px-3 py-2">{b.service.name}</td>
                 <td>
-                  <select className="bg-gray-800 p-1 rounded" onChange={e => assign(b.id, e.target.value)}>
+                  <select className="p-1 rounded border" onChange={e => assign(b.id, e.target.value)}>
                     <option value="">Select staff</option>
                     {staff.map(s => (
                       <option key={s.id} value={s.id}>{s.name}</option>

--- a/src/app/admin/service-categories/page.tsx
+++ b/src/app/admin/service-categories/page.tsx
@@ -75,9 +75,9 @@ export default function ServiceCategoriesPage() {
   return (
     <div className="max-w-3xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Service Categories</h1>
-      <form onSubmit={save} className="space-y-2 bg-black p-4 rounded mb-6">
+      <form onSubmit={save} className="space-y-2 bg-white p-4 rounded shadow border mb-6">
         <input
-          className="w-full p-2 rounded bg-gray-800"
+          className="w-full p-2 rounded border"
           placeholder="Name"
           value={form.name}
           onChange={e => setForm({ ...form, name: e.target.value })}
@@ -91,46 +91,46 @@ export default function ServiceCategoriesPage() {
           type="file"
           accept="image/*"
           onChange={handleImage}
-          className="w-full p-2 rounded bg-gray-800"
+          className="w-full p-2 rounded border"
         />
         {form.imageUrl && (
           <img src={form.imageUrl} alt="preview" className="h-32 object-cover" />
         )}
         <input
-          className="w-full p-2 rounded bg-gray-800"
+          className="w-full p-2 rounded border"
           placeholder="Caption"
           value={form.caption || ''}
           onChange={e => setForm({ ...form, caption: e.target.value })}
         />
         <input
           type="number"
-          className="w-full p-2 rounded bg-gray-800"
+          className="w-full p-2 rounded border"
           placeholder="Order"
           value={form.order ?? 0}
           onChange={e => setForm({ ...form, order: parseInt(e.target.value) })}
         />
-        <button className="bg-green-600 px-4 py-2 rounded" type="submit">
+        <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">
           {editing ? 'Update' : 'Add'} Category
         </button>
       </form>
-      <table className="w-full text-left text-sm">
-        <thead>
+      <table className="w-full text-left text-sm bg-white rounded shadow border">
+        <thead className="bg-gray-50">
           <tr>
-            <th>Name</th>
-            <th>Caption</th>
-            <th>Image</th>
-            <th>Actions</th>
+            <th className="px-3 py-2">Name</th>
+            <th className="px-3 py-2">Caption</th>
+            <th className="px-3 py-2">Image</th>
+            <th className="px-3 py-2">Actions</th>
           </tr>
         </thead>
         <tbody>
           {cats.map(c => (
-            <tr key={c.id} className="border-t border-gray-700">
-              <td>{c.name}</td>
-              <td>{c.caption ?? '—'}</td>
-              <td>{c.imageUrl ? <img src={c.imageUrl} className="h-10"/> : '—'}</td>
-              <td className="space-x-2">
+            <tr key={c.id} className="border-t">
+              <td className="px-3 py-2">{c.name}</td>
+              <td className="px-3 py-2">{c.caption ?? '—'}</td>
+              <td className="px-3 py-2">{c.imageUrl ? <img src={c.imageUrl} className="h-10"/> : '—'}</td>
+              <td className="space-x-2 px-3 py-2">
                 <button className="underline" onClick={() => edit(c)}>Edit</button>
-                <button className="underline text-red-400" onClick={() => del(c.id)}>Delete</button>
+                <button className="underline text-red-600" onClick={() => del(c.id)}>Delete</button>
               </td>
             </tr>
           ))}

--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -251,7 +251,7 @@ export default function ServicesAdmin() {
       <h1 className="text-2xl font-bold mb-4">Services</h1>
       <div className="flex items-center gap-2 mb-4">
         <select
-          className="bg-gray-800 p-2 rounded"
+          className="p-2 rounded border"
           value={category}
           onChange={e => setCategory(e.target.value)}
         >
@@ -266,22 +266,22 @@ export default function ServicesAdmin() {
       </div>
 
       {services.length > 0 && (
-        <table className="w-full text-sm text-left">
-          <thead>
+        <table className="w-full text-sm text-left bg-white rounded shadow border">
+          <thead className="bg-gray-50">
             <tr>
-              <th>Name</th>
-              <th>Caption</th>
-              <th>Tiers</th>
-              <th></th>
+              <th className="px-3 py-2">Name</th>
+              <th className="px-3 py-2">Caption</th>
+              <th className="px-3 py-2">Tiers</th>
+              <th className="px-3 py-2"></th>
             </tr>
           </thead>
           <tbody>
             {services.map(s => (
-              <tr key={s.id} className="border-t border-gray-700">
-                <td>{s.name}</td>
-                <td>{s.caption ?? '—'}</td>
-                <td>{s.tiers.length}</td>
-                <td className="space-x-2">
+              <tr key={s.id} className="border-t">
+                <td className="px-3 py-2">{s.name}</td>
+                <td className="px-3 py-2">{s.caption ?? '—'}</td>
+                <td className="px-3 py-2">{s.tiers.length}</td>
+                <td className="space-x-2 px-3 py-2">
                   <button className="underline" onClick={() => openEditService(s)}>Edit</button>
                   <button className="underline" onClick={() => openTierManager(s)}>Manage Tiers</button>
                   <button className="underline" onClick={() => openImageManager(s)}>Manage Images</button>
@@ -294,18 +294,18 @@ export default function ServicesAdmin() {
 
       {showServiceForm && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-          <div className="bg-gray-900 p-6 rounded w-full max-w-lg">
+          <div className="bg-white p-6 rounded shadow w-full max-w-lg">
             <h2 className="text-xl mb-4">{editingService ? 'Edit' : 'Add'} Service</h2>
             <form onSubmit={saveService} className="space-y-2">
               <input
-                className="w-full p-2 rounded bg-gray-800"
+                className="w-full p-2 rounded border"
                 placeholder="Name"
                 value={serviceForm.name || ''}
                 onChange={e => setServiceForm({ ...serviceForm, name: e.target.value })}
                 required
               />
               <input
-                className="w-full p-2 rounded bg-gray-800"
+                className="w-full p-2 rounded border"
                 placeholder="Caption"
                 value={serviceForm.caption || ''}
                 onChange={e => setServiceForm({ ...serviceForm, caption: e.target.value })}
@@ -318,14 +318,14 @@ export default function ServicesAdmin() {
                 type="file"
                 accept="image/*"
                 onChange={handleServiceImage}
-                className="w-full p-2 rounded bg-gray-800"
+                className="w-full p-2 rounded border"
               />
               {serviceForm.imageUrl && (
                 <img src={serviceForm.imageUrl} alt="preview" className="h-32 object-cover" />
               )}
               <div className="text-right space-x-2 pt-2">
-                <button type="button" className="px-3 py-1 bg-gray-600 rounded" onClick={() => setShowServiceForm(false)}>Cancel</button>
-                <button type="submit" className="px-3 py-1 bg-green-600 rounded">Save</button>
+                <button type="button" className="px-3 py-1 bg-gray-300 rounded" onClick={() => setShowServiceForm(false)}>Cancel</button>
+                <button type="submit" className="px-3 py-1 bg-green-600 text-white rounded">Save</button>
               </div>
             </form>
           </div>
@@ -334,38 +334,38 @@ export default function ServicesAdmin() {
 
       {showTierModal && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-          <div className="bg-gray-900 p-6 rounded w-full max-w-lg">
+          <div className="bg-white p-6 rounded shadow w-full max-w-lg">
             <h2 className="text-xl mb-4">Manage Tiers</h2>
-            <table className="w-full text-sm text-left mb-4">
-              <thead>
+            <table className="w-full text-sm text-left mb-4 bg-white rounded shadow border">
+              <thead className="bg-gray-50">
                 <tr>
-                  <th>Name</th>
-                  <th>Price</th>
-                  <th>Offer</th>
-                  <th>Duration</th>
-                  <th></th>
+                  <th className="px-3 py-2">Name</th>
+                  <th className="px-3 py-2">Price</th>
+                  <th className="px-3 py-2">Offer</th>
+                  <th className="px-3 py-2">Duration</th>
+                  <th className="px-3 py-2"></th>
                 </tr>
               </thead>
               <tbody>
                 {tiers.map(t => (
-                  <tr key={t.id} className="border-t border-gray-700">
-                    <td>{t.name}</td>
-                    <td>{t.actualPrice}</td>
-                    <td>{t.offerPrice ?? '—'}</td>
-                    <td>{t.duration ?? '—'}</td>
-                    <td className="space-x-2">
+                  <tr key={t.id} className="border-t">
+                    <td className="px-3 py-2">{t.name}</td>
+                    <td className="px-3 py-2">{t.actualPrice}</td>
+                    <td className="px-3 py-2">{t.offerPrice ?? '—'}</td>
+                    <td className="px-3 py-2">{t.duration ?? '—'}</td>
+                    <td className="space-x-2 px-3 py-2">
                       <button className="underline" onClick={() => openEditTier(t)}>Edit</button>
-                      <button className="underline text-red-400" onClick={() => deleteTier(t.id)}>Delete</button>
+                      <button className="underline text-red-600" onClick={() => deleteTier(t.id)}>Delete</button>
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
-            <button className="bg-green-600 px-3 py-1 rounded mb-4" onClick={openAddTier}>+ Add Tier</button>
+            <button className="bg-green-600 px-3 py-1 rounded text-white mb-4" onClick={openAddTier}>+ Add Tier</button>
             {tierForm.name !== undefined && (
               <form onSubmit={saveTier} className="space-y-2">
                 <input
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded border"
                   placeholder="Name"
                   value={tierForm.name || ''}
                   onChange={e => setTierForm({ ...tierForm, name: e.target.value })}
@@ -373,7 +373,7 @@ export default function ServicesAdmin() {
                 />
                 <input
                   type="number"
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded border"
                   placeholder="Actual Price"
                   value={tierForm.actualPrice ?? 0}
                   onChange={e => setTierForm({ ...tierForm, actualPrice: parseFloat(e.target.value) })}
@@ -381,25 +381,25 @@ export default function ServicesAdmin() {
                 />
                 <input
                   type="number"
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded border"
                   placeholder="Offer Price"
                   value={tierForm.offerPrice ?? ''}
                   onChange={e => setTierForm({ ...tierForm, offerPrice: e.target.value ? parseFloat(e.target.value) : null })}
                 />
                 <input
                   type="number"
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded border"
                   placeholder="Duration (min)"
                   value={tierForm.duration ?? ''}
                   onChange={e => setTierForm({ ...tierForm, duration: e.target.value ? parseInt(e.target.value) : null })}
                 />
                 <div className="text-right space-x-2 pt-2">
-                  <button type="submit" className="px-3 py-1 bg-green-600 rounded">{editingTier ? 'Update' : 'Add'} Tier</button>
+                  <button type="submit" className="px-3 py-1 bg-green-600 text-white rounded">{editingTier ? 'Update' : 'Add'} Tier</button>
                 </div>
               </form>
             )}
             <div className="text-right mt-4">
-              <button className="px-3 py-1 bg-gray-600 rounded" onClick={() => setShowTierModal(false)}>Close</button>
+              <button className="px-3 py-1 bg-gray-300 rounded" onClick={() => setShowTierModal(false)}>Close</button>
             </div>
           </div>
         </div>
@@ -407,19 +407,19 @@ export default function ServicesAdmin() {
 
       {showImageModal && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-          <div className="bg-gray-900 p-6 rounded w-full max-w-lg">
+          <div className="bg-white p-6 rounded shadow w-full max-w-lg">
             <h2 className="text-xl mb-4">Manage Images</h2>
-            <table className="w-full text-sm text-left mb-4">
-              <thead>
+            <table className="w-full text-sm text-left mb-4 bg-white rounded shadow border">
+              <thead className="bg-gray-50">
                 <tr>
-                  <th>Image</th>
-                  <th>Caption</th>
-                  <th></th>
+                  <th className="px-3 py-2">Image</th>
+                  <th className="px-3 py-2">Caption</th>
+                  <th className="px-3 py-2"></th>
                 </tr>
               </thead>
               <tbody>
                 {images.map(img => (
-                  <tr key={img.id} className="border-t border-gray-700">
+                  <tr key={img.id} className="border-t">
 
                     <td>{img.imageUrl ? <img src={img.imageUrl} className="h-10"/> : '—'}</td>
 
@@ -428,13 +428,13 @@ export default function ServicesAdmin() {
                     <td>{img.caption ?? '—'}</td>
                     <td className="space-x-2">
                       <button className="underline" onClick={() => openEditImage(img)}>Edit</button>
-                      <button className="underline text-red-400" onClick={() => deleteImage(img.id)}>Delete</button>
+                      <button className="underline text-red-600" onClick={() => deleteImage(img.id)}>Delete</button>
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
-            <button className="bg-green-600 px-3 py-1 rounded mb-4" onClick={openAddImage}>+ Add Image</button>
+            <button className="bg-green-600 px-3 py-1 rounded text-white mb-4" onClick={openAddImage}>+ Add Image</button>
             {imageForm.imageUrl !== undefined && (
               <form onSubmit={saveImage} className="space-y-2">
                 <input
@@ -442,13 +442,13 @@ export default function ServicesAdmin() {
                   type="file"
                   accept="image/*"
                   onChange={handleImageUpload}
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded border"
                 />
                 {imageForm.imageUrl && (
                   <img src={imageForm.imageUrl} alt="preview" className="h-24 object-cover" />
                 )}
 
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded border"
                   placeholder="Image URL"
                   value={imageForm.imageUrl || ''}
                   onChange={e => setImageForm({ ...imageForm, imageUrl: e.target.value })}
@@ -456,18 +456,18 @@ export default function ServicesAdmin() {
                 />
 
                 <input
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded border"
                   placeholder="Caption"
                   value={imageForm.caption || ''}
                   onChange={e => setImageForm({ ...imageForm, caption: e.target.value })}
                 />
                 <div className="text-right space-x-2 pt-2">
-                  <button type="submit" className="px-3 py-1 bg-green-600 rounded">{editingImage ? 'Update' : 'Add'} Image</button>
+                  <button type="submit" className="px-3 py-1 bg-green-600 text-white rounded">{editingImage ? 'Update' : 'Add'} Image</button>
                 </div>
               </form>
             )}
             <div className="text-right mt-4">
-              <button className="px-3 py-1 bg-gray-600 rounded" onClick={() => setShowImageModal(false)}>Close</button>
+              <button className="px-3 py-1 bg-gray-300 rounded" onClick={() => setShowImageModal(false)}>Close</button>
             </div>
           </div>
         </div>

--- a/src/app/staff/page.tsx
+++ b/src/app/staff/page.tsx
@@ -161,7 +161,7 @@ const handleExport = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-800 p-6 text-white">
+    <div className="min-h-screen bg-gray-50 p-6 text-gray-900">
       <Toaster richColors position="top-center"/>
       <header className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold">Staff Management</h1>
@@ -187,7 +187,7 @@ const handleExport = () => {
           placeholder="Search staff..."
           value={searchTerm}
           onChange={e=>setSearchTerm(e.target.value)}
-          className="flex-1 p-2 rounded bg-gray-700 border border-gray-600"
+          className="flex-1 p-2 rounded bg-gray-200 border border-gray-300"
         />
         <div className="space-x-2">
           {['ALL','AVAILABLE','REMOVED'].map(val=>(
@@ -195,7 +195,7 @@ const handleExport = () => {
               key={val}
               onClick={()=>setFilter(val as any)}
               className={`px-3 py-1 rounded ${
-                filter===val?'bg-indigo-600':'bg-gray-700'
+                filter===val?'bg-indigo-600':'bg-gray-200'
               }`}
             >
               {val}
@@ -211,10 +211,10 @@ const handleExport = () => {
         {filtered.map(staff=>(
           <div
             key={staff.id}
-            className="bg-gray-900 p-6 rounded-xl border border-gray-700 shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition"
+            className="bg-white p-6 rounded-xl border border-gray-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition"
           >
             <div className="flex justify-center mb-6">
-               <div className="w-32 h-32 rounded-full bg-gray-700 overflow-hidden">
+               <div className="w-32 h-32 rounded-full bg-gray-200 overflow-hidden">
                 {staff.imageUrl
                    ? <img src={staff.imageUrl} className="w-full h-full object-cover"/>
                    : <span className="block w-full h-full text-2xl text-center leading-14">
@@ -226,7 +226,7 @@ const handleExport = () => {
             </div>
             <div className="flex justify-center mb-6">
  <h1 className="text-3xl font-semibold">{staff.name}</h1></div>
-            <table className="w-full text-white text-base mb-6">
+            <table className="w-full text-base mb-6 bg-white rounded shadow border">
               <tbody>
                 <tr>
                   <th className="text-left pr-4 py-1 font-medium">Email</th>
@@ -298,12 +298,12 @@ const handleExport = () => {
       {/* ── ADD MODAL ── */}
       {showAddModal && (
         <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-          <div className="bg-gray-900 p-6 rounded-xl w-full max-w-2xl border border-gray-700 overflow-auto max-h-[90vh]">
+          <div className="bg-white p-6 rounded-xl w-full max-w-2xl border border-gray-300 overflow-auto max-h-[90vh]">
             <h2 className="text-2xl mb-4">Add New Staff</h2>
             <form
               onSubmit={handleAdd}
               encType="multipart/form-data"
-              className="grid grid-cols-2 gap-4 text-white"
+              className="grid grid-cols-2 gap-4 text-gray-900"
             >
               {/* Profile Pic */}
               <div className="col-span-2">
@@ -317,7 +317,7 @@ const handleExport = () => {
                 <input
                   name="name"
                   required
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 />
               </div>
               {/* Email */}
@@ -327,7 +327,7 @@ const handleExport = () => {
                   name="email"
                   type="email"
                   required
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 />
               </div>
               {/* Phone */}
@@ -336,7 +336,7 @@ const handleExport = () => {
                 <input
                   name="phone"
                   required maxLength={10} pattern="\d{10}"
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 />
               </div>
               {/* Gender */}
@@ -345,7 +345,7 @@ const handleExport = () => {
                 <select
                   name="gender"
                   required
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 >
                   <option value="">— select —</option>
                   <option>Male</option>
@@ -360,7 +360,7 @@ const handleExport = () => {
                   name="dob"
                   type="date"
                   required
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 />
               </div>
               {/* Address */}
@@ -369,7 +369,7 @@ const handleExport = () => {
                 <input
                   name="address"
                   required
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 />
               </div>
               {/* Designation */}
@@ -378,7 +378,7 @@ const handleExport = () => {
                 <input
                   name="designation"
                   required
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 />
               </div>
               {/* Experience */}
@@ -386,7 +386,7 @@ const handleExport = () => {
                 <label className="block mb-1">Experience</label>
                 <input
                   name="experience"
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 />
               </div>
               {/* Start Date */}
@@ -396,7 +396,7 @@ const handleExport = () => {
                   name="startDate"
                   type="date"
                   required
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 />
               </div>
               {/* Role */}
@@ -405,7 +405,7 @@ const handleExport = () => {
                 <select
                   name="role"
                   required
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 >
                   <option>customer</option>
                   <option>staff</option>
@@ -418,7 +418,7 @@ const handleExport = () => {
                 <select
                   name="branchId"
                   required
-                  className="w-full p-2 rounded bg-gray-700"
+                  className="w-full p-2 rounded bg-gray-200"
                 >
                   <option value="">— select —</option>
                   {branches.map(b=>(
@@ -431,7 +431,7 @@ const handleExport = () => {
                 <button
                   type="button"
                   onClick={()=>setShowAddModal(false)}
-                  className="px-4 py-2 bg-gray-600 rounded"
+                  className="px-4 py-2 bg-gray-300 rounded"
                 >
                   Cancel
                 </button>
@@ -450,12 +450,12 @@ const handleExport = () => {
       {/* ── EDIT MODAL ── */}
       {selectedStaff && (
         <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-          <div className="bg-gray-900 p-6 rounded-xl w-full max-w-2xl border border-gray-700 overflow-auto max-h-[90vh]">
+          <div className="bg-white p-6 rounded-xl w-full max-w-2xl border border-gray-300 overflow-auto max-h-[90vh]">
             <h2 className="text-2xl mb-4">Edit Staff</h2>
             <form
               onSubmit={handleEdit}
               encType="multipart/form-data"
-              className="grid grid-cols-2 gap-4 text-white"
+              className="grid grid-cols-2 gap-4 text-gray-900"
             >
               {/* Profile Pic */}
               <div className="col-span-2">
@@ -473,7 +473,7 @@ const handleExport = () => {
                   name="name"
                   defaultValue={selectedStaff.name}
                   required
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 />
               </div>
 
@@ -485,7 +485,7 @@ const handleExport = () => {
                   type="email"
                   defaultValue={selectedStaff.email}
                   required
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 />
               </div>
 
@@ -496,7 +496,7 @@ const handleExport = () => {
                   name="phone"
                   defaultValue={selectedStaff.phone}
                   required maxLength={10} pattern="\d{10}"
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 />
               </div>
 
@@ -507,7 +507,7 @@ const handleExport = () => {
                   name="gender"
                   defaultValue={selectedStaff.gender}
                   required
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 >
                   <option value="">— select —</option>
                   <option>Male</option>
@@ -524,7 +524,7 @@ const handleExport = () => {
                   type="date"
                   defaultValue={selectedStaff.dob?.split('T')[0]}
                   required
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 />
               </div>
 
@@ -535,7 +535,7 @@ const handleExport = () => {
                   name="address"
                   defaultValue={selectedStaff.address}
                   required
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 />
               </div>
 
@@ -546,7 +546,7 @@ const handleExport = () => {
                   name="designation"
                   defaultValue={selectedStaff.designation}
                   required
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 />
               </div>
 
@@ -556,7 +556,7 @@ const handleExport = () => {
                 <input
                   name="experience"
                   defaultValue={selectedStaff.experience}
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 />
               </div>
 
@@ -568,7 +568,7 @@ const handleExport = () => {
                   type="date"
                   defaultValue={selectedStaff.startDate?.split('T')[0]}
                   required
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 />
               </div>
 
@@ -579,7 +579,7 @@ const handleExport = () => {
                   name="role"
                   defaultValue={selectedStaff.role}
                   required
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 >
                   <option>customer</option>
                   <option>staff</option>
@@ -594,7 +594,7 @@ const handleExport = () => {
                   name="branchId"
                   defaultValue={selectedStaff.branchId||''}
                   required
-                  className="w-full p-2 rounded bg-gray-800"
+                  className="w-full p-2 rounded bg-gray-100"
                 >
                   <option value="">— select —</option>
                   {branches.map(b=>(
@@ -608,7 +608,7 @@ const handleExport = () => {
                 <button
                   type="button"
                   onClick={()=>setSelectedStaff(null)}
-                  className="px-4 py-2 bg-gray-600 rounded"
+                  className="px-4 py-2 bg-gray-300 rounded"
                 >
                   Cancel
                 </button>


### PR DESCRIPTION
## Summary
- restyle admin dashboard and pages with Tailwind light theme
- add sidebar icons and modern tables
- update staff page styles

## Testing
- `npm install`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873a7c1a91c83258bb3162ae982c0ee