### PR TITLE
Improve admin UI and fix image modal

### DIFF
--- a/src/app/admin/appointments/page.tsx
+++ b/src/app/admin/appointments/page.tsx
@@ -33,7 +33,7 @@ export default function AppointmentPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Appointment Requests</h1>
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Appointment Requests</h1>
       <table className="w-full text-sm text-left bg-white rounded shadow border">
         <thead className="bg-gray-50">
           <tr>

--- a/src/app/admin/branches/page.tsx
+++ b/src/app/admin/branches/page.tsx
@@ -54,13 +54,33 @@ export default function BranchesAdmin() {
 
   return (
     <div className="max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Branch Management</h1>
-      <form onSubmit={save} className="space-y-2 bg-white p-4 rounded shadow border mb-6">
-        <input className="w-full p-2 rounded border" placeholder="Name" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
-        <input className="w-full p-2 rounded border" placeholder="Address" value={form.address} onChange={e => setForm({ ...form, address: e.target.value })} required />
-        <input className="w-full p-2 rounded border" placeholder="Phone" value={form.phone} onChange={e => setForm({ ...form, phone: e.target.value })} required />
-        <input className="w-full p-2 rounded border" placeholder="UPI ID" value={form.upiId} onChange={e => setForm({ ...form, upiId: e.target.value })} />
-        <input className="w-full p-2 rounded border" placeholder="QR URL" value={form.qrUrl} onChange={e => setForm({ ...form, qrUrl: e.target.value })} />
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Branch Management</h1>
+      <form onSubmit={save} className="space-y-4 bg-white p-6 rounded shadow border mb-6">
+        <div>
+          <label className="block font-medium mb-1">Name</label>
+          <input className="w-full p-2 rounded border" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
+          <small className="text-gray-500">Branch name</small>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Address</label>
+          <input className="w-full p-2 rounded border" value={form.address} onChange={e => setForm({ ...form, address: e.target.value })} required />
+          <small className="text-gray-500">Full address of branch</small>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Phone</label>
+          <input className="w-full p-2 rounded border" value={form.phone} onChange={e => setForm({ ...form, phone: e.target.value })} required />
+          <small className="text-gray-500">Contact number</small>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">UPI ID</label>
+          <input className="w-full p-2 rounded border" value={form.upiId} onChange={e => setForm({ ...form, upiId: e.target.value })} />
+          <small className="text-gray-500">Optional UPI payment ID</small>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">QR URL</label>
+          <input className="w-full p-2 rounded border" value={form.qrUrl} onChange={e => setForm({ ...form, qrUrl: e.target.value })} />
+          <small className="text-gray-500">Link to payment QR image</small>
+        </div>
         <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">{editing ? 'Update' : 'Add'} Branch</button>
       </form>
       <table className="w-full text-left text-sm bg-white rounded shadow border">

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -20,7 +20,7 @@ export default function DashboardPage() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+      <h1 className="text-2xl font-bold text-green-700">Admin Dashboard</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-white p-4 rounded shadow border">
           <div className="text-sm text-gray-500">Bookings</div>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -43,17 +43,17 @@ const sections: {
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   return (
-    <div className="min-h-screen flex text-gray-900 bg-gray-50">
+    <div className="min-h-screen flex text-gray-900 bg-green-50">
       <nav className="w-60 bg-white border-r border-gray-200 p-4 space-y-4 overflow-y-auto">
         {sections.map(sec => (
           <div key={sec.heading}>
-            <div className="uppercase text-xs text-gray-500 mb-1">{sec.heading}</div>
+            <div className="uppercase text-xs text-green-700 mb-1">{sec.heading}</div>
             <div className="space-y-1">
               {sec.items.map(item => (
                 <Link
                   key={item.href}
                   href={item.href}
-                  className={`flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 ${pathname === item.href ? 'bg-gray-100 font-semibold' : ''}`}
+                  className={`flex items-center gap-2 px-3 py-2 rounded hover:bg-green-100 ${pathname === item.href ? 'bg-green-100 font-semibold' : ''}`}
                 >
                   <item.icon className="text-lg" />
                   <span>{item.label}</span>

--- a/src/app/admin/price-history/page.tsx
+++ b/src/app/admin/price-history/page.tsx
@@ -73,7 +73,7 @@ export default function PriceHistoryPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Price History</h1>
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Price History</h1>
       <select className="bg-gray-800 p-2 rounded mb-4" value={selected} onChange={e => setSelected(e.target.value)}>
         <option value="">Select service</option>
         {services.map(s => (

--- a/src/app/admin/scheduling/page.tsx
+++ b/src/app/admin/scheduling/page.tsx
@@ -41,7 +41,7 @@ export default function SchedulingPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Schedule Appointments</h1>
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Schedule Appointments</h1>
       <select className="p-2 rounded border mb-4" value={branch} onChange={e => setBranch(e.target.value)}>
         <option value="">Select branch</option>
         {branches.map(b => (

--- a/src/app/admin/service-categories/page.tsx
+++ b/src/app/admin/service-categories/page.tsx
@@ -74,41 +74,58 @@ export default function ServiceCategoriesPage() {
 
   return (
     <div className="max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Service Categories</h1>
-      <form onSubmit={save} className="space-y-2 bg-white p-4 rounded shadow border mb-6">
-        <input
-          className="w-full p-2 rounded border"
-          placeholder="Name"
-          value={form.name}
-          onChange={e => setForm({ ...form, name: e.target.value })}
-          required
-        />
-        <WysiwygEditor
-          value={form.description || ''}
-          onChange={desc => setForm({ ...form, description: desc })}
-        />
-        <input
-          type="file"
-          accept="image/*"
-          onChange={handleImage}
-          className="w-full p-2 rounded border"
-        />
-        {form.imageUrl && (
-          <img src={form.imageUrl} alt="preview" className="h-32 object-cover" />
-        )}
-        <input
-          className="w-full p-2 rounded border"
-          placeholder="Caption"
-          value={form.caption || ''}
-          onChange={e => setForm({ ...form, caption: e.target.value })}
-        />
-        <input
-          type="number"
-          className="w-full p-2 rounded border"
-          placeholder="Order"
-          value={form.order ?? 0}
-          onChange={e => setForm({ ...form, order: parseInt(e.target.value) })}
-        />
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Service Categories</h1>
+      <form onSubmit={save} className="space-y-4 bg-white p-6 rounded shadow border mb-6">
+        <div>
+          <label className="block font-medium mb-1">Name</label>
+          <input
+            className="w-full p-2 rounded border"
+            value={form.name}
+            onChange={e => setForm({ ...form, name: e.target.value })}
+            required
+          />
+          <small className="text-gray-500">Service category name</small>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Description</label>
+          <WysiwygEditor
+            value={form.description || ''}
+            onChange={desc => setForm({ ...form, description: desc })}
+          />
+          <small className="text-gray-500">Detailed info about this category</small>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Image</label>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleImage}
+            className="w-full p-2 rounded border"
+          />
+          {form.imageUrl && (
+            <img src={form.imageUrl} alt="preview" className="h-32 object-cover mt-2" />
+          )}
+          <small className="text-gray-500">Upload category thumbnail</small>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Caption</label>
+          <input
+            className="w-full p-2 rounded border"
+            value={form.caption || ''}
+            onChange={e => setForm({ ...form, caption: e.target.value })}
+          />
+          <small className="text-gray-500">Short tagline for this category</small>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Order</label>
+          <input
+            type="number"
+            className="w-full p-2 rounded border"
+            value={form.order ?? 0}
+            onChange={e => setForm({ ...form, order: parseInt(e.target.value) })}
+          />
+          <small className="text-gray-500">Display order in lists</small>
+        </div>
         <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">
           {editing ? 'Update' : 'Add'} Category
         </button>

--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -248,7 +248,7 @@ export default function ServicesAdmin() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Services</h1>
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Services</h1>
       <div className="flex items-center gap-2 mb-4">
         <select
           className="p-2 rounded border"
@@ -296,33 +296,46 @@ export default function ServicesAdmin() {
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
           <div className="bg-white p-6 rounded shadow w-full max-w-lg">
             <h2 className="text-xl mb-4">{editingService ? 'Edit' : 'Add'} Service</h2>
-            <form onSubmit={saveService} className="space-y-2">
-              <input
-                className="w-full p-2 rounded border"
-                placeholder="Name"
-                value={serviceForm.name || ''}
-                onChange={e => setServiceForm({ ...serviceForm, name: e.target.value })}
-                required
-              />
-              <input
-                className="w-full p-2 rounded border"
-                placeholder="Caption"
-                value={serviceForm.caption || ''}
-                onChange={e => setServiceForm({ ...serviceForm, caption: e.target.value })}
-              />
-              <WysiwygEditor
-                value={serviceForm.description || ''}
-                onChange={desc => setServiceForm({ ...serviceForm, description: desc })}
-              />
-              <input
-                type="file"
-                accept="image/*"
-                onChange={handleServiceImage}
-                className="w-full p-2 rounded border"
-              />
-              {serviceForm.imageUrl && (
-                <img src={serviceForm.imageUrl} alt="preview" className="h-32 object-cover" />
-              )}
+            <form onSubmit={saveService} className="space-y-4">
+              <div>
+                <label className="block font-medium mb-1">Name</label>
+                <input
+                  className="w-full p-2 rounded border"
+                  value={serviceForm.name || ''}
+                  onChange={e => setServiceForm({ ...serviceForm, name: e.target.value })}
+                  required
+                />
+                <small className="text-gray-500">Service name</small>
+              </div>
+              <div>
+                <label className="block font-medium mb-1">Caption</label>
+                <input
+                  className="w-full p-2 rounded border"
+                  value={serviceForm.caption || ''}
+                  onChange={e => setServiceForm({ ...serviceForm, caption: e.target.value })}
+                />
+                <small className="text-gray-500">Short tagline</small>
+              </div>
+              <div>
+                <label className="block font-medium mb-1">Description</label>
+                <WysiwygEditor
+                  value={serviceForm.description || ''}
+                  onChange={desc => setServiceForm({ ...serviceForm, description: desc })}
+                />
+              </div>
+              <div>
+                <label className="block font-medium mb-1">Image</label>
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={handleServiceImage}
+                  className="w-full p-2 rounded border"
+                />
+                {serviceForm.imageUrl && (
+                  <img src={serviceForm.imageUrl} alt="preview" className="h-32 object-cover mt-2" />
+                )}
+                <small className="text-gray-500">Main display image</small>
+              </div>
               <div className="text-right space-x-2 pt-2">
                 <button type="button" className="px-3 py-1 bg-gray-300 rounded" onClick={() => setShowServiceForm(false)}>Cancel</button>
                 <button type="submit" className="px-3 py-1 bg-green-600 text-white rounded">Save</button>
@@ -363,36 +376,44 @@ export default function ServicesAdmin() {
             </table>
             <button className="bg-green-600 px-3 py-1 rounded text-white mb-4" onClick={openAddTier}>+ Add Tier</button>
             {tierForm.name !== undefined && (
-              <form onSubmit={saveTier} className="space-y-2">
-                <input
-                  className="w-full p-2 rounded border"
-                  placeholder="Name"
-                  value={tierForm.name || ''}
-                  onChange={e => setTierForm({ ...tierForm, name: e.target.value })}
-                  required
-                />
-                <input
-                  type="number"
-                  className="w-full p-2 rounded border"
-                  placeholder="Actual Price"
-                  value={tierForm.actualPrice ?? 0}
-                  onChange={e => setTierForm({ ...tierForm, actualPrice: parseFloat(e.target.value) })}
-                  required
-                />
-                <input
-                  type="number"
-                  className="w-full p-2 rounded border"
-                  placeholder="Offer Price"
-                  value={tierForm.offerPrice ?? ''}
-                  onChange={e => setTierForm({ ...tierForm, offerPrice: e.target.value ? parseFloat(e.target.value) : null })}
-                />
-                <input
-                  type="number"
-                  className="w-full p-2 rounded border"
-                  placeholder="Duration (min)"
-                  value={tierForm.duration ?? ''}
-                  onChange={e => setTierForm({ ...tierForm, duration: e.target.value ? parseInt(e.target.value) : null })}
-                />
+              <form onSubmit={saveTier} className="space-y-4">
+                <div>
+                  <label className="block font-medium mb-1">Name</label>
+                  <input
+                    className="w-full p-2 rounded border"
+                    value={tierForm.name || ''}
+                    onChange={e => setTierForm({ ...tierForm, name: e.target.value })}
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block font-medium mb-1">Actual Price</label>
+                  <input
+                    type="number"
+                    className="w-full p-2 rounded border"
+                    value={tierForm.actualPrice ?? 0}
+                    onChange={e => setTierForm({ ...tierForm, actualPrice: parseFloat(e.target.value) })}
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block font-medium mb-1">Offer Price</label>
+                  <input
+                    type="number"
+                    className="w-full p-2 rounded border"
+                    value={tierForm.offerPrice ?? ''}
+                    onChange={e => setTierForm({ ...tierForm, offerPrice: e.target.value ? parseFloat(e.target.value) : null })}
+                  />
+                </div>
+                <div>
+                  <label className="block font-medium mb-1">Duration (min)</label>
+                  <input
+                    type="number"
+                    className="w-full p-2 rounded border"
+                    value={tierForm.duration ?? ''}
+                    onChange={e => setTierForm({ ...tierForm, duration: e.target.value ? parseInt(e.target.value) : null })}
+                  />
+                </div>
                 <div className="text-right space-x-2 pt-2">
                   <button type="submit" className="px-3 py-1 bg-green-600 text-white rounded">{editingTier ? 'Update' : 'Add'} Tier</button>
                 </div>
@@ -420,11 +441,7 @@ export default function ServicesAdmin() {
               <tbody>
                 {images.map(img => (
                   <tr key={img.id} className="border-t">
-
                     <td>{img.imageUrl ? <img src={img.imageUrl} className="h-10"/> : '—'}</td>
-
-                    <td>{img.imageUrl}</td>
-
                     <td>{img.caption ?? '—'}</td>
                     <td className="space-x-2">
                       <button className="underline" onClick={() => openEditImage(img)}>Edit</button>
@@ -436,31 +453,37 @@ export default function ServicesAdmin() {
             </table>
             <button className="bg-green-600 px-3 py-1 rounded text-white mb-4" onClick={openAddImage}>+ Add Image</button>
             {imageForm.imageUrl !== undefined && (
-              <form onSubmit={saveImage} className="space-y-2">
-                <input
-
-                  type="file"
-                  accept="image/*"
-                  onChange={handleImageUpload}
-                  className="w-full p-2 rounded border"
-                />
+              <form onSubmit={saveImage} className="space-y-4">
+                <div>
+                  <label className="block font-medium mb-1">Image File</label>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={handleImageUpload}
+                    className="w-full p-2 rounded border"
+                  />
+                </div>
                 {imageForm.imageUrl && (
                   <img src={imageForm.imageUrl} alt="preview" className="h-24 object-cover" />
                 )}
-
-                  className="w-full p-2 rounded border"
-                  placeholder="Image URL"
-                  value={imageForm.imageUrl || ''}
-                  onChange={e => setImageForm({ ...imageForm, imageUrl: e.target.value })}
-                  required
-                />
-
-                <input
-                  className="w-full p-2 rounded border"
-                  placeholder="Caption"
-                  value={imageForm.caption || ''}
-                  onChange={e => setImageForm({ ...imageForm, caption: e.target.value })}
-                />
+                <div>
+                  <label className="block font-medium mb-1">Image URL</label>
+                  <input
+                    className="w-full p-2 rounded border"
+                    value={imageForm.imageUrl || ''}
+                    onChange={e => setImageForm({ ...imageForm, imageUrl: e.target.value })}
+                    required
+                  />
+                  <small className="text-gray-500">Direct link to image</small>
+                </div>
+                <div>
+                  <label className="block font-medium mb-1">Caption</label>
+                  <input
+                    className="w-full p-2 rounded border"
+                    value={imageForm.caption || ''}
+                    onChange={e => setImageForm({ ...imageForm, caption: e.target.value })}
+                  />
+                </div>
                 <div className="text-right space-x-2 pt-2">
                   <button type="submit" className="px-3 py-1 bg-green-600 text-white rounded">{editingImage ? 'Update' : 'Add'} Image</button>
                 </div>

--- a/src/app/components/WysiwygEditor.tsx
+++ b/src/app/components/WysiwygEditor.tsx
@@ -3,7 +3,8 @@ import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import TextStyle from '@tiptap/extension-text-style'
 import Color from '@tiptap/extension-color'
-import { useEffect } from "react";
+import { useEffect } from 'react'
+import { MdFormatBold, MdFormatItalic, MdLooksOne, MdLooksTwo } from 'react-icons/md'
 
 export default function WysiwygEditor({ value, onChange, className = '' }) {
   const editor = useEditor({
@@ -27,16 +28,46 @@ export default function WysiwygEditor({ value, onChange, className = '' }) {
   if (!editor) return <div>Loading editor...</div>;
 
   return (
-    <div className={`rounded border bg-black p-2 text-secondary ${className}`}>
+    <div className={`rounded border bg-white p-2 text-gray-800 ${className}`}>
       <div className="mb-2 flex gap-1 flex-wrap">
-        <button onClick={() => editor.chain().focus().toggleBold().run()} className={editor.isActive('bold') ? 'font-bold text-primary' : ''}><b>B</b></button>
-        <button onClick={() => editor.chain().focus().toggleItalic().run()} className={editor.isActive('italic') ? 'italic text-primary' : ''}><i>I</i></button>
-        <button onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()} className={editor.isActive('heading', { level: 1 }) ? 'text-primary underline' : ''}>H1</button>
-        <button onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()} className={editor.isActive('heading', { level: 2 }) ? 'text-primary underline' : ''}>H2</button>
-        <input type="color" onChange={e => editor.chain().focus().setColor(e.target.value).run()} />
-        <button onClick={() => editor.chain().focus().unsetColor().run()}>No Color</button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          className={`p-1 rounded hover:bg-green-100 ${editor.isActive('bold') ? 'bg-green-200' : ''}`}
+        >
+          <MdFormatBold />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          className={`p-1 rounded hover:bg-green-100 ${editor.isActive('italic') ? 'bg-green-200' : ''}`}
+        >
+          <MdFormatItalic />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+          className={`p-1 rounded hover:bg-green-100 ${editor.isActive('heading', { level: 1 }) ? 'bg-green-200' : ''}`}
+        >
+          <MdLooksOne />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+          className={`p-1 rounded hover:bg-green-100 ${editor.isActive('heading', { level: 2 }) ? 'bg-green-200' : ''}`}
+        >
+          <MdLooksTwo />
+        </button>
+        <input
+          type="color"
+          onChange={e => editor.chain().focus().setColor(e.target.value).run()}
+          className="h-8 w-8 p-0 border rounded"
+        />
+        <button type="button" onClick={() => editor.chain().focus().unsetColor().run()} className="p-1 rounded hover:bg-green-100">
+          Reset
+        </button>
       </div>
-      <EditorContent editor={editor} className="min-h-[120px] bg-black text-secondary p-2 rounded" />
+      <EditorContent editor={editor} className="min-h-[120px] bg-white text-gray-800 p-2 rounded border" />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- update WYSIWYG editor to light theme with icons
- style admin layout and headings with green tones
- add labels/helper text for admin forms
- fix service image management modal markup

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ab2e0460832594d3127d1100fcf7