### PR TITLE
Fix service image uploads and modal style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tiptap/extension-text-style": "^2.23.0",
         "@tiptap/react": "^2.23.0",
         "@tiptap/starter-kit": "^2.23.0",
+        "cloudinary": "^2.0.0",
         "date-fns": "^4.1.0",
         "formidable": "^3.5.4",
         "framer-motion": "^12.23.0",
@@ -3117,6 +3118,19 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/cloudinary": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.7.0.tgz",
+      "integrity": "sha512-qrqDn31+qkMCzKu1GfRpzPNAO86jchcNwEHCUiqvPHNSFqu7FTNF9FuAkBUyvM1CFFgFPu64NT0DyeREwLwK0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5335,6 +5349,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6327,6 +6347,17 @@
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tiptap/extension-text-style": "^2.23.0",
     "@tiptap/react": "^2.23.0",
     "@tiptap/starter-kit": "^2.23.0",
+    "cloudinary": "^2.0.0",
     "date-fns": "^4.1.0",
     "formidable": "^3.5.4",
     "framer-motion": "^12.23.0",

--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -675,7 +675,7 @@ export default function ServicesAdmin() {
         {showImageModal && (
           <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
             <Card className="w-full max-w-4xl max-h-[90vh] overflow-y-auto shadow-2xl border-0">
-              <CardHeader className="bg-gradient-to-r from-purple-500 to-pink-600 text-white">
+              <CardHeader className="bg-purple-50 text-purple-800">
                 <CardTitle className="flex items-center justify-between">
                   <span className="flex items-center gap-2">
                     <ImageIcon className="h-5 w-5" />
@@ -685,7 +685,7 @@ export default function ServicesAdmin() {
                     variant="ghost"
                     size="sm"
                     onClick={() => setShowImageModal(false)}
-                    className="text-white hover:bg-white/20"
+                    className="text-purple-800 hover:bg-purple-100"
                   >
                     <X className="h-4 w-4" />
                   </Button>


### PR DESCRIPTION
## Summary
- upload images through Cloudinary instead of local filesystem
- adjust Manage Service Images modal header styling
- update staff add/update routes to store pictures in Cloudinary
- add Cloudinary dependency

## Testing
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873ffa4c0508325b141678ca38e986c