### PR TITLE
Enable local upload for service images

### DIFF
--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -69,7 +69,7 @@ export default function ServicesAdmin() {
     if (!file) return
     const fd = new FormData()
     fd.append("file", file)
-    const res = await fetch("/api/upload", { method: "POST", body: fd })
+    const res = await fetch("/api/upload-local", { method: "POST", body: fd })
     const data = await res.json()
     setServiceForm({ ...serviceForm, imageUrl: data.url })
   }
@@ -93,7 +93,7 @@ export default function ServicesAdmin() {
     if (!file) return
     const fd = new FormData()
     fd.append("file", file)
-    const res = await fetch("/api/upload", { method: "POST", body: fd })
+    const res = await fetch("/api/upload-local", { method: "POST", body: fd })
     const data = await res.json()
     setImageForm({ ...imageForm, imageUrl: data.url })
   }

--- a/src/app/api/upload-local/route.ts
+++ b/src/app/api/upload-local/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { writeFile, mkdir } from 'fs/promises'
+import path from 'path'
+import fs from 'fs'
+
+export const runtime = 'nodejs'
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.formData()
+    const file = data.get('file') as File | null
+    if (!file) {
+      return NextResponse.json({ error: 'No file' }, { status: 400 })
+    }
+
+    if (!file.type.startsWith('image/')) {
+      return NextResponse.json({ error: 'Invalid file type' }, { status: 400 })
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const uploadsDir = path.join(process.cwd(), 'public', 'uploads')
+    if (!fs.existsSync(uploadsDir)) {
+      await mkdir(uploadsDir, { recursive: true })
+    }
+    const filename = `${Date.now()}-${file.name.replace(/\s+/g, '')}`
+    const filepath = path.join(uploadsDir, filename)
+    await writeFile(filepath, buffer)
+
+    const url = `/uploads/${filename}`
+    return NextResponse.json({ url })
+  } catch (err) {
+    console.error('Local upload error:', err)
+    return NextResponse.json({ error: 'Upload failed' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add new `/api/upload-local` endpoint to store uploaded images on the server
- switch services admin page to use the new local upload endpoint

## Testing
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687420e944988325862a234ae6801627