### PR TITLE
Add admin booking creation and invoice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "next-auth": "^4.24.11",
         "nodemailer": "^6.10.1",
         "papaparse": "^5.5.3",
+        "pdf-lib": "^1.17.1",
         "prisma": "^6.8.2",
         "react": "18.3.1",
         "react-beautiful-dnd": "^13.1.1",
@@ -1177,6 +1178,24 @@
       "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@popperjs/core": {
@@ -5987,6 +6006,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/papaparse": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
@@ -6027,6 +6052,24 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "next-auth": "^4.24.11",
     "nodemailer": "^6.10.1",
     "papaparse": "^5.5.3",
+    "pdf-lib": "^1.17.1",
     "prisma": "^6.8.2",
     "react": "18.3.1",
     "react-beautiful-dnd": "^13.1.1",

--- a/src/app/admin/appointments/new/page.tsx
+++ b/src/app/admin/appointments/new/page.tsx
@@ -19,7 +19,7 @@ export default function NewAppointment() {
       .then((d) => {
         if (d.success) {
           setBranches(d.branches)
-          if (d.branches.length === 1) setBranch(d.branches[0].id)
+          if (d.branches.length === 1) setBranch(String(d.branches[0].id))
         }
       })
   }, [])
@@ -60,21 +60,27 @@ export default function NewAppointment() {
         <label className="block mb-1">Branch</label>
         <select name="branchId" value={branch} onChange={e => setBranch(e.target.value)} required className="p-2 border rounded w-full">
           <option value="">Select branch</option>
-          {branches.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
+          {branches.map(b => (
+            <option key={b.id} value={String(b.id)}>{b.name}</option>
+          ))}
         </select>
       </div>
       <div>
         <label className="block mb-1">Service</label>
         <select name="serviceId" required className="p-2 border rounded w-full">
           <option value="">Select service</option>
-          {services.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+          {services.map(s => (
+            <option key={s.id} value={String(s.id)}>{s.name}</option>
+          ))}
         </select>
       </div>
       <div>
         <label className="block mb-1">Staff (optional)</label>
         <select name="staffId" className="p-2 border rounded w-full">
           <option value="">Any</option>
-          {staff.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+          {staff.map(s => (
+            <option key={s.id} value={String(s.id)}>{s.name}</option>
+          ))}
         </select>
       </div>
       <div>

--- a/src/app/admin/appointments/new/page.tsx
+++ b/src/app/admin/appointments/new/page.tsx
@@ -14,7 +14,14 @@ export default function NewAppointment() {
   const [branch, setBranch] = useState('')
 
   useEffect(() => {
-    fetch('/api/branch').then(r => r.json()).then(d => d.success && setBranches(d.branches))
+    fetch('/api/branch')
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.success) {
+          setBranches(d.branches)
+          if (d.branches.length === 1) setBranch(d.branches[0].id)
+        }
+      })
   }, [])
 
   useEffect(() => {

--- a/src/app/admin/appointments/new/page.tsx
+++ b/src/app/admin/appointments/new/page.tsx
@@ -27,8 +27,15 @@ export default function NewAppointment() {
       .then((r) => r.json())
       .then((d) => {
         if (d.success) {
-          setBranches(d.branches);
-          if (d.branches.length === 1) setBranch(String(d.branches[0].id));
+          const br = d.branches.map((b: Branch) => ({
+            ...b,
+            id: String(b.id),
+          }));
+          setBranches(br);
+          if (br.length === 1) {
+            setBranch(br[0].id);
+            loadBranchData(br[0].id);
+          }
         }
       });
   }, []);

--- a/src/app/admin/appointments/new/page.tsx
+++ b/src/app/admin/appointments/new/page.tsx
@@ -1,0 +1,96 @@
+'use client'
+import { useEffect, useState, FormEvent } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface Service { id: string; name: string }
+interface Branch { id: string; name: string }
+interface Staff { id: string; name: string }
+
+export default function NewAppointment() {
+  const router = useRouter()
+  const [services, setServices] = useState<Service[]>([])
+  const [branches, setBranches] = useState<Branch[]>([])
+  const [staff, setStaff] = useState<Staff[]>([])
+  const [branch, setBranch] = useState('')
+
+  useEffect(() => {
+    fetch('/api/branch').then(r => r.json()).then(d => d.success && setBranches(d.branches))
+  }, [])
+
+  useEffect(() => {
+    if (!branch) return
+    fetch(`/api/services?branchId=${branch}`)
+      .then(r => r.json())
+      .then(d => d.success && setServices(d.services))
+    fetch(`/api/staff?branchId=${branch}`)
+      .then(r => r.json())
+      .then(d => d.success && setStaff(d.staff))
+  }, [branch])
+
+  const submit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const fd = new FormData(e.currentTarget)
+    const res = await fetch('/api/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        preferredDate: fd.get('date'),
+        customerName: fd.get('name'),
+        customerPhone: fd.get('phone'),
+        customerGender: fd.get('gender'),
+        branchId: fd.get('branchId'),
+        items: [{ serviceId: fd.get('serviceId'), staffId: fd.get('staffId') || undefined }],
+      }),
+    })
+    const data = await res.json()
+    if (data.success) router.push('/admin/appointments')
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-4 max-w-md">
+      <h1 className="text-2xl font-bold mb-4 text-green-700">New Appointment</h1>
+      <div>
+        <label className="block mb-1">Branch</label>
+        <select name="branchId" value={branch} onChange={e => setBranch(e.target.value)} required className="p-2 border rounded w-full">
+          <option value="">Select branch</option>
+          {branches.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Service</label>
+        <select name="serviceId" required className="p-2 border rounded w-full">
+          <option value="">Select service</option>
+          {services.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Staff (optional)</label>
+        <select name="staffId" className="p-2 border rounded w-full">
+          <option value="">Any</option>
+          {staff.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Preferred Date</label>
+        <input type="date" name="date" required className="p-2 border rounded w-full" />
+      </div>
+      <div>
+        <label className="block mb-1">Customer Name</label>
+        <input name="name" required className="p-2 border rounded w-full" />
+      </div>
+      <div>
+        <label className="block mb-1">Customer Phone</label>
+        <input name="phone" maxLength={10} required className="p-2 border rounded w-full" />
+      </div>
+      <div>
+        <label className="block mb-1">Gender</label>
+        <select name="gender" required className="p-2 border rounded w-full">
+          <option value="Male">Male</option>
+          <option value="Female">Female</option>
+          <option value="Other">Other</option>
+        </select>
+      </div>
+      <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">Create</button>
+    </form>
+  )
+}

--- a/src/app/admin/appointments/new/page.tsx
+++ b/src/app/admin/appointments/new/page.tsx
@@ -23,33 +23,33 @@ export default function NewAppointment() {
   const [branch, setBranch] = useState("");
 
   useEffect(() => {
-    fetch("/api/branch")
+    fetch('/api/branch')
       .then((r) => r.json())
       .then((d) => {
         if (d.success) {
-          const br = d.branches.map((b: Branch) => ({
-            ...b,
-            id: String(b.id),
-          }));
-          setBranches(br);
-          if (br.length === 1) {
-            setBranch(br[0].id);
-            loadBranchData(br[0].id);
-          }
+          const br = d.branches.map((b: Branch) => ({ ...b, id: String(b.id) }))
+          setBranches(br)
+          if (br.length === 1) setBranch(br[0].id)
         }
-      });
-  }, []);
+      })
+      .catch(() => {})
+  }, [])
 
   const loadBranchData = (id: string) => {
+    if (!id) return
     fetch(`/api/branch/${encodeURIComponent(id)}/data`)
       .then((r) => r.json())
       .then((d) => {
         if (d.success) {
-          setServices(d.services);
-          setStaff(d.staff);
+          setServices(d.services)
+          setStaff(d.staff)
+        } else if (d.services && d.staff) {
+          // tolerate responses without success flag
+          setServices(d.services)
+          setStaff(d.staff)
         }
       })
-      .catch(() => {});
+      .catch(() => {})
   };
 
   useEffect(() => {

--- a/src/app/admin/appointments/new/page.tsx
+++ b/src/app/admin/appointments/new/page.tsx
@@ -39,16 +39,23 @@ export default function NewAppointment() {
       setStaff([]);
       return;
     }
-    fetch(`/api/services?branchId=${encodeURIComponent(branch)}`)
+    const current = branch;
+    fetch(`/api/services?branchId=${encodeURIComponent(current)}`)
       .then((r) => r.json())
       .then((d) => {
-        if (d.success !== false) setServices(d.services ?? d);
-      });
-    fetch(`/api/staff?branchId=${encodeURIComponent(branch)}`)
+        if (current === branch && d.success !== false) {
+          setServices(d.services ?? d);
+        }
+      })
+      .catch(() => {});
+    fetch(`/api/staff?branchId=${encodeURIComponent(current)}`)
       .then((r) => r.json())
       .then((d) => {
-        if (d.success !== false) setStaff(d.staff ?? d);
-      });
+        if (current === branch && d.success !== false) {
+          setStaff(d.staff ?? d);
+        }
+      })
+      .catch(() => {});
   }, [branch]);
 
   const submit = async (e: FormEvent<HTMLFormElement>) => {

--- a/src/app/admin/appointments/new/page.tsx
+++ b/src/app/admin/appointments/new/page.tsx
@@ -33,29 +33,25 @@ export default function NewAppointment() {
       });
   }, []);
 
