### PR TITLE
Add notes field for customer bookings

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,6 +84,7 @@ model Booking {
   status        String    @default("pending") @db.VarChar(191)
   date          DateTime? @db.DateTime(3)
   paid          Boolean   @default(false)
+  notes         String?   @db.Text
   createdAt     DateTime  @default(now()) @db.Timestamp(3)
   updatedAt     DateTime  @default(now()) @updatedAt @db.Timestamp(3)
 }

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: Request) {
 export async function POST(req: Request) {
   try {
     const session = await getServerSession(authOptions);
-    const { preferredDate, date, customerName, customerPhone, customerGender, items, branchId, coupon } = await req.json();
+    const { preferredDate, date, customerName, customerPhone, customerGender, items, branchId, coupon, notes } = await req.json();
 
     let customer;
 
@@ -101,6 +101,7 @@ export async function POST(req: Request) {
             date: it.date && it.slot ? new Date(`${it.date}T${it.slot}:00`) : null,
             paid: false,
             coupon: coupon || null,
+            notes: notes || null,
           },
         })
       )

--- a/src/app/api/customer/bookings/route.ts
+++ b/src/app/api/customer/bookings/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const { branchId, preferredDate, items } = await req.json();
+  const { branchId, preferredDate, items, notes } = await req.json();
   if (!branchId || !preferredDate || !Array.isArray(items) || items.length === 0) {
     return NextResponse.json(
       { success: false, error: 'branchId, date and items are required' },
@@ -47,6 +47,7 @@ export async function POST(req: NextRequest) {
             preferredDate: new Date(preferredDate),
             date: null,
             paid: false,
+            notes: notes || null,
           },
         })
       )

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -27,6 +27,7 @@ export default function CartPage() {
   const [couponCode, setCouponCode] = useState("");
   const [appliedCoupon, setAppliedCoupon] = useState<{ code: string, desc: string, discount: number } | null>(null);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [notes, setNotes] = useState("");
 
   function isDayDisabled(d: Date) {
     // Disable past dates and Tuesdays
@@ -72,6 +73,7 @@ export default function CartPage() {
   function handleConfirmBooking() {
     setShowConfirmModal(true);
     clear();
+    setNotes("");
   }
   function handleLogout() {
     logout();
@@ -247,6 +249,17 @@ export default function CartPage() {
                     Coupon <b>{appliedCoupon.code}</b> applied!
                   </div>
                 )}
+              </div>
+
+              {/* Notes */}
+              <div className="my-4">
+                <label className="block font-semibold mb-1 text-green-100">Notes</label>
+                <textarea
+                  className="w-full rounded-md p-2 bg-[#12281a] border border-lime-700 text-white h-24"
+                  placeholder="Any special requests? (optional)"
+                  value={notes}
+                  onChange={e=>setNotes(e.target.value)}
+                />
               </div>
 
               <button

--- a/src/app/customer/book/page.tsx
+++ b/src/app/customer/book/page.tsx
@@ -86,6 +86,7 @@ export default function BookingPage() {
     minAmount?: number;
   } | null>(null);
   const [couponError, setCouponError]     = useState('');
+  const [notes, setNotes]                 = useState('');
 
   // Require login
   useEffect(() => {
@@ -195,7 +196,8 @@ export default function BookingPage() {
         items: selected.map(s=>({
           serviceId: s.service.id
         })),
-        couponCode: appliedCoupon?.code
+        couponCode: appliedCoupon?.code,
+        notes
       })
     });
     const d = await res.json();
@@ -324,21 +326,32 @@ export default function BookingPage() {
                       </button>
                     </div>
                     {couponError && <p className="text-red-400 mt-1">{couponError}</p>}
-                    {appliedCoupon && (
-                      <p className="text-green-400 mt-1">
-                        Applied {appliedCoupon.code}: −
-                        {appliedCoupon.discountType==='percent'
-                          ? `${appliedCoupon.discountValue}%`
-                          : `₹${appliedCoupon.discountValue}`}
-                      </p>
-                    )}
-                  </div>
+                  {appliedCoupon && (
+                    <p className="text-green-400 mt-1">
+                      Applied {appliedCoupon.code}: −
+                      {appliedCoupon.discountType==='percent'
+                        ? `${appliedCoupon.discountValue}%`
+                        : `₹${appliedCoupon.discountValue}`}
+                    </p>
+                  )}
+                </div>
 
-                  <div className="mt-6 text-right">
-                    <button
-                      className="bg-primary text-black px-6 py-2 rounded font-semibold"
-                      onClick={handleConfirm}
-                    >
+                {/* Notes */}
+                <div className="mt-4">
+                  <label className="text-primary">Notes</label>
+                  <textarea
+                    className={inputClass + ' h-24'}
+                    value={notes}
+                    onChange={e=>setNotes(e.target.value)}
+                    placeholder="Any special requests? (optional)"
+                  />
+                </div>
+
+                <div className="mt-6 text-right">
+                  <button
+                    className="bg-primary text-black px-6 py-2 rounded font-semibold"
+                    onClick={handleConfirm}
+                  >
                       Confirm Booking
                     </button>
                   </div>


### PR DESCRIPTION
## Summary
- expand `Booking` model with optional `notes` field
- accept `notes` in customer booking API and staff booking API
- collect notes on booking page and cart summary page
- send notes when confirming bookings

## Testing
- `npm run lint` *(fails: various lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_687c9c70dcd08325b3bc9cf1dc53b467