### PR TITLE
Enhance admin UI

### DIFF
--- a/src/app/admin/branches/page.tsx
+++ b/src/app/admin/branches/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import { Pencil, Trash2 } from 'lucide-react'
 
 interface Branch {
   id: string
@@ -96,9 +97,19 @@ export default function BranchesAdmin() {
             <tr key={b.id} className="border-t">
               <td className="px-3 py-2">{b.name}</td>
               <td className="px-3 py-2">{b.phone}</td>
-              <td className="space-x-2 px-3 py-2">
-                <button className="underline" onClick={() => edit(b)}>Edit</button>
-                <button className="underline text-red-600" onClick={() => del(b.id)}>Delete</button>
+              <td className="flex gap-2 px-3 py-2">
+                <button
+                  className="flex items-center gap-1 px-2 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded"
+                  onClick={() => edit(b)}
+                >
+                  <Pencil className="h-4 w-4" /> Edit
+                </button>
+                <button
+                  className="flex items-center gap-1 px-2 py-1 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                  onClick={() => del(b.id)}
+                >
+                  <Trash2 className="h-4 w-4" /> Delete
+                </button>
               </td>
             </tr>
           ))}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import React from 'react'
+import { signOut } from 'next-auth/react'
 import {
   MdDashboard,
   MdEvent,
@@ -11,6 +12,7 @@ import {
   MdCategory,
   MdDesignServices,
   MdHistory,
+  MdLogout,
 } from 'react-icons/md'
 import type { IconType } from 'react-icons'
 
@@ -35,7 +37,6 @@ const sections: {
         icon: MdCategory,
       },
       { href: '/admin/services', label: 'Services', icon: MdDesignServices },
-      { href: '/admin/price-history', label: 'Price History', icon: MdHistory },
       { href: '/admin/tier-price-history', label: 'Tier Price History', icon: MdHistory },
     ],
   },
