### PR TITLE
Add admin loading overlay

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,6 +2,8 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import React, { useState } from 'react'
+import { LoadingProvider } from '@/contexts/LoadingContext'
+import Loader from '@/components/Loader'
 import { signOut } from 'next-auth/react'
 import {
   MdDashboard,
@@ -47,7 +49,9 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   const pathname = usePathname()
   const [open, setOpen] = useState(false)
   return (
-    <div className="min-h-screen flex flex-col text-gray-900 bg-green-50">
+    <LoadingProvider>
+      <Loader />
+      <div className="min-h-screen flex flex-col text-gray-900 bg-green-50">
       <header className="flex items-center justify-between bg-green-800 text-green-100 px-4 md:px-6 py-3">
         <div className="flex items-center gap-2">
           <button
@@ -102,6 +106,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
           {children}
         </main>
       </div>
-    </div>
+      </div>
+    </LoadingProvider>
   )
 }

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { useLoading } from '@/contexts/LoadingContext'
+
+export default function Loader() {
+  const { loading, progress } = useLoading()
+  if (!loading) return null
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow p-4 w-56">
+        <div className="h-2 bg-gray-200 rounded">
+          <div
+            className="h-full bg-green-500 rounded"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <div className="text-center mt-2 text-sm font-medium text-gray-700">
+          {Math.round(progress)}%
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/contexts/LoadingContext.tsx
+++ b/src/contexts/LoadingContext.tsx
@@ -1,0 +1,81 @@
+'use client'
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+interface LoadingValue {
+  loading: boolean
+  progress: number
+  start: () => void
+  set: (p: number) => void
+  done: () => void
+}
+
+const LoadingContext = createContext<LoadingValue | undefined>(undefined)
+
+export function LoadingProvider({ children }: { children: React.ReactNode }) {
+  const [loading, setLoading] = useState(false)
+  const [progress, setProgress] = useState(0)
+  const [active, setActive] = useState(0)
+
+  const start = () => {
+    setActive(n => n + 1)
+    if (!loading) {
+      setProgress(0)
+      setLoading(true)
+    }
+  }
+
+  const done = () => {
+    setActive(n => {
+      const next = n - 1
+      if (next <= 0) {
+        setProgress(100)
+        setTimeout(() => {
+          setLoading(false)
+          setProgress(0)
+        }, 300)
+        return 0
+      }
+      return next
+    })
+  }
+
+  const set = (p: number) => setProgress(p)
+
+  // auto progress animation
+  useEffect(() => {
+    if (!loading) return
+    const timer = setInterval(() => {
+      setProgress(p => (p < 90 ? p + 5 : p))
+    }, 200)
+    return () => clearInterval(timer)
+  }, [loading])
+
+  // patch fetch to show loader for all requests
+  useEffect(() => {
+    const orig = window.fetch
+    window.fetch = async (...args) => {
+      start()
+      try {
+        const res = await orig(...args)
+        return res
+      } finally {
+        done()
+      }
+    }
+    return () => {
+      window.fetch = orig
+    }
+  }, [])
+
+  return (
+    <LoadingContext.Provider value={{ loading, progress, start, set, done }}>
+      {children}
+    </LoadingContext.Provider>
+  )
+}
+
+export function useLoading() {
+  const ctx = useContext(LoadingContext)
+  if (!ctx) throw new Error('useLoading must be inside LoadingProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add LoadingContext provider with global fetch interceptor
- create Loader component
- wrap admin layout with loading provider and overlay

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cae36b4608325a32e96b036e10f17