### PR TITLE
Add missing UI components

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: 'default' | 'secondary'
+}
+
+export const Badge = ({ className, variant = 'default', ...props }: BadgeProps) => {
+  const variants = {
+    default: 'bg-blue-600 text-white',
+    secondary: 'bg-gray-200 text-gray-800',
+  }
+  return <span className={cn('inline-flex items-center rounded px-2 py-0.5 text-sm font-medium', variants[variant], className)} {...props} />
+}
+
+export default Badge

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline' | 'ghost'
+  size?: 'default' | 'sm'
+}
+
+const variantClasses = {
+  default: 'bg-blue-600 text-white hover:bg-blue-700',
+  outline: 'border border-slate-300 hover:bg-slate-100',
+  ghost: 'hover:bg-slate-100',
+}
+
+const sizeClasses = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-8 px-3 text-sm',
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center rounded-md font-medium focus:outline-none focus:ring-2 focus:ring-blue-500',
+        variantClasses[variant],
+        sizeClasses[size],
+        className,
+      )}
+      {...props}
+    />
+  )
+)
+Button.displayName = 'Button'
+
+export { Button }
+export default Button

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-white text-slate-900', className)}
+      {...props}
+    />
+  )
+)
+Card.displayName = 'Card'
+
+export const CardHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('border-b px-6 py-4', className)} {...props} />
+)
+CardHeader.displayName = 'CardHeader'
+
+export const CardTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <h3 className={cn('text-lg font-semibold', className)} {...props} />
+)
+CardTitle.displayName = 'CardTitle'
+
+export const CardContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('px-6 py-4', className)} {...props} />
+)
+CardContent.displayName = 'CardContent'

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => (
+  <input
+    ref={ref}
+    className={cn('flex h-10 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500', className)}
+    {...props}
+  />
+))
+Input.displayName = 'Input'
+
+export { Input }
+export default Input

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label ref={ref} className={cn('text-sm font-medium', className)} {...props} />
+  )
+)
+Label.displayName = 'Label'
+
+export default Label

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface SelectProps {
+  value: string
+  onValueChange: (value: string) => void
+  children: React.ReactNode
+  className?: string
+}
+
+export const Select = ({ value, onValueChange, children, className }: SelectProps) => {
+  const placeholderRef = React.useRef<string>('')
+  const options: Array<{ value: string; label: React.ReactNode }> = []
+
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) return
+    if (child.type === SelectTrigger) {
+      React.Children.forEach(child.props.children, (c) => {
+        if (React.isValidElement(c) && c.type === SelectValue) {
+          placeholderRef.current = c.props.placeholder || ''
+        }
+      })
+    }
+    if (child.type === SelectContent) {
+      React.Children.forEach(child.props.children, (c) => {
+        if (React.isValidElement(c) && c.type === SelectItem) {
+          options.push({ value: c.props.value, label: c.props.children })
+        }
+      })
+    }
+  })
+
+  return (
+    <select
+      className={cn('h-10 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500', className)}
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      {placeholderRef.current && (
+        <option value="" disabled hidden>
+          {placeholderRef.current}
+        </option>
+      )}
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+export const SelectTrigger = ({ children }: { children: React.ReactNode }) => <>{children}</>
+export const SelectValue = ({ placeholder }: { placeholder?: string }) => null
+export const SelectContent = ({ children }: { children: React.ReactNode }) => <>{children}</>
+export const SelectItem = ({ value, children }: { value: string; children: React.ReactNode }) => (
+  <option value={value}>{children}</option>
+)
+

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn('flex min-h-[80px] w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500', className)}
+    {...props}
+  />
+))
+Textarea.displayName = 'Textarea'
+
+export { Textarea }
+export default Textarea

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- provide simple UI component implementations under `src/components/ui`
- add a small `cn()` util for class joining

## Testing
- `npm run build`
- `npm run lint` *(fails: several lint errors outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_6873b4986cac8325a5b16e485b125569