@@ -44,27 +45,41 @@ const sections: {
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   return (
-    <div className="min-h-screen flex text-gray-900 bg-green-50">
-      <nav className="w-60 bg-white border-r border-gray-200 p-4 space-y-4 overflow-y-auto">
-        {sections.map(sec => (
-          <div key={sec.heading}>
-            <div className="uppercase text-xs text-green-700 mb-1">{sec.heading}</div>
-            <div className="space-y-1">
-              {sec.items.map(item => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={`flex items-center gap-2 px-3 py-2 rounded hover:bg-green-100 ${pathname === item.href ? 'bg-green-100 font-semibold' : ''}`}
-                >
-                  <item.icon className="text-lg" />
-                  <span>{item.label}</span>
-                </Link>
-              ))}
+    <div className="min-h-screen flex flex-col text-gray-900 bg-green-50">
+      <header className="flex items-center justify-between bg-green-800 text-green-100 px-6 py-3">
+        <Link href="/admin/dashboard" className="flex items-center gap-2">
+          <img src="/logo.png" alt="Greens" className="h-8 w-auto" />
+          <span className="font-bold">Admin</span>
+        </Link>
+        <button
+          onClick={() => signOut({ callbackUrl: '/' })}
+          className="flex items-center gap-1 bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
+        >
+          <MdLogout className="text-lg" /> Logout
+        </button>
+      </header>
+      <div className="flex flex-1">
+        <nav className="w-60 bg-gradient-to-b from-green-900 to-green-700 text-green-100 p-4 space-y-4 overflow-y-auto">
+          {sections.map(sec => (
+            <div key={sec.heading}>
+              <div className="uppercase text-xs text-green-200 mb-1">{sec.heading}</div>
+              <div className="space-y-1">
+                {sec.items.map(item => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={`flex items-center gap-2 px-3 py-2 rounded hover:bg-green-600 ${pathname === item.href ? 'bg-green-600 font-semibold text-white' : ''}`}
+                  >
+                    <item.icon className="text-lg" />
+                    <span>{item.label}</span>
+                  </Link>
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
-      </nav>
-      <main className="flex-1 p-6 overflow-x-auto">{children}</main>
+          ))}
+        </nav>
+        <main className="flex-1 p-6 overflow-x-auto">{children}</main>
+      </div>
     </div>
   )
 }

--- a/src/app/admin/price-history/page.tsx
+++ b/src/app/admin/price-history/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import { Pencil, Trash2 } from 'lucide-react'
 
 interface Service {
   id: string
@@ -74,7 +75,7 @@ export default function PriceHistoryPage() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4 text-green-700">Price History</h1>
-      <select className="bg-gray-800 p-2 rounded mb-4" value={selected} onChange={e => setSelected(e.target.value)}>
+      <select className="bg-white p-2 rounded mb-4 border" value={selected} onChange={e => setSelected(e.target.value)}>
         <option value="">Select service</option>
         {services.map(s => (
           <option key={s.id} value={s.id}>{s.main_service_name}</option>
@@ -132,9 +133,19 @@ export default function PriceHistoryPage() {
                     <td className="px-3 py-2">{e.offerPrice ?? '—'}</td>
                     <td className="px-3 py-2">{e.offerStartDate ? new Date(e.offerStartDate).toLocaleDateString() : '—'}</td>
                     <td className="px-3 py-2">{e.offerEndDate ? new Date(e.offerEndDate).toLocaleDateString() : '—'}</td>
-                    <td className="space-x-2 px-3 py-2">
-                      <button className="underline" onClick={() => edit(e)}>Edit</button>
-                      <button className="underline text-red-600" onClick={() => del(e.id)}>Delete</button>
+                    <td className="flex gap-2 px-3 py-2">
+                      <button
+                        className="flex items-center gap-1 px-2 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded"
+                        onClick={() => edit(e)}
+                      >
+                        <Pencil className="h-4 w-4" /> Edit
+                      </button>
+                      <button
+                        className="flex items-center gap-1 px-2 py-1 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                        onClick={() => del(e.id)}
+                      >
+                        <Trash2 className="h-4 w-4" /> Delete
+                      </button>
                     </td>
                   </tr>
                 ))}

--- a/src/app/admin/service-categories/page.tsx
+++ b/src/app/admin/service-categories/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import WysiwygEditor from '@/app/components/WysiwygEditor'
+import { Pencil, Trash2 } from 'lucide-react'
 
 interface Category {
   id: string
@@ -145,9 +146,19 @@ export default function ServiceCategoriesPage() {
               <td className="px-3 py-2">{c.name}</td>
               <td className="px-3 py-2">{c.caption ?? '—'}</td>
               <td className="px-3 py-2">{c.imageUrl ? <img src={c.imageUrl} className="h-10"/> : '—'}</td>
-              <td className="space-x-2 px-3 py-2">
-                <button className="underline" onClick={() => edit(c)}>Edit</button>
-                <button className="underline text-red-600" onClick={() => del(c.id)}>Delete</button>
+              <td className="flex gap-2 px-3 py-2">
+                <button
+                  className="flex items-center gap-1 px-2 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded"
+                  onClick={() => edit(c)}
+                >
+                  <Pencil className="h-4 w-4" /> Edit
+                </button>
+                <button
+                  className="flex items-center gap-1 px-2 py-1 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                  onClick={() => del(c.id)}
+                >
+                  <Trash2 className="h-4 w-4" /> Delete
+                </button>
               </td>
             </tr>
           ))}

--- a/src/app/admin/tier-price-history/page.tsx
+++ b/src/app/admin/tier-price-history/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import { Pencil, Trash2 } from 'lucide-react'
 
 interface Tier {
   id: string
@@ -74,7 +75,7 @@ export default function TierPriceHistoryPage() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4 text-green-700">Tier Price History</h1>
-      <select className="bg-gray-800 p-2 rounded mb-4" value={selected} onChange={e => setSelected(e.target.value)}>
+      <select className="bg-white p-2 rounded mb-4 border" value={selected} onChange={e => setSelected(e.target.value)}>
         <option value="">Select tier</option>
         {tiers.map(t => (
           <option key={t.id} value={t.id}>
@@ -120,9 +121,19 @@ export default function TierPriceHistoryPage() {
                     <td className="px-3 py-2">{e.actualPrice}</td>
                     <td className="px-3 py-2">{e.offerPrice ?? '—'}</td>
                     <td className="px-3 py-2">{new Date(e.changedAt).toLocaleDateString()}</td>
-                    <td className="space-x-2 px-3 py-2">
-                      <button className="underline" onClick={() => edit(e)}>Edit</button>
-                      <button className="underline text-red-600" onClick={() => del(e.id)}>Delete</button>
+                    <td className="flex gap-2 px-3 py-2">
+                      <button
+                        className="flex items-center gap-1 px-2 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded"
+                        onClick={() => edit(e)}
+                      >
+                        <Pencil className="h-4 w-4" /> Edit
+                      </button>
+                      <button
+                        className="flex items-center gap-1 px-2 py-1 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                        onClick={() => del(e.id)}
+                      >
+                        <Trash2 className="h-4 w-4" /> Delete
+                      </button>
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- add admin header with logo and logout button
- give the sidebar a green gradient and remove Price History
- convert edit/delete links to buttons with icons
- lighten dropdown backgrounds in price history pages

## Testing
- `npm run lint` *(fails: many existing warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_68742ed4b01883258e278ee07609003a