### PR TITLE
Update tier modals with price info

### DIFF
--- a/src/app/admin/tier-price-history/page.tsx
+++ b/src/app/admin/tier-price-history/page.tsx
@@ -129,7 +129,13 @@ export default function TierPriceHistoryPage() {
               <td className="px-3 py-2">{row.categoryName}</td>
               <td className="px-3 py-2">{row.serviceName}</td>
               <td className="px-3 py-2">{row.tierName}</td>
-              <td className="px-3 py-2">{row.current ? row.current.actualPrice : '—'}</td>
+              <td className="px-3 py-2">
+                {row.current ? (
+                  row.current.actualPrice
+                ) : (
+                  <span className="text-red-600">Not set</span>
+                )}
+              </td>
               <td className="px-3 py-2">{row.current?.endDate ? new Date(row.current.endDate).toLocaleDateString() : '—'}</td>
               <td className="px-3 py-2">{row.upcoming ? row.upcoming.actualPrice : '—'}</td>
               <td className="px-3 py-2">{row.upcoming?.startDate ? new Date(row.upcoming.startDate).toLocaleDateString() : '—'}</td>

--- a/src/app/api/admin/service-tiers/[serviceId]/route.ts
+++ b/src/app/api/admin/service-tiers/[serviceId]/route.ts
@@ -4,9 +4,29 @@ import { NextResponse } from 'next/server'
 const prisma = new PrismaClient()
 
 export async function GET(req: Request, { params }: { params: { serviceId: string } }) {
-  const { serviceId } = await params
-  const tiers = await prisma.serviceTier.findMany({ where: { serviceId }, orderBy: { name: 'asc' } })
-  return NextResponse.json(tiers)
+  const { serviceId } = params
+  const tiers = await prisma.serviceTier.findMany({
+    where: { serviceId },
+    include: { priceHistory: true },
+    orderBy: { name: 'asc' },
+  })
+  const now = new Date()
+  const response = tiers.map(t => {
+    const current = t.priceHistory.find(ph => {
+      const start = ph.startDate
+      const end = ph.endDate
+      return start <= now && (!end || now < end)
+    })
+    return {
+      id: t.id,
+      name: t.name,
+      duration: t.duration,
+      currentPrice: current
+        ? { actualPrice: current.actualPrice, offerPrice: current.offerPrice }
+        : null,
+    }
+  })
+  return NextResponse.json(response)
 }
 
 export async function POST(req: Request, { params }: { params: { serviceId: string } }) {
@@ -16,34 +36,42 @@ export async function POST(req: Request, { params }: { params: { serviceId: stri
     data: {
       serviceId,
       name: data.name,
-      actualPrice: Number(data.actualPrice || 0),
-      offerPrice: data.offerPrice === null || data.offerPrice === undefined ? null : Number(data.offerPrice),
+      actualPrice: data.actualPrice !== undefined ? Number(data.actualPrice || 0) : 0,
+      offerPrice:
+        data.offerPrice === null || data.offerPrice === undefined
+          ? null
+          : Number(data.offerPrice),
       duration: data.duration ? Number(data.duration) : null,
     },
   })
-  await prisma.serviceTierPriceHistory.create({
-    data: {
-      tierId: tier.id,
-      actualPrice: tier.actualPrice,
-      offerPrice: tier.offerPrice,
-    },
-  })
+  if (data.actualPrice !== undefined || data.offerPrice !== undefined) {
+    await prisma.serviceTierPriceHistory.create({
+      data: {
+        tierId: tier.id,
+        actualPrice: tier.actualPrice,
+        offerPrice: tier.offerPrice,
+      },
+    })
+  }
   return NextResponse.json(tier)
 }
 
 export async function PUT(req: Request, { params }: { params: { serviceId: string } }) {
   const data = await req.json()
   const existing = await prisma.serviceTier.findUnique({ where: { id: data.id } })
-  const tier = await prisma.serviceTier.update({
-    where: { id: data.id },
-    data: {
-      name: data.name,
-      actualPrice: Number(data.actualPrice || 0),
-      offerPrice: data.offerPrice === null || data.offerPrice === undefined ? null : Number(data.offerPrice),
-      duration: data.duration ? Number(data.duration) : null,
-    },
-  })
-  if (existing && (existing.actualPrice !== tier.actualPrice || existing.offerPrice !== tier.offerPrice)) {
+  const updateData: any = { name: data.name }
+  if (data.duration !== undefined) updateData.duration = data.duration ? Number(data.duration) : null
+  if (data.actualPrice !== undefined) updateData.actualPrice = Number(data.actualPrice || 0)
+  if (data.offerPrice !== undefined) updateData.offerPrice =
+    data.offerPrice === null ? null : Number(data.offerPrice)
+
+  const tier = await prisma.serviceTier.update({ where: { id: data.id }, data: updateData })
+
+  if (
+    existing &&
+    (('actualPrice' in updateData && existing.actualPrice !== tier.actualPrice) ||
+      ('offerPrice' in updateData && existing.offerPrice !== tier.offerPrice))
+  ) {
     await prisma.serviceTierPriceHistory.create({
       data: {
         tierId: tier.id,


### PR DESCRIPTION
## Summary
- show current tier price using price history table
- fetch tiers with current price in admin services page
- hide price fields when creating/editing tiers
- highlight missing tier price
- style modal headers with dark text

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687441c4097c8325af8774b7b152b241