### PR TITLE
Enhance service details page

### DIFF
--- a/src/app/api/v2/services/[id]/route.ts
+++ b/src/app/api/v2/services/[id]/route.ts
@@ -15,19 +15,29 @@ export async function GET(req, { params }) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
 
+    const images = await prisma.serviceImage.findMany({
+      where: { serviceId: id },
+      orderBy: { id: 'asc' },
+    })
+
     const result = {
       id: service.id,
       name: service.name,
       caption: service.caption ?? '',
       description: service.description ?? '',
       imageUrl: service.imageUrl ?? null,
+      images: images.map(img => ({
+        id: img.id,
+        imageUrl: img.imageUrl,
+        caption: img.caption ?? null,
+      })),
       tiers: service.tiers.map(t => ({
         id: t.id,
         name: t.name,
         actualPrice: t.actualPrice,
         offerPrice: t.offerPrice,
         duration: t.duration,
-      }))
+      })),
     }
 
     return NextResponse.json(result)

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -14,6 +14,13 @@ export default async function ServiceDetailsPage({ params }) {
       {service.imageUrl && (
         <img src={service.imageUrl} alt={service.name} className="mb-6 rounded-xl w-full max-h-64 object-cover" />
       )}
+      {service.images && service.images.length > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+          {service.images.map(img => (
+            <img key={img.id} src={img.imageUrl} alt={img.caption || service.name} className="rounded-xl object-cover w-full" />
+          ))}
+        </div>
+      )}
       <h1 className="text-3xl font-bold mb-2" style={{ color: '#41eb70' }}>{service.name}</h1>
       {service.caption && <p className="text-lg text-gray-300 mb-4">{service.caption}</p>}
       <div className="prose prose-invert mb-6" dangerouslySetInnerHTML={{ __html: service.description || '' }} />
@@ -26,8 +33,9 @@ export default async function ServiceDetailsPage({ params }) {
           </li>
         ))}
       </ul>
-      <div className="mt-6 text-center">
+      <div className="mt-8 flex justify-between items-center">
         <Link href="/" className="text-green-400 underline">Back to Home</Link>
+        <Link href={`/booking?service=${service.id}`} className="bg-green-600 text-gray-900 font-bold px-6 py-3 rounded-xl hover:bg-green-500 transition-colors">Book Now</Link>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- include gallery info in service detail API
- show gallery and book-now button on service details page

## Testing
- `npm run lint` *(fails: various pre-existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873ae1dd3708325bbed04a8c6791a26