+  const loadBranchData = (id: string) => {
+    fetch(`/api/branch/${encodeURIComponent(id)}/data`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.success) {
+          setServices(d.services);
+          setStaff(d.staff);
+        }
+      })
+      .catch(() => {});
+  };
+
   useEffect(() => {
     if (!branch) {
       setServices([]);
       setStaff([]);
-      return;
+    } else {
+      loadBranchData(branch);
     }
-    const current = branch;
-    fetch(`/api/services?branchId=${encodeURIComponent(current)}`)
-      .then((r) => r.json())
-      .then((d) => {
-        if (current === branch && d.success !== false) {
-          setServices(d.services ?? d);
-        }
-      })
-      .catch(() => {});
-    fetch(`/api/staff?branchId=${encodeURIComponent(current)}`)
-      .then((r) => r.json())
-      .then((d) => {
-        if (current === branch && d.success !== false) {
-          setStaff(d.staff ?? d);
-        }
-      })
-      .catch(() => {});
   }, [branch]);
 
   const submit = async (e: FormEvent<HTMLFormElement>) => {

--- a/src/app/admin/appointments/new/page.tsx
+++ b/src/app/admin/appointments/new/page.tsx
@@ -1,67 +1,99 @@
-'use client'
-import { useEffect, useState, FormEvent } from 'react'
-import { useRouter } from 'next/navigation'
+"use client";
+import { useEffect, useState, FormEvent } from "react";
+import { useRouter } from "next/navigation";
 
-interface Service { id: string; name: string }
-interface Branch { id: string; name: string }
-interface Staff { id: string; name: string }
+interface Service {
+  id: string;
+  name: string;
+}
+interface Branch {
+  id: string;
+  name: string;
+}
+interface Staff {
+  id: string;
+  name: string;
+}
 
 export default function NewAppointment() {
-  const router = useRouter()
-  const [services, setServices] = useState<Service[]>([])
-  const [branches, setBranches] = useState<Branch[]>([])
-  const [staff, setStaff] = useState<Staff[]>([])
-  const [branch, setBranch] = useState('')
+  const router = useRouter();
+  const [services, setServices] = useState<Service[]>([]);
+  const [branches, setBranches] = useState<Branch[]>([]);
+  const [staff, setStaff] = useState<Staff[]>([]);
+  const [branch, setBranch] = useState("");
 
   useEffect(() => {
-    fetch('/api/branch')
+    fetch("/api/branch")
       .then((r) => r.json())
       .then((d) => {
         if (d.success) {
-          setBranches(d.branches)
-          if (d.branches.length === 1) setBranch(String(d.branches[0].id))
+          setBranches(d.branches);
+          if (d.branches.length === 1) setBranch(String(d.branches[0].id));
         }
-      })
-  }, [])
+      });
+  }, []);
 
   useEffect(() => {
-    if (!branch) return
-    fetch(`/api/services?branchId=${branch}`)
-      .then(r => r.json())
-      .then(d => d.success && setServices(d.services))
-    fetch(`/api/staff?branchId=${branch}`)
-      .then(r => r.json())
-      .then(d => d.success && setStaff(d.staff))
-  }, [branch])
+    if (!branch) {
+      setServices([]);
+      setStaff([]);
+      return;
+    }
+    fetch(`/api/services?branchId=${encodeURIComponent(branch)}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.success !== false) setServices(d.services ?? d);
+      });
+    fetch(`/api/staff?branchId=${encodeURIComponent(branch)}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.success !== false) setStaff(d.staff ?? d);
+      });
+  }, [branch]);
 
   const submit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    const fd = new FormData(e.currentTarget)
