### PR TITLE
Fix service page fetch

### DIFF
--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link'
+import { headers } from 'next/headers'
 
 export default async function ServiceDetailsPage({ params }: { params: { id: string } }) {
   const { id } = params
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || ''
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL || `http://${headers().get('host')}`
   const res = await fetch(`${baseUrl}/api/v2/services/${id}`, { cache: 'no-store' })
   if (!res.ok) {
     return <div className="text-red-500 text-xl p-8">Unable to load service details</div>


### PR DESCRIPTION
## Summary
- use absolute API URL when fetching service details

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874243519748325a14bb2e88ddc1e6f