### PR TITLE
Fix uploads and SEO slug

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,13 @@ import { MdMale, MdFemale, MdStar, MdDiamond, MdEco } from "react-icons/md"
 import { motion, AnimatePresence } from "framer-motion"
 import Header from "@/components/Header"
 
+function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
 // ---- Tier/Type labels & badge colors ----
 const TIER_LABELS = {
   deluxe: {
@@ -344,7 +351,7 @@ export default function HomePage() {
                                   </div>
                                 </div>
                                 <Link
-                                  href={`/services/${svc.id}`}
+                                  href={`/services/${slugify(svc.name)}`}
                                   prefetch={false}
                                   className="text-green-400 underline text-sm font-semibold hover:text-green-300"
                                 >


### PR DESCRIPTION
## Summary
- allow `/api/upload` to save images locally if Cloudinary credentials are missing
- resolve service details via slug as well as ID
- use slugified service names for links on homepage

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687408e1bb248325b5bef978085cb06f