### PR TITLE
Add preferred booking workflow

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,11 +80,12 @@ model Booking {
   serviceId String  @db.VarChar(191)
   service   Service @relation(fields: [serviceId], references: [id])
 
-  status    String   @default("pending") @db.VarChar(191)
-  date      DateTime @db.DateTime(3)
-  paid      Boolean  @default(false)
-  createdAt DateTime @default(now()) @db.Timestamp(3)
-  updatedAt DateTime @default(now()) @updatedAt @db.Timestamp(3)
+  preferredDate DateTime? @db.DateTime(3)
+  status        String    @default("pending") @db.VarChar(191)
+  date          DateTime? @db.DateTime(3)
+  paid          Boolean   @default(false)
+  createdAt     DateTime  @default(now()) @db.Timestamp(3)
+  updatedAt     DateTime  @default(now()) @updatedAt @db.Timestamp(3)
 }
 
 model ServiceCategory {
@@ -131,7 +132,6 @@ model ServiceImage {
   service   ServiceNew @relation(fields: [serviceId], references: [id])
   serviceId String
 }
-
 
 model BranchService {
   branch    Branch  @relation(fields: [branchId], references: [id])

--- a/src/app/admin/appointments/page.tsx
+++ b/src/app/admin/appointments/page.tsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from 'react'
 
 interface Booking {
   id: string
-  date: string
+  date: string | null
+  preferredDate: string | null
   status: string
   service: { name: string }
   branch: { name: string }
@@ -22,11 +23,11 @@ export default function AppointmentPage() {
 
   useEffect(() => { load() }, [])
 
-  const update = async (id: string, status: string) => {
+  const update = async (id: string, status: string, date?: string) => {
     await fetch('/api/bookings', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, status }),
+      body: JSON.stringify({ id, status, date: date ? new Date(date) : undefined }),
     })
     load()
   }
@@ -37,7 +38,8 @@ export default function AppointmentPage() {
       <table className="w-full text-sm text-left bg-white rounded shadow border">
         <thead className="bg-gray-50">
           <tr>
-            <th className="px-3 py-2">Date</th>
+            <th className="px-3 py-2">Preferred Date</th>
+            <th className="px-3 py-2">Scheduled Time</th>
             <th className="px-3 py-2">Customer</th>
             <th className="px-3 py-2">Service</th>
             <th className="px-3 py-2">Status</th>
@@ -46,7 +48,15 @@ export default function AppointmentPage() {
         <tbody>
           {bookings.map(b => (
             <tr key={b.id} className="border-t">
-              <td className="px-3 py-2">{new Date(b.date).toLocaleString()}</td>
+              <td className="px-3 py-2">{b.preferredDate ? new Date(b.preferredDate).toLocaleDateString() : '—'}</td>
+              <td className="px-3 py-2">
+                <input
+                  type="datetime-local"
+                  className="p-1 border rounded"
+                  value={b.date ? b.date.slice(0,16) : ''}
+                  onChange={e => update(b.id, 'confirmed', e.target.value)}
+                />
+              </td>
               <td className="px-3 py-2">{b.user?.name || '—'}</td>
               <td className="px-3 py-2">{b.service.name}</td>
               <td>

--- a/src/app/api/customer/bookings/route.ts
+++ b/src/app/api/customer/bookings/route.ts
@@ -14,8 +14,8 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const { branchId, date, items } = await req.json();
-  if (!branchId || !date || !Array.isArray(items) || items.length === 0) {
+  const { branchId, preferredDate, items } = await req.json();
+  if (!branchId || !preferredDate || !Array.isArray(items) || items.length === 0) {
     return NextResponse.json(
       { success: false, error: 'branchId, date and items are required' },
       { status: 400 }
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
 
     // create bookings
     const created = await Promise.all(
-      items.map((it: { serviceId: string; staffId?: string; slot: string }) =>
+      items.map((it: { serviceId: string; staffId?: string }) =>
         prisma.booking.create({
           data: {
             userId: customer.id,
@@ -44,7 +44,8 @@ export async function POST(req: NextRequest) {
             serviceId: it.serviceId,
             staffId: it.staffId || null,
             status: 'pending',
-            date: new Date(`${date}T${it.slot}:00`),
+            preferredDate: new Date(preferredDate),
+            date: null,
             paid: false,
           },
         })

--- a/src/app/customer/book/page.tsx
+++ b/src/app/customer/book/page.tsx
@@ -57,8 +57,6 @@ interface StaffMember { id: string; name: string }
 type SelectedService = {
   id: string;
   service: Service;
-  staff: string;
-  slot: string;
   price: number;
   duration: number;
 };
@@ -76,9 +74,6 @@ export default function BookingPage() {
   const [date, setDate]                   = useState('');
   const [serviceQuery, setServiceQuery]   = useState('');
   const [selServiceId, setSelServiceId]   = useState('');
-  const [selStaff, setSelStaff]           = useState('');
-  const [selSlot, setSelSlot]             = useState('');
-  const [availableSlots, setAvailableSlots] = useState<{ time: string; available: boolean }[]>([]);
   const [selected, setSelected]           = useState<SelectedService[]>([]);
 
   // Coupon state
@@ -154,14 +149,14 @@ export default function BookingPage() {
 
   // Add service
   const handleAdd = () => {
-    if (!selServiceId || !selSlot) return;
+    if (!selServiceId) return;
     const svc = services.find(s => s.id === selServiceId)!;
     const price = getCurrentPrice(svc.priceHistory, date||getToday());
     setSelected(prev => [
       ...prev,
-      { id: crypto.randomUUID(), service: svc, staff: selStaff, slot: selSlot, price, duration: svc.duration }
+      { id: crypto.randomUUID(), service: svc, price, duration: svc.duration }
     ]);
-    setServiceQuery(''); setSelServiceId(''); setSelStaff(''); setSelSlot('');
+    setServiceQuery(''); setSelServiceId('');
   };
 
   // Compute totals
@@ -196,11 +191,9 @@ export default function BookingPage() {
       headers:{'Content-Type':'application/json'},
       body: JSON.stringify({
         branchId,
-        date,
+        preferredDate: date,
         items: selected.map(s=>({
-          serviceId: s.service.id,
-          staffId:   s.staff||undefined,
-          slot:      s.slot
+          serviceId: s.service.id
         })),
         couponCode: appliedCoupon?.code
       })
@@ -276,38 +269,10 @@ export default function BookingPage() {
                   )}
                 </div>
 
-                <label className="text-primary">Staff</label>
-                <select
-                  className={inputClass + ' mb-2'}
-                  value={selStaff}
-                  onChange={e=>setSelStaff(e.target.value)}
-                >
-                  <option value="">Any</option>
-                  {staff.map(s=>(
-                    <option key={s.id} value={s.id}>{s.name}</option>
-                  ))}
-                </select>
-
-                <label className="text-primary">Time Slot</label>
-                <div className="grid grid-cols-3 gap-2 mb-2">
-                  {availableSlots.map(slot=>(
-                    <button
-                      key={slot.time}
-                      disabled={!slot.available}
-                      className={`rounded py-1 text-sm ${
-                        selSlot===slot.time ? 'bg-primary text-black':'bg-gray-800 text-white'
-                      } ${!slot.available?'opacity-50 cursor-not-allowed':''}`}
-                      onClick={()=>setSelSlot(slot.time)}
-                    >
-                      {slot.time}
-                    </button>
-                  ))}
-                </div>
-
                 <button
                   className="bg-primary text-black px-4 py-2 rounded font-semibold"
                   onClick={handleAdd}
-                  disabled={!selServiceId||!selSlot}
+                  disabled={!selServiceId}
                 >
                   Add Service
                 </button>
@@ -322,9 +287,6 @@ export default function BookingPage() {
                   >
                     <div>
                       <div className="font-semibold text-primary">{item.service.name}</div>
-                      <div className="text-sm text-secondary">
-                        {item.slot}{item.staff&&` · ${staff.find(x=>x.id===item.staff)?.name}`}
-                      </div>
                       <div className="text-sm text-secondary">
                         ₹{item.price} · {item.duration} mins
                       </div>

--- a/src/app/customer/dashboard/page.tsx
+++ b/src/app/customer/dashboard/page.tsx
@@ -59,12 +59,14 @@ export default function CustomerDashboard() {
   }, [status, session]);
 
   const today = new Date().toISOString().slice(0, 10);
-  const upcoming = bookings.filter(b =>
-    b.date.slice(0, 10) >= today && ['pending', 'confirmed'].includes(b.status)
-  );
-  const past = bookings.filter(b =>
-    b.date.slice(0, 10) < today || ['completed', 'cancelled'].includes(b.status)
-  );
+  const upcoming = bookings.filter(b => {
+    const d = b.date || b.preferredDate;
+    return d.slice(0,10) >= today && ['pending','confirmed'].includes(b.status);
+  });
+  const past = bookings.filter(b => {
+    const d = b.date || b.preferredDate;
+    return d.slice(0,10) < today || ['completed','cancelled'].includes(b.status);
+  });
 
   return (
     <div className="min-h-screen bg-[#052b1e] flex">
@@ -167,7 +169,7 @@ export default function CustomerDashboard() {
                 >
                   <div className="flex justify-between items-center mb-2">
                     <span className="text-primary font-bold text-lg">
-                      {new Date(booking.date).toLocaleDateString('en-IN', {
+                      {new Date((booking.date||booking.preferredDate)).toLocaleDateString('en-IN', {
                         day: '2-digit', month: 'short', year: 'numeric'
                       })}
                     </span>
@@ -184,6 +186,11 @@ export default function CustomerDashboard() {
                   {booking.staff && (
                     <p className="text-sm text-secondary">Staff: {booking.staff.name}</p>
                   )}
+
+                  <p className="text-sm text-secondary">
+                    Preferred: {new Date(booking.preferredDate).toLocaleDateString('en-IN')}
+                    {booking.date && ` · Scheduled at ${new Date(booking.date).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})}`}
+                  </p>
 
                   {/* Payment Status */}
                   <p className="text-sm mt-2">

--- a/src/app/staff/tasks/page.tsx
+++ b/src/app/staff/tasks/page.tsx
@@ -1,0 +1,72 @@
+'use client'
+import { useSession, signIn } from 'next-auth/react'
+import { useEffect, useState } from 'react'
+import { Toaster } from 'sonner'
+
+interface Booking {
+  id: string
+  preferredDate: string | null
+  date: string | null
+  status: string
+  service: { name: string }
+  branch: { name: string }
+  user: { name: string }
+}
+
+export default function StaffTasks() {
+  const { data: session, status } = useSession()
+  const [bookings, setBookings] = useState<Booking[]>([])
+
+  useEffect(() => {
+    if (status === 'unauthenticated') signIn()
+  }, [status])
+
+  useEffect(() => {
+    if (status !== 'authenticated' || !session?.user?.id) return
+    fetch(`/api/bookings?staffId=${session.user.id}`)
+      .then(r => r.json())
+      .then(d => d.success && setBookings(d.bookings))
+  }, [status, session])
+
+  const complete = async(id: string) => {
+    await fetch('/api/bookings', {
+      method:'PUT',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ id, status:'completed' })
+    })
+    setBookings(b => b.filter(x => x.id !== id))
+  }
+
+  return (
+    <div className="p-4">
+      <Toaster richColors position="top-center" />
+      <h1 className="text-2xl font-bold mb-4">My Tasks</h1>
+      <table className="w-full text-sm text-left bg-white rounded shadow border">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2">Preferred</th>
+            <th className="px-3 py-2">Scheduled</th>
+            <th className="px-3 py-2">Customer</th>
+            <th className="px-3 py-2">Service</th>
+            <th className="px-3 py-2">Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {bookings.map(b => (
+            <tr key={b.id} className="border-t">
+              <td className="px-3 py-2">{b.preferredDate ? new Date(b.preferredDate).toLocaleDateString() : '—'}</td>
+              <td className="px-3 py-2">{b.date ? new Date(b.date).toLocaleString() : '—'}</td>
+              <td className="px-3 py-2">{b.user.name}</td>
+              <td className="px-3 py-2">{b.service.name}</td>
+              <td className="px-3 py-2">
+                {b.status !== 'completed' && (
+                  <button className="bg-green-600 text-white px-2 py-1 rounded" onClick={() => complete(b.id)}>Done</button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add preferredDate column in schema
- support staffId filter and scheduling updates in bookings API
- update customer booking flow to request date only
- show preferred date and scheduled time in customer dashboard
- display preferred date and allow scheduling in admin page
- add simple staff tasks page

## Testing
- `npm install`
- `npm run lint` *(fails: `next` not found / numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b8ef844d88325a7a2938f392439d1