### PR TITLE
Add mobile-responsive admin sidebar

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,7 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import React from 'react'
+import React, { useState } from 'react'
 import { signOut } from 'next-auth/react'
 import {
   MdDashboard,
@@ -13,6 +13,7 @@ import {
   MdDesignServices,
   MdHistory,
   MdLogout,
+  MdMenu,
 } from 'react-icons/md'
 import type { IconType } from 'react-icons'
 
@@ -44,13 +45,23 @@ const sections: {
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+  const [open, setOpen] = useState(false)
   return (
     <div className="min-h-screen flex flex-col text-gray-900 bg-green-50">
-      <header className="flex items-center justify-between bg-green-800 text-green-100 px-6 py-3">
-        <Link href="/admin/dashboard" className="flex items-center gap-2">
-          <img src="/logo.png" alt="Greens" className="h-8 w-auto" />
-          <span className="font-bold">Admin</span>
-        </Link>
+      <header className="flex items-center justify-between bg-green-800 text-green-100 px-4 md:px-6 py-3">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setOpen(true)}
+            className="md:hidden p-2 -ml-2"
+            aria-label="Open menu"
+          >
+            <MdMenu className="text-2xl" />
+          </button>
+          <Link href="/admin/dashboard" className="flex items-center gap-2">
+            <img src="/logo.png" alt="Greens" className="h-8 w-auto" />
+            <span className="font-bold">Admin</span>
+          </Link>
+        </div>
         <button
           onClick={() => signOut({ callbackUrl: '/' })}
           className="flex items-center gap-1 bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
@@ -58,8 +69,14 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
           <MdLogout className="text-lg" /> Logout
         </button>
       </header>
-      <div className="flex flex-1">
-<nav className="w-60 bg-green-900  text-white p-4 space-y-4 shadow-lg">
+      <div className="flex flex-1 overflow-hidden">
+        {open && (
+          <div
+            className="fixed inset-0 bg-black/50 z-20 md:hidden"
+            onClick={() => setOpen(false)}
+          />
+        )}
+<nav className={`fixed md:static top-0 left-0 h-full w-60 bg-green-900  text-white p-4 space-y-4 shadow-lg z-30 transform transition-transform ${open ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0`}>
           {sections.map(sec => (
             <div key={sec.heading}>
               <div className="uppercase text-xs text-green-200 mb-1">{sec.heading}</div>
@@ -68,6 +85,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                   <Link
                     key={item.href}
                     href={item.href}
+                    onClick={() => setOpen(false)}
                     className={`flex items-center gap-2 px-3 py-2 rounded hover:bg-green-600 ${pathname === item.href ? 'bg-green-600 font-semibold text-white' : ''}`}
                   >
                     <item.icon className="text-lg" />
@@ -78,7 +96,11 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             </div>
           ))}
         </nav>
-        <main className="flex-1 p-6 overflow-x-auto">{children}</main>
+        <main
+          className={`flex-1 p-4 md:p-6 overflow-x-auto transform transition-transform ${open ? 'translate-x-60' : ''} md:translate-x-0`}
+        >
+          {children}
+        </main>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- make the admin sidebar collapsible on mobile
- use push-style menu with overlay

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68746d36e2448325a36e73d87b762ff2