### PR TITLE
Add mock authentication and global cart context

### DIFF
--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,5 +1,7 @@
 'use client'
 import React, { useState } from "react";
+import { useCart } from "@/contexts/CartContext";
+import { useAuth } from "@/contexts/AuthContext";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { FiTrash, FiLogOut } from "react-icons/fi";
@@ -7,17 +9,14 @@ import { MdDashboard, MdCheckCircle } from "react-icons/md";
 import Header from "@/components/Header";
 
 const holidays = [2]; // 2: Tuesday (holiday)
-const dummyCart = [
-  { id: 'svc_hydrafacial', name: "Hydra Facial Deluxe", price: 2500, desc: "Advanced hydration and deep cleansing facial." },
-  { id: 'svc_haircut', name: "Premium Haircut", price: 600, desc: "Precision haircut by senior stylist." },
-];
 const availableCoupons = [
   { code: "WELCOME100", desc: "₹100 off for new customers!", discount: 100 },
   { code: "FREESHINE", desc: "Get a free Shine Serum with Hydra Facial.", discount: 0 }
 ];
 
 export default function CartPage() {
-  const [cart, setCart] = useState(dummyCart);
+  const { items: cart, remove, clear } = useCart();
+  const { logout } = useAuth();
   const [date, setDate] = useState<Date | null>(null);
   const [mobile, setMobile] = useState("");
   const [otp, setOtp] = useState("");
@@ -37,7 +36,7 @@ export default function CartPage() {
   }
 
   function handleRemove(id: string) {
-    setCart(c => c.filter(x => x.id !== id));
+    remove(id);
   }
   function handleSendOtp() {
     if (!/^\d{10}$/.test(mobile)) {
@@ -72,8 +71,10 @@ export default function CartPage() {
   }
   function handleConfirmBooking() {
     setShowConfirmModal(true);
+    clear();
   }
   function handleLogout() {
+    logout();
     window.location.href = "/";
   }
   function gotoDashboard() {
@@ -86,7 +87,7 @@ export default function CartPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-[#05241a] via-[#03150d] to-[#0f3b27] text-white pb-12">
-      <Header cartCount={cart.length} />
+      <Header />
 
       <main className="max-w-lg mx-auto p-2 flex flex-col gap-6">
         {/* CART */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@
 import './globals.css'
 import React from 'react'
 import { Providers } from './providers'
+import { CartProvider } from '../contexts/CartContext'
+import { AuthProvider } from '../contexts/AuthContext'
 import "react-datepicker/dist/react-datepicker.css";
 
 export const metadata = {
@@ -67,7 +69,11 @@ export default function RootLayout({
         `}</style>
       </head>
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          <AuthProvider>
+            <CartProvider>{children}</CartProvider>
+          </AuthProvider>
+        </Providers>
       </body>
     </html>
   )

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,20 +1,22 @@
+
 'use client'
-import { signIn } from 'next-auth/react'
+import { useAuth } from '@/contexts/AuthContext'
 
 export default function LoginPage() {
+  const { login } = useAuth()
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100 p-6">
       <div className="bg-white shadow-md p-8 rounded-lg w-full max-w-md">
         <h1 className="text-2xl font-semibold mb-4 text-center">Login to Greens Salon</h1>
 
         <button
-          onClick={() => signIn('google')}
+          onClick={() => login({ name: 'Guest User', role: 'customer' })}
           className="w-full bg-green-600 text-white py-2 rounded hover:bg-green-700 transition"
         >
-          Sign in with Google
+          Mock Login
         </button>
 
-        <p className="text-sm text-center mt-6 text-gray-500">More login options coming soon</p>
+        <p className="text-sm text-center mt-6 text-gray-500">This is a temporary mock login.</p>
       </div>
     </div>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useMemo } from "react"
+import { useCart } from "@/contexts/CartContext"
 import Link from 'next/link'
 import {
   FiShoppingCart,
@@ -38,10 +39,10 @@ const TIER_LABELS = {
 }
 
 export default function HomePage() {
+  const { items, add } = useCart()
   const [categories, setCategories] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
   const [expandedCat, setExpandedCat] = useState<string | null>(null)
-  const [cart, setCart] = useState<any[]>([])
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -68,17 +69,13 @@ export default function HomePage() {
   }, [expandedCat, categories])
 
   function addToCart(service: any) {
-    setCart(prev =>
-      prev.find(item => item.id === service.id)
-        ? prev
-        : [...prev, { ...service, qty: 1 }]
-    )
+    add({ id: service.id, name: service.name, price: service.offerPrice ?? service.mrp })
   }
 
   return (
     <main className="bg-gray-900 min-h-screen font-sans text-gray-100">
       {/* HEADER */}
-      <Header cartCount={cart.length} />
+      <Header />
 
       {/* HERO SECTION WITH VIDEO */}
       <section className="relative h-[90vh] flex items-center justify-center overflow-hidden">
@@ -367,7 +364,7 @@ export default function HomePage() {
 
       {/* CART BAR */}
       <AnimatePresence>
-        {cart.length > 0 && (
+        {items.length > 0 && (
           <motion.div
             className="fixed left-6 right-6 bottom-6 bg-gradient-to-r from-green-600 via-emerald-600 to-green-700 text-white py-4 px-6 rounded-2xl shadow-2xl z-50 flex items-center justify-between backdrop-blur-sm"
             initial={{ y: 100, opacity: 0 }}
@@ -380,13 +377,13 @@ export default function HomePage() {
                 <FiShoppingCart className="text-xl" />
               </div>
               <div>
-                <span className="font-bold text-lg">{cart.length} service{cart.length > 1 ? "s" : ""} selected</span>
+                <span className="font-bold text-lg">{items.length} service{items.length > 1 ? "s" : ""} selected</span>
                 <p className="text-sm opacity-90">Ready to book your appointment</p>
               </div>
             </div>
             <motion.button
               className="bg-white text-green-600 px-6 py-3 rounded-xl font-bold hover:bg-gray-100 transition-colors shadow-lg"
-              onClick={() => alert("Proceeding to cart!")}
+              onClick={() => (window.location.href = '/cart')}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,9 +4,13 @@ import Link from "next/link"
 import { FiShoppingCart, FiMenu, FiX } from "react-icons/fi"
 import { motion, AnimatePresence } from "framer-motion"
 import { useState } from "react"
+import { useCart } from "@/contexts/CartContext"
+import { useAuth } from "@/contexts/AuthContext"
 
-export default function Header({ cartCount }) {
+export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const { items } = useCart()
+  const { user, logout } = useAuth()
 
   return (
     <header className="bg-gray-900/90 backdrop-blur-xl text-gray-100 py-4 shadow-lg sticky top-0 z-50 border-b border-green-400/20">
@@ -37,12 +41,12 @@ export default function Header({ cartCount }) {
             <li>
               <motion.button
                 className="relative hover:text-green-400 transition-colors"
-                onClick={() => alert("Go to cart page!")}
+                onClick={() => (window.location.href = '/cart')}
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
               >
                 <FiShoppingCart className="text-2xl" />
-                {cartCount > 0 && (
+                {items.length > 0 && (
                   <motion.span
                     className="absolute -top-2 -right-2 text-gray-900 rounded-full text-xs font-bold px-2 py-0.5"
                     style={{ backgroundColor: "#41eb70" }}
@@ -50,17 +54,24 @@ export default function Header({ cartCount }) {
                     animate={{ scale: 1 }}
                     transition={{ type: "spring", stiffness: 500 }}
                   >
-                    {cartCount}
+                    {items.length}
                   </motion.span>
                 )}
               </motion.button>
+            </li>
+            <li>
+              {user ? (
+                <button onClick={logout} className="hover:text-green-400 font-medium">Logout</button>
+              ) : (
+                <Link href="/auth/signin" className="hover:text-green-400 font-medium">Login</Link>
+              )}
             </li>
           </ul>
         </nav>
 
         {/* Mobile Menu Button */}
         <div className="md:hidden flex items-center gap-4">
-          {cartCount > 0 && (
+          {items.length > 0 && (
             <motion.button
               className="relative hover:text-green-400 transition-colors"
               onClick={() => alert("Go to cart page!")}
@@ -75,7 +86,7 @@ export default function Header({ cartCount }) {
                 animate={{ scale: 1 }}
                 transition={{ type: "spring", stiffness: 500 }}
               >
-                {cartCount}
+                {items.length}
               </motion.span>
             </motion.button>
           )}
@@ -127,6 +138,13 @@ export default function Header({ cartCount }) {
                     </Link>
                   </li>
                 </ul>
+                <div className="mt-4">
+                  {user ? (
+                    <button onClick={() => { setIsMenuOpen(false); logout(); }} className="block w-full text-left hover:text-green-400 font-medium">Logout</button>
+                  ) : (
+                    <Link href="/auth/signin" onClick={() => setIsMenuOpen(false)} className="block hover:text-green-400 font-medium">Login</Link>
+                  )}
+                </div>
               </nav>
             </motion.div>
           )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -74,7 +74,7 @@ export default function Header() {
           {items.length > 0 && (
             <motion.button
               className="relative hover:text-green-400 transition-colors"
-              onClick={() => alert("Go to cart page!")}
+              onClick={() => (window.location.href = '/cart')}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,41 @@
+'use client'
+import React, {createContext, useContext, useState, ReactNode, useEffect} from 'react'
+
+interface User {
+  name: string
+  role: 'customer' | 'staff' | 'admin'
+}
+
+interface AuthValue {
+  user: User | null
+  login: (u: User) => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthValue | undefined>(undefined)
+
+export function AuthProvider({children}:{children: ReactNode}) {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('mockUser')
+    if(stored) setUser(JSON.parse(stored))
+  }, [])
+
+  function login(u: User) {
+    localStorage.setItem('mockUser', JSON.stringify(u))
+    setUser(u)
+  }
+  function logout() {
+    localStorage.removeItem('mockUser')
+    setUser(null)
+  }
+
+  return <AuthContext.Provider value={{user, login, logout}}>{children}</AuthContext.Provider>
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if(!ctx) throw new Error('useAuth must be inside AuthProvider')
+  return ctx
+}

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -1,0 +1,43 @@
+import React, {createContext, useContext, useState, ReactNode} from 'react'
+
+export interface CartItem {
+  id: string
+  name: string
+  price: number
+  desc?: string
+}
+
+interface CartContextValue {
+  items: CartItem[]
+  add: (item: CartItem) => void
+  remove: (id: string) => void
+  clear: () => void
+}
+
+const CartContext = createContext<CartContextValue | undefined>(undefined)
+
+export function CartProvider({children}:{children: ReactNode}) {
+  const [items, setItems] = useState<CartItem[]>([])
+
+  function add(item: CartItem) {
+    setItems(curr => curr.some(i => i.id === item.id) ? curr : [...curr, item])
+  }
+  function remove(id: string) {
+    setItems(curr => curr.filter(i => i.id !== id))
+  }
+  function clear() {
+    setItems([])
+  }
+
+  return (
+    <CartContext.Provider value={{items, add, remove, clear}}>
+      {children}
+    </CartContext.Provider>
+  )
+}
+
+export function useCart() {
+  const ctx = useContext(CartContext)
+  if(!ctx) throw new Error('useCart must be inside CartProvider')
+  return ctx
+}

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, {createContext, useContext, useState, ReactNode} from 'react'
 
 export interface CartItem {


### PR DESCRIPTION
## Summary
- add CartProvider and AuthProvider contexts
- integrate providers in app layout
- update Header to use cart count and login/logout links
- simplify login page with mock login
- connect home and cart pages to new contexts

## Testing
- `npm run lint` *(fails: several lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_687c5fddcfb08325ad0a6153872e538d