### PR TITLE
Implement walk‑in booking admin page

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,8 @@ model User {
   createdAt   DateTime  @default(now()) @db.Timestamp(3)
   updatedAt   DateTime  @default(now()) @updatedAt @db.Timestamp(3)
 
+  walkinBookings WalkinBooking[]
+
   
 }
 
@@ -152,4 +154,20 @@ model ServiceTierPriceHistory {
   changedAt   DateTime    @default(now()) @map("changed_at") @db.Timestamp(3)
 
   @@map("servicetierpricehistory")
+}
+
+model WalkinBooking {
+  id            String   @id @default(uuid()) @db.VarChar(191)
+  customerName  String   @db.VarChar(191)
+  customerPhone String   @db.VarChar(191)
+  services      String   @db.Text
+  totalAmount   Float
+  startTime     DateTime @db.Timestamp(3)
+  duration      Int
+  staffId       String?  @db.VarChar(191)
+  staff         User?    @relation(fields: [staffId], references: [id])
+  createdAt     DateTime @default(now()) @db.Timestamp(3)
+  updatedAt     DateTime @default(now()) @updatedAt @db.Timestamp(3)
+
+  @@map("walkin_booking")
 }

--- a/src/app/admin/walk-in/page.tsx
+++ b/src/app/admin/walk-in/page.tsx
@@ -1,0 +1,152 @@
+'use client'
+import { useEffect, useState, FormEvent } from 'react'
+
+interface Tier {
+  id: string
+  tierName: string
+  serviceName: string
+  categoryName: string
+  duration?: number | null
+  price?: number | null
+}
+
+interface Staff { id: string; name: string }
+
+interface Booking {
+  id: string
+  customerName: string
+  customerPhone: string
+  startTime: string
+  duration: number
+  services: string
+  totalAmount: number
+  staffId?: string | null
+  staff?: Staff | null
+}
+
+const COLORS = ['bg-red-300','bg-blue-300','bg-green-300','bg-yellow-300','bg-purple-300','bg-pink-300']
+
+export default function WalkInAdmin() {
+  const [tiers, setTiers] = useState<Tier[]>([])
+  const [staff, setStaff] = useState<Staff[]>([])
+  const [bookings, setBookings] = useState<Booking[]>([])
+  const [date, setDate] = useState<string>(new Date().toISOString().split('T')[0])
+
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [selected, setSelected] = useState<string[]>([])
+  const [time, setTime] = useState('09:00')
+  const [assign, setAssign] = useState('')
+
+  const loadTiers = async () => {
+    const res = await fetch('/api/admin/service-tiers/all')
+    const data = await res.json()
+    setTiers(data)
+  }
+  const loadStaff = async () => {
+    const res = await fetch('/api/staff')
+    const { staff } = await res.json()
+    setStaff(staff)
+  }
+  const loadBookings = async () => {
+    const res = await fetch(`/api/walkin-bookings?date=${date}`)
+    const data = await res.json()
+    setBookings(data)
+  }
+
+  useEffect(() => { loadTiers(); loadStaff(); }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { loadBookings() }, [date])
+
+  const tiersSelected = tiers.filter(t => selected.includes(t.id))
+  const amount = tiersSelected.reduce((s,t)=> s + (t.price || 0),0)
+  const duration = tiersSelected.reduce((s,t)=> s + (t.duration || 0),0)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    const body = {
+      customerName: name,
+      customerPhone: phone,
+      services: tiersSelected,
+      startTime: `${date}T${time}:00`,
+      staffId: assign || null
+    }
+    await fetch('/api/walkin-bookings',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(body)
+    })
+    setName(''); setPhone(''); setSelected([]); setTime('09:00'); setAssign('');
+    loadBookings()
+  }
+
+  const startOfDay = new Date(`${date}T09:00:00`)
+  const slots = Array.from({length:48},(_,i)=>{
+    const d = new Date(startOfDay.getTime()+i*15*60000)
+    return d.toTimeString().slice(0,5)
+  })
+  const colorMap = (id:string)=> COLORS[id.split('-')[0].charCodeAt(0)%COLORS.length]
+
+  const bookingsFor = (sid:string|null,slot:number)=>
+    bookings.filter(b=> (sid?b.staffId===sid:!b.staffId) &&
+      slot>=Math.floor((new Date(b.startTime).getTime()-startOfDay.getTime())/900000) &&
+      slot<Math.floor((new Date(b.startTime).getTime()-startOfDay.getTime())/900000)+Math.ceil(b.duration/15))
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold text-green-700">Walk-in Bookings</h1>
+      <form onSubmit={handleSubmit} className="bg-white p-4 rounded shadow space-y-4">
+        <div className="flex gap-4 flex-wrap">
+          <input type="date" value={date} onChange={e=>setDate(e.target.value)} className="border p-2 rounded" />
+          <input value={name} onChange={e=>setName(e.target.value)} placeholder="Customer Name" className="border p-2 rounded" required />
+          <input value={phone} onChange={e=>setPhone(e.target.value)} placeholder="Phone" className="border p-2 rounded" required />
+          <select multiple value={selected} onChange={e=> setSelected(Array.from(e.target.selectedOptions).map(o=>o.value))} className="border p-2 rounded flex-1 min-w-48" size={4}>
+            {tiers.map(t=> <option key={t.id} value={t.id}>{t.categoryName} - {t.serviceName} - {t.tierName}</option>)}
+          </select>
+          <input type="time" step="900" min="09:00" max="20:45" value={time} onChange={e=>setTime(e.target.value)} className="border p-2 rounded" />
+          <select value={assign} onChange={e=>setAssign(e.target.value)} className="border p-2 rounded">
+            <option value="">Unassigned</option>
+            {staff.map(s=> <option key={s.id} value={s.id}>{s.name}</option>)}
+          </select>
+          <div className="flex items-center font-semibold">Amount: ₹{amount} | Duration: {duration}m</div>
+        </div>
+        <button className="bg-green-600 text-white px-4 py-2 rounded" type="submit">Add Booking</button>
+      </form>
+
+      <div className="overflow-auto">
+        <table className="text-sm border-collapse">
+          <thead>
+            <tr>
+              <th className="border px-2">Time</th>
+              <th className="border px-2">Unassigned</th>
+              {staff.map(s=> <th key={s.id} className="border px-2">{s.name}</th>)}
+            </tr>
+          </thead>
+          <tbody>
+            {slots.map((t,i)=>(
+              <tr key={t}>
+                <td className="border px-2 whitespace-nowrap">{t}</td>
+                <td className="border h-6 w-32">
+                  <div className="flex gap-0.5 h-full">
+                    {bookingsFor(null,i).map(b=> (
+                      <div key={b.id} className={`flex-1 ${colorMap(b.id)}`} title={`${b.customerName} ₹${b.totalAmount}`}></div>
+                    ))}
+                  </div>
+                </td>
+                {staff.map(s=> (
+                  <td key={s.id} className="border h-6 w-32">
+                    <div className="flex gap-0.5 h-full">
+                      {bookingsFor(s.id,i).map(b=> (
+                        <div key={b.id} className={`flex-1 ${colorMap(b.id)}`} title={`${b.customerName} ₹${b.totalAmount}`}></div>
+                      ))}
+                    </div>
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/walkin-bookings/[id]/route.ts
+++ b/src/app/api/walkin-bookings/[id]/route.ts
@@ -1,0 +1,13 @@
+import { prisma } from '@/lib/prisma';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const { id } = params;
+  const data = await req.json();
+  const booking = await prisma.walkinBooking.update({
+    where: { id },
+    data: { staffId: data.staffId || null },
+    include: { staff: { select: { id: true, name: true } } },
+  });
+  return NextResponse.json(booking);
+}

--- a/src/app/api/walkin-bookings/route.ts
+++ b/src/app/api/walkin-bookings/route.ts
@@ -1,0 +1,37 @@
+import { prisma } from '@/lib/prisma';
+import { NextRequest, NextResponse } from 'next/server';
+import { startOfDay, endOfDay } from 'date-fns';
+
+export async function GET(req: NextRequest) {
+  const dateStr = new URL(req.url).searchParams.get('date');
+  if (!dateStr) return NextResponse.json([]);
+  const date = new Date(dateStr);
+  const bookings = await prisma.walkinBooking.findMany({
+    where: {
+      startTime: { gte: startOfDay(date), lt: endOfDay(date) },
+    },
+    include: { staff: { select: { id: true, name: true } } },
+    orderBy: { startTime: 'asc' },
+  });
+  return NextResponse.json(bookings);
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  const services = data.services || [];
+  const duration = services.reduce((t: number, s: any) => t + (s.duration || 0), 0);
+  const totalAmount = services.reduce((t: number, s: any) => t + (s.price || 0), 0);
+  const booking = await prisma.walkinBooking.create({
+    data: {
+      customerName: data.customerName,
+      customerPhone: data.customerPhone,
+      services: JSON.stringify(services),
+      totalAmount,
+      startTime: new Date(data.startTime),
+      duration,
+      staffId: data.staffId || null,
+    },
+    include: { staff: { select: { id: true, name: true } } },
+  });
+  return NextResponse.json(booking);
+}


### PR DESCRIPTION
## Summary
- add WalkinBooking model
- expose API endpoints to create and fetch walk‑in bookings
- extend service tier API to return price and duration
- implement admin UI to create bookings and visualize daily schedule

## Testing
- `npm run lint` *(fails: several lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_687dc939f77c8325ad1bdc9fcc783cb8