### PR TITLE
Fix Prisma service field names

### DIFF
--- a/src/app/api/bookings/[id]/invoice/route.ts
+++ b/src/app/api/bookings/[id]/invoice/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     const booking = await prisma.booking.findUnique({
       where: { id: params.id },
       include: {
-        service: { select: { name: true } },
+        service: { select: { mainServiceName: true } },
         branch: { select: { name: true } },
         staff: { select: { name: true } },
         user: { select: { name: true } },
@@ -28,7 +28,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     draw('Greens Salon Invoice', 16)
     draw(`Booking ID: ${booking.id}`)
     draw(`Customer: ${booking.user?.name || 'N/A'}`)
-    draw(`Service: ${booking.service.name}`)
+    draw(`Service: ${booking.service.mainServiceName}`)
     if (booking.staff) draw(`Staff: ${booking.staff.name}`)
     draw(`Branch: ${booking.branch.name}`)
     if (booking.date) draw(`Date: ${new Date(booking.date).toLocaleString()}`)

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: Request) {
     const bookingsData = await prisma.booking.findMany({
       where,
       include: {
-        service: { select: { id: true, name: true, duration: true } },
+        service: { select: { id: true, mainServiceName: true, duration: true } },
         staff:   { select: { id: true, name: true } },
         branch:  { select: { id: true, name: true } },
         user:    { select: { id: true, name: true } },
@@ -29,6 +29,11 @@ export async function GET(request: Request) {
 
     const bookings = bookingsData.map(b => ({
       ...b,
+      service: {
+        id: b.service.id,
+        duration: b.service.duration,
+        name: b.service.mainServiceName,
+      },
       invoiceUrl: `/api/bookings/${b.id}/invoice`,
     }))
 

--- a/src/app/api/customer/my-bookings/route.ts
+++ b/src/app/api/customer/my-bookings/route.ts
@@ -20,16 +20,21 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ success: false, error: 'User not found' }, { status: 404 });
     }
 
-    const bookings = await prisma.booking.findMany({
+    const bookingsData = await prisma.booking.findMany({
       where: { userId: user.id },
       orderBy: { date: 'desc' },
       include: {
-        service: { select: { name: true } },
+        service: { select: { mainServiceName: true } },
         branch: { select: { name: true } },
         staff: { select: { name: true } },
         coupon: { select: { code: true } },
       },
     });
+
+    const bookings = bookingsData.map(b => ({
+      ...b,
+      service: { name: b.service.mainServiceName },
+    }));
 
     return NextResponse.json({ success: true, bookings });
   } catch (error) {


### PR DESCRIPTION
## Summary
- fix service selection in booking API routes
- rename service output field to match new schema

## Testing
- `npm run lint` *(fails: fs defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687d1599856c8325af154a4188596759