### PR TITLE
Add overlay loader and improve tier price modal

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import LoadingOverlay from '@/components/LoadingOverlay'
 
 interface Metrics {
   bookings: number
@@ -16,27 +17,29 @@ export default function DashboardPage() {
       .then(setData)
   }, [])
 
-  if (!data) return <p>Loading...</p>
+  const metrics = data || { bookings: 0, services: 0, staff: 0, branches: 0 }
+
 
   return (
     <div className="space-y-4">
+      <LoadingOverlay show={!data} />
       <h1 className="text-2xl font-bold text-green-700">Admin Dashboard</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Bookings</div>
-          <div className="text-2xl font-bold">{data.bookings}</div>
+      <div className="text-sm text-gray-500">Bookings</div>
+      <div className="text-2xl font-bold">{metrics.bookings}</div>
         </div>
         <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Services</div>
-          <div className="text-2xl font-bold">{data.services}</div>
+      <div className="text-sm text-gray-500">Services</div>
+      <div className="text-2xl font-bold">{metrics.services}</div>
         </div>
         <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Staff</div>
-          <div className="text-2xl font-bold">{data.staff}</div>
+      <div className="text-sm text-gray-500">Staff</div>
+      <div className="text-2xl font-bold">{metrics.staff}</div>
         </div>
         <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Branches</div>
-          <div className="text-2xl font-bold">{data.branches}</div>
+      <div className="text-sm text-gray-500">Branches</div>
+      <div className="text-2xl font-bold">{metrics.branches}</div>
         </div>
       </div>
     </div>

--- a/src/app/admin/tier-price-history/page.tsx
+++ b/src/app/admin/tier-price-history/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { Pencil, Trash2 } from 'lucide-react'
+import { Label } from '@/components/ui/label'
 
 interface TierRow {
   id: string
@@ -154,36 +155,54 @@ export default function TierPriceHistoryPage() {
           <div className="bg-white rounded shadow w-full max-w-xl p-4 space-y-4">
             <h2 className="text-lg font-semibold">Edit Price History</h2>
             <form onSubmit={save} className="space-y-2">
-              <input
-                type="number"
-                className="w-full p-2 rounded border"
-                placeholder="Actual price"
-                value={form.actualPrice ?? 0}
-                onChange={e => setForm({ ...form, actualPrice: parseFloat(e.target.value) })}
-                required
-              />
-              <input
-                type="number"
-                className="w-full p-2 rounded border"
-                placeholder="Offer price (optional)"
-                value={form.offerPrice ?? ''}
-                onChange={e => setForm({ ...form, offerPrice: e.target.value ? parseFloat(e.target.value) : null })}
-              />
-              <input
-                type="date"
-                className="w-full p-2 rounded border"
-                value={form.startDate || ''}
-                onChange={e => setForm({ ...form, startDate: e.target.value })}
-                required
-              />
-              <p className="text-xs text-gray-500">Start date when this price becomes effective</p>
-              <input
-                type="date"
-                className="w-full p-2 rounded border"
-                value={form.endDate || ''}
-                onChange={e => setForm({ ...form, endDate: e.target.value || null })}
-              />
-              <p className="text-xs text-gray-500">Leave blank if this price has no planned end date</p>
+              <div className="space-y-1">
+                <Label htmlFor="actual">Actual Price</Label>
+                <input
+                  id="actual"
+                  type="number"
+                  className="w-full p-2 rounded border"
+                  placeholder="Enter actual price"
+                  value={form.actualPrice ?? 0}
+                  onChange={e => setForm({ ...form, actualPrice: parseFloat(e.target.value) })}
+                  required
+                />
+                <p className="text-xs text-gray-500">Base price for this tier</p>
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="offer">Offer Price</Label>
+                <input
+                  id="offer"
+                  type="number"
+                  className="w-full p-2 rounded border"
+                  placeholder="Optional discount price"
+                  value={form.offerPrice ?? ''}
+                  onChange={e => setForm({ ...form, offerPrice: e.target.value ? parseFloat(e.target.value) : null })}
+                />
+                <p className="text-xs text-gray-500">Leave blank if no discount</p>
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="start">Start Date</Label>
+                <input
+                  id="start"
+                  type="date"
+                  className="w-full p-2 rounded border"
+                  value={form.startDate || ''}
+                  onChange={e => setForm({ ...form, startDate: e.target.value })}
+                  required
+                />
+                <p className="text-xs text-gray-500">Start date when this price becomes effective</p>
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="end">End Date</Label>
+                <input
+                  id="end"
+                  type="date"
+                  className="w-full p-2 rounded border"
+                  value={form.endDate || ''}
+                  onChange={e => setForm({ ...form, endDate: e.target.value || null })}
+                />
+                <p className="text-xs text-gray-500">Leave blank if this price has no planned end date</p>
+              </div>
               <div className="flex gap-2 justify-end pt-2">
                 <button type="button" className="px-3 py-1 rounded border" onClick={() => { setSelected(''); setEntries([]) }}>
                   Close

--- a/src/app/customer/coupons/page.tsx
+++ b/src/app/customer/coupons/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { useSession, signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Toaster, toast } from 'sonner';
+import LoadingOverlay from '@/components/LoadingOverlay';
 
 interface Coupon {
   id: string;
@@ -40,6 +41,7 @@ export default function MyCouponsPage() {
 
   return (
     <div className="min-h-screen bg-[#052b1e] flex">
+      <LoadingOverlay show={loading} />
       <Toaster richColors position="top-center" />
 
       {/* reuse same Sidebar component as other pages */}

--- a/src/app/customer/my-bookings/page.tsx
+++ b/src/app/customer/my-bookings/page.tsx
@@ -4,6 +4,7 @@ import { useSession, signIn } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Toaster, toast } from 'sonner';
+import LoadingOverlay from '@/components/LoadingOverlay';
 
 export default function MyBookings() {
   const { data: session, status } = useSession();
@@ -33,6 +34,7 @@ export default function MyBookings() {
 
   return (
     <div className="min-h-screen bg-[#052b1e] flex">
+      <LoadingOverlay show={loading} />
       <Toaster richColors position="top-center" />
 
       {/* Sidebar */}

--- a/src/app/customer/profile/page.tsx
+++ b/src/app/customer/profile/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, FormEvent } from 'react';
 import { useSession, signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Toaster, toast } from 'sonner';
+import LoadingOverlay from '@/components/LoadingOverlay';
 
 const MENU = [
   { label: 'My Profile', icon: 'ri-user-3-line', path: '/customer/profile' },
@@ -108,16 +109,10 @@ export default function CustomerProfile() {
     }
   }
 
-  if (status === 'loading' || loading) {
-    return (
-      <div className="min-h-screen bg-[#052b1e] flex items-center justify-center">
-        <p className="text-primary">Loading profile…</p>
-      </div>
-    );
-  }
 
   return (
     <div className="min-h-screen bg-[#052b1e] flex">
+      <LoadingOverlay show={status === 'loading' || loading} />
       <Toaster richColors position="top-center" />
 
       {/* Sidebar */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import {
 import { MdMale, MdFemale, MdStar, MdDiamond, MdEco } from "react-icons/md"
 import { motion, AnimatePresence } from "framer-motion"
 import Header from "@/components/Header"
+import LoadingOverlay from '@/components/LoadingOverlay'
 
 
 // ---- Tier/Type labels & badge colors ----
@@ -77,6 +78,7 @@ export default function HomePage() {
 
   return (
     <main className="bg-gray-900 min-h-screen font-sans text-gray-100">
+      <LoadingOverlay show={loading} />
       {/* HEADER */}
       <Header cartCount={cart.length} />
 

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function LoadingOverlay({ show }: { show: boolean }) {
+  if (!show) return null
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="w-12 h-12 border-4 border-white border-t-transparent rounded-full animate-spin" />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable `LoadingOverlay` component
- show overlay loader on pages when loading data
- add form labels and helper text to tier price history modal
- guard metrics in admin dashboard

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run build` *(fails: Next.js build error during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_687471bca99083258587b2429f0d0e20