### PR TITLE
Add service tier price history tracking

### DIFF
--- a/prisma/migrations/20250713220000_tier_price_history/README.md
+++ b/prisma/migrations/20250713220000_tier_price_history/README.md
@@ -1,0 +1,1 @@
+Adds ServiceTierPriceHistory table to log price changes for each service tier.

--- a/prisma/migrations/20250713220000_tier_price_history/migration.sql
+++ b/prisma/migrations/20250713220000_tier_price_history/migration.sql
@@ -1,0 +1,14 @@
+-- Create table for service tier price history
+CREATE TABLE `servicetierpricehistory` (
+  `id` VARCHAR(191) NOT NULL,
+  `tierId` VARCHAR(191) NOT NULL,
+  `actual_price` DOUBLE NOT NULL,
+  `offer_price` DOUBLE NULL,
+  `changed_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Add foreign key constraint
+ALTER TABLE `servicetierpricehistory`
+  ADD CONSTRAINT `servicetierpricehistory_tierId_fkey`
+  FOREIGN KEY (`tierId`) REFERENCES `ServiceTier`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,11 +168,23 @@ model ServiceNew {
 }
 
 model ServiceTier {
-  id          String     @id @default(uuid())
-  serviceId   String
-  service     ServiceNew @relation(fields: [serviceId], references: [id])
-  name        String
-  actualPrice Float
-  offerPrice  Float?
-  duration    Int?
+  id           String                    @id @default(uuid())
+  serviceId    String
+  service      ServiceNew                @relation(fields: [serviceId], references: [id])
+  name         String
+  actualPrice  Float
+  offerPrice   Float?
+  duration     Int?
+  priceHistory ServiceTierPriceHistory[]
+}
+
+model ServiceTierPriceHistory {
+  id          String      @id @default(uuid()) @db.VarChar(191)
+  tierId      String      @db.VarChar(191)
+  tier        ServiceTier @relation(fields: [tierId], references: [id])
+  actualPrice Float       @map("actual_price")
+  offerPrice  Float?      @map("offer_price")
+  changedAt   DateTime    @default(now()) @map("changed_at") @db.Timestamp(3)
+
+  @@map("servicetierpricehistory")
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -36,6 +36,7 @@ const sections: {
       },
       { href: '/admin/services', label: 'Services', icon: MdDesignServices },
       { href: '/admin/price-history', label: 'Price History', icon: MdHistory },
+      { href: '/admin/tier-price-history', label: 'Tier Price History', icon: MdHistory },
     ],
   },
 ]

--- a/src/app/admin/tier-price-history/page.tsx
+++ b/src/app/admin/tier-price-history/page.tsx
@@ -1,0 +1,136 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface Tier {
+  id: string
+  tierName: string
+  serviceName: string
+  categoryName: string
+}
+
+interface Entry {
+  id: string
+  actualPrice: number
+  offerPrice?: number | null
+  changedAt: string
+}
+
+export default function TierPriceHistoryPage() {
+  const [tiers, setTiers] = useState<Tier[]>([])
+  const [selected, setSelected] = useState('')
+  const [entries, setEntries] = useState<Entry[]>([])
+  const empty: Partial<Entry> = { id: '', actualPrice: 0 }
+  const [form, setForm] = useState<Partial<Entry>>(empty)
+  const [editing, setEditing] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/admin/service-tiers/all').then(r => r.json()).then(setTiers)
+  }, [])
+
+  useEffect(() => {
+    if (!selected) return
+    fetch(`/api/admin/tier-price-history/${selected}`).then(r => r.json()).then(setEntries)
+  }, [selected])
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const body = {
+      actualPrice: Number(form.actualPrice),
+      offerPrice: form.offerPrice !== undefined && form.offerPrice !== null ? Number(form.offerPrice) : null,
+    }
+    if (editing) {
+      await fetch(`/api/admin/tier-price-history/${selected}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: form.id, ...body }),
+      })
+    } else {
+      await fetch(`/api/admin/tier-price-history/${selected}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: crypto.randomUUID(), ...body }),
+      })
+    }
+    setForm(empty)
+    setEditing(false)
+    fetch(`/api/admin/tier-price-history/${selected}`).then(r => r.json()).then(setEntries)
+  }
+
+  const edit = (e: Entry) => {
+    setForm(e)
+    setEditing(true)
+  }
+
+  const del = async (id: string) => {
+    if (!confirm('Delete this entry?')) return
+    await fetch(`/api/admin/tier-price-history/${selected}`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    })
+    fetch(`/api/admin/tier-price-history/${selected}`).then(r => r.json()).then(setEntries)
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Tier Price History</h1>
+      <select className="bg-gray-800 p-2 rounded mb-4" value={selected} onChange={e => setSelected(e.target.value)}>
+        <option value="">Select tier</option>
+        {tiers.map(t => (
+          <option key={t.id} value={t.id}>
+            {t.categoryName} / {t.serviceName} / {t.tierName}
+          </option>
+        ))}
+      </select>
+      {selected && (
+        <div className="space-y-4">
+          <form onSubmit={save} className="space-y-2 bg-white p-4 rounded shadow border">
+            <input
+              type="number"
+              className="w-full p-2 rounded border"
+              placeholder="Actual price"
+              value={form.actualPrice ?? 0}
+              onChange={e => setForm({ ...form, actualPrice: parseFloat(e.target.value) })}
+              required
+            />
+            <input
+              type="number"
+              className="w-full p-2 rounded border"
+              placeholder="Offer price"
+              value={form.offerPrice ?? ''}
+              onChange={e => setForm({ ...form, offerPrice: e.target.value ? parseFloat(e.target.value) : null })}
+            />
+            <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">
+              {editing ? 'Update' : 'Add'} Entry
+            </button>
+          </form>
+          {entries.length > 0 && (
+            <table className="w-full text-sm text-left bg-white rounded shadow border">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-3 py-2">Actual</th>
+                  <th className="px-3 py-2">Offer</th>
+                  <th className="px-3 py-2">Changed At</th>
+                  <th className="px-3 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map(e => (
+                  <tr key={e.id} className="border-t">
+                    <td className="px-3 py-2">{e.actualPrice}</td>
+                    <td className="px-3 py-2">{e.offerPrice ?? '—'}</td>
+                    <td className="px-3 py-2">{new Date(e.changedAt).toLocaleDateString()}</td>
+                    <td className="space-x-2 px-3 py-2">
+                      <button className="underline" onClick={() => edit(e)}>Edit</button>
+                      <button className="underline text-red-600" onClick={() => del(e.id)}>Delete</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/api/admin/service-tiers/[serviceId]/route.ts
+++ b/src/app/api/admin/service-tiers/[serviceId]/route.ts
@@ -21,11 +21,19 @@ export async function POST(req: Request, { params }: { params: { serviceId: stri
       duration: data.duration ? Number(data.duration) : null,
     },
   })
+  await prisma.serviceTierPriceHistory.create({
+    data: {
+      tierId: tier.id,
+      actualPrice: tier.actualPrice,
+      offerPrice: tier.offerPrice,
+    },
+  })
   return NextResponse.json(tier)
 }
 
 export async function PUT(req: Request, { params }: { params: { serviceId: string } }) {
   const data = await req.json()
+  const existing = await prisma.serviceTier.findUnique({ where: { id: data.id } })
   const tier = await prisma.serviceTier.update({
     where: { id: data.id },
     data: {
@@ -35,6 +43,15 @@ export async function PUT(req: Request, { params }: { params: { serviceId: strin
       duration: data.duration ? Number(data.duration) : null,
     },
   })
+  if (existing && (existing.actualPrice !== tier.actualPrice || existing.offerPrice !== tier.offerPrice)) {
+    await prisma.serviceTierPriceHistory.create({
+      data: {
+        tierId: tier.id,
+        actualPrice: tier.actualPrice,
+        offerPrice: tier.offerPrice,
+      },
+    })
+  }
   return NextResponse.json(tier)
 }
 

--- a/src/app/api/admin/service-tiers/all/route.ts
+++ b/src/app/api/admin/service-tiers/all/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const tiers = await prisma.serviceTier.findMany({
+    include: {
+      service: {
+        select: {
+          name: true,
+          category: { select: { name: true } },
+        },
+      },
+    },
+    orderBy: { name: 'asc' },
+  })
+
+  const response = tiers.map(t => ({
+    id: t.id,
+    tierName: t.name,
+    serviceName: t.service.name,
+    categoryName: t.service.category.name,
+  }))
+
+  return NextResponse.json(response)
+}

--- a/src/app/api/admin/tier-price-history/[tierId]/route.ts
+++ b/src/app/api/admin/tier-price-history/[tierId]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(req: Request, { params }: { params: { tierId: string } }) {
+  const { tierId } = params
+  const entries = await prisma.serviceTierPriceHistory.findMany({
+    where: { tierId },
+    orderBy: { changedAt: 'desc' },
+  })
+  return NextResponse.json(entries)
+}
+
+export async function POST(req: Request, { params }: { params: { tierId: string } }) {
+  const { tierId } = params
+  const data = await req.json()
+  const entry = await prisma.serviceTierPriceHistory.create({
+    data: {
+      tierId,
+      actualPrice: Number(data.actualPrice),
+      offerPrice: data.offerPrice === null || data.offerPrice === undefined ? null : Number(data.offerPrice),
+    },
+  })
+  return NextResponse.json(entry)
+}
+
+export async function PUT(req: Request, { params }: { params: { tierId: string } }) {
+  const data = await req.json()
+  const entry = await prisma.serviceTierPriceHistory.update({
+    where: { id: data.id },
+    data: {
+      actualPrice: Number(data.actualPrice),
+      offerPrice: data.offerPrice === null || data.offerPrice === undefined ? null : Number(data.offerPrice),
+    },
+  })
+  return NextResponse.json(entry)
+}
+
+export async function DELETE(req: Request, { params }: { params: { tierId: string } }) {
+  const { id } = await req.json()
+  await prisma.serviceTierPriceHistory.delete({ where: { id } })
+  return NextResponse.json({ success: true })
+}


### PR DESCRIPTION
## Summary
- add `ServiceTierPriceHistory` model and migration
- store price changes when service tiers are created or updated
- expose API routes to manage tier price history
- add admin UI for tier price history
- link new page from admin navigation

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68742a18fe6483258205727c3c2ef05b