-    const res = await fetch('/api/bookings', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const res = await fetch("/api/bookings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        preferredDate: fd.get('date'),
-        customerName: fd.get('name'),
-        customerPhone: fd.get('phone'),
-        customerGender: fd.get('gender'),
-        branchId: fd.get('branchId'),
-        items: [{ serviceId: fd.get('serviceId'), staffId: fd.get('staffId') || undefined }],
+        preferredDate: fd.get("date"),
+        customerName: fd.get("name"),
+        customerPhone: fd.get("phone"),
+        customerGender: fd.get("gender"),
+        branchId: fd.get("branchId"),
+        items: [
+          {
+            serviceId: fd.get("serviceId"),
+            staffId: fd.get("staffId") || undefined,
+          },
+        ],
       }),
-    })
-    const data = await res.json()
-    if (data.success) router.push('/admin/appointments')
-  }
+    });
+    const data = await res.json();
+    if (data.success) router.push("/admin/appointments");
+  };
 
   return (
     <form onSubmit={submit} className="space-y-4 max-w-md">
-      <h1 className="text-2xl font-bold mb-4 text-green-700">New Appointment</h1>
+      <h1 className="text-2xl font-bold mb-4 text-green-700">
+        New Appointment
+      </h1>
       <div>
         <label className="block mb-1">Branch</label>
-        <select name="branchId" value={branch} onChange={e => setBranch(e.target.value)} required className="p-2 border rounded w-full">
+        <select
+          name="branchId"
+          value={branch}
+          onChange={(e) => setBranch(e.target.value)}
+          required
+          className="p-2 border rounded w-full"
+        >
           <option value="">Select branch</option>
-          {branches.map(b => (
-            <option key={b.id} value={String(b.id)}>{b.name}</option>
+          {branches.map((b) => (
+            <option key={b.id} value={String(b.id)}>
+              {b.name}
+            </option>
           ))}
         </select>
       </div>
@@ -69,8 +101,10 @@ export default function NewAppointment() {
         <label className="block mb-1">Service</label>
         <select name="serviceId" required className="p-2 border rounded w-full">
           <option value="">Select service</option>
-          {services.map(s => (
-            <option key={s.id} value={String(s.id)}>{s.name}</option>
+          {services.map((s) => (
+            <option key={s.id} value={String(s.id)}>
+              {s.name}
+            </option>
           ))}
         </select>
       </div>
@@ -78,14 +112,21 @@ export default function NewAppointment() {
         <label className="block mb-1">Staff (optional)</label>
         <select name="staffId" className="p-2 border rounded w-full">
           <option value="">Any</option>
-          {staff.map(s => (
-            <option key={s.id} value={String(s.id)}>{s.name}</option>
+          {staff.map((s) => (
+            <option key={s.id} value={String(s.id)}>
+              {s.name}
+            </option>
           ))}
         </select>
       </div>
       <div>
         <label className="block mb-1">Preferred Date</label>
-        <input type="date" name="date" required className="p-2 border rounded w-full" />
+        <input
+          type="date"
+          name="date"
+          required
+          className="p-2 border rounded w-full"
+        />
       </div>
       <div>
         <label className="block mb-1">Customer Name</label>
@@ -93,7 +134,12 @@ export default function NewAppointment() {
       </div>
       <div>
         <label className="block mb-1">Customer Phone</label>
-        <input name="phone" maxLength={10} required className="p-2 border rounded w-full" />
+        <input
+          name="phone"
+          maxLength={10}
+          required
+          className="p-2 border rounded w-full"
+        />
       </div>
       <div>
         <label className="block mb-1">Gender</label>
@@ -103,7 +149,12 @@ export default function NewAppointment() {
           <option value="Other">Other</option>
         </select>
       </div>
-      <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">Create</button>
+      <button
+        type="submit"
+        className="bg-green-600 text-white px-4 py-2 rounded"
+      >
+        Create
+      </button>
     </form>
-  )
+  );
 }

--- a/src/app/admin/appointments/page.tsx
+++ b/src/app/admin/appointments/page.tsx
@@ -6,10 +6,12 @@ interface Booking {
   date: string | null
   preferredDate: string | null
   status: string
+  paid: boolean
   service: { name: string }
   branch: { name: string }
   user: { name: string }
   staff?: { name: string } | null
+  invoiceUrl?: string
 }
 
 export default function AppointmentPage() {
@@ -23,18 +25,21 @@ export default function AppointmentPage() {
 
   useEffect(() => { load() }, [])
 
-  const update = async (id: string, status: string, date?: string) => {
+  const update = async (id: string, status: string, date?: string, paid?: boolean) => {
     await fetch('/api/bookings', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, status, date: date ? new Date(date) : undefined }),
+      body: JSON.stringify({ id, status, paid, date: date ? new Date(date) : undefined }),
     })
     load()
   }
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4 text-green-700">Appointment Requests</h1>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold text-green-700">Appointment Requests</h1>
+        <a href="/admin/appointments/new" className="bg-green-600 text-white px-3 py-1 rounded">New</a>
+      </div>
       <table className="w-full text-sm text-left bg-white rounded shadow border">
         <thead className="bg-gray-50">
           <tr>
@@ -43,6 +48,8 @@ export default function AppointmentPage() {
             <th className="px-3 py-2">Customer</th>
             <th className="px-3 py-2">Service</th>
             <th className="px-3 py-2">Status</th>
+            <th className="px-3 py-2">Paid</th>
+            <th className="px-3 py-2">Invoice</th>
           </tr>
         </thead>
         <tbody>
@@ -70,6 +77,18 @@ export default function AppointmentPage() {
                   <option value="completed">completed</option>
                   <option value="cancelled">cancelled</option>
                 </select>
+              </td>
+              <td className="px-3 py-2">
+                {b.paid ? 'Yes' : (
+                  <button className="text-sm text-green-700 underline" onClick={() => update(b.id, b.status, undefined, true)}>
+                    Mark Paid
+                  </button>
+                )}
+              </td>
+              <td className="px-3 py-2">
+                {b.invoiceUrl && (
+                  <a href={b.invoiceUrl} target="_blank" className="text-blue-600 underline">Download</a>
+                )}
               </td>
             </tr>
           ))}

--- a/src/app/api/bookings/[id]/invoice/route.ts
+++ b/src/app/api/bookings/[id]/invoice/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { PDFDocument, StandardFonts } from 'pdf-lib'
+
+export const runtime = 'nodejs'
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const booking = await prisma.booking.findUnique({
+      where: { id: params.id },
+      include: {
+        service: { select: { name: true } },
+        branch: { select: { name: true } },
+        staff: { select: { name: true } },
+        user: { select: { name: true } },
+      },
+    })
+    if (!booking) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    const pdf = await PDFDocument.create()
+    const page = pdf.addPage()
+    const font = await pdf.embedFont(StandardFonts.Helvetica)
+    let y = page.getHeight() - 40
+    const draw = (text: string, size = 12) => {
+      page.drawText(text, { x: 50, y, size, font })
+      y -= size + 10
+    }
+    draw('Greens Salon Invoice', 16)
+    draw(`Booking ID: ${booking.id}`)
+    draw(`Customer: ${booking.user?.name || 'N/A'}`)
+    draw(`Service: ${booking.service.name}`)
+    if (booking.staff) draw(`Staff: ${booking.staff.name}`)
+    draw(`Branch: ${booking.branch.name}`)
+    if (booking.date) draw(`Date: ${new Date(booking.date).toLocaleString()}`)
+    else if (booking.preferredDate) draw(`Preferred: ${new Date(booking.preferredDate).toLocaleDateString()}`)
+    draw(`Status: ${booking.status}`)
+    draw(`Paid: ${booking.paid ? 'Yes' : 'No'}`)
+
+    const bytes = await pdf.save()
+    return new NextResponse(bytes, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename=invoice-${booking.id}.pdf`,
+      },
+    })
+  } catch (err: any) {
+    console.error('invoice error', err)
+    return NextResponse.json({ error: 'failed' }, { status: 500 })
+  }
+}

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
   if (status) where.status = status;
 
   try {
-    const bookings = await prisma.booking.findMany({
+    const bookingsData = await prisma.booking.findMany({
       where,
       include: {
         service: { select: { id: true, name: true, duration: true } },
@@ -24,9 +24,15 @@ export async function GET(request: Request) {
         branch:  { select: { id: true, name: true } },
         user:    { select: { id: true, name: true } },
       },
-      orderBy: { date: 'asc' }
-    });
-    return NextResponse.json({ success: true, bookings });
+      orderBy: { date: 'asc' },
+    })
+
+    const bookings = bookingsData.map(b => ({
+      ...b,
+      invoiceUrl: `/api/bookings/${b.id}/invoice`,
+    }))
+
+    return NextResponse.json({ success: true, bookings })
   } catch (err: any) {
     console.error('GET /api/bookings error', err);
     return NextResponse.json(

--- a/src/app/api/branch/data/route.ts
+++ b/src/app/api/branch/data/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const id = searchParams.get('id')
+  if (!id) {
+    return NextResponse.json({ success: false, error: 'id required' }, { status: 400 })
+  }
+  try {
+    const staff = await prisma.user.findMany({
+      where: { role: 'staff', branchId: id },
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+    })
+    const serviceIds = (
+      await prisma.branchService.findMany({
+        where: { branchId: id },
+        select: { serviceId: true },
+      })
+    ).map((b) => b.serviceId)
+
+    const services = await prisma.service.findMany({
+      where: { id: { in: serviceIds }, active: true },
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+    })
+
+    return NextResponse.json({ success: true, services, staff })
+  } catch (err: any) {
+    console.error('branch data error', err)
+    return NextResponse.json(
+      { success: false, error: err.message || 'failed' },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- allow admin to create new appointment
- expose invoice download endpoint and link it in booking API
- display invoice and paid status in appointment table

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687cefe798f483258f78d6fa89fb8a2c