### PR TITLE
Add admin walk-in booking feature

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -13,6 +13,7 @@ import {
   MdDesignServices,
   MdHistory,
   MdLogout,
+  MdEvent,
   MdMenu,
 } from 'react-icons/md'
 import type { IconType } from 'react-icons'
@@ -37,6 +38,7 @@ const sections: {
       },
       { href: '/admin/services', label: 'Services', icon: MdDesignServices },
       { href: '/admin/tier-price-history', label: 'Tier Price History', icon: MdHistory },
+      { href: '/admin/walk-in', label: 'Walk-in', icon: MdEvent },
     ],
   },
 ]

--- a/src/app/admin/walk-in/page.tsx
+++ b/src/app/admin/walk-in/page.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { format } from 'date-fns'
+
+interface Category {
+  id: string
+  name: string
+}
+
+interface Tier {
+  id: string
+  name: string
+  duration?: number | null
+  currentPrice?: { actualPrice: number; offerPrice?: number | null } | null
+}
+
+interface Service {
+  id: string
+  name: string
+  tiers: Tier[]
+}
+
+interface Staff {
+  id: string
+  name: string
+}
+interface StaffApi extends Staff { removed: boolean }
+
+interface Selected {
+  serviceId: string
+  tierId: string
+  name: string
+  duration: number
+  price: number
+}
+
+interface Booking {
+  id: string
+  customer: string
+  phone: string
+  services: Selected[]
+  staffId: string
+  start: string
+  color: string
+}
+
+const COLORS = ['#f87171','#60a5fa','#34d399','#fbbf24','#c084fc','#f472b6']
+
+export default function WalkIn() {
+  const [categories,setCategories] = useState<Category[]>([])
+  const [category,setCategory] = useState('')
+  const [services,setServices] = useState<Service[]>([])
+  const [selectedSvc,setSelectedSvc] = useState('')
+  const [tiers,setTiers] = useState<Tier[]>([])
+  const [selectedTier,setSelectedTier] = useState('')
+  const [items,setItems] = useState<Selected[]>([])
+
+  const [staff,setStaff] = useState<Staff[]>([])
+  const [staffId,setStaffId] = useState('')
+  const [customer,setCustomer] = useState('')
+  const [phone,setPhone] = useState('')
+  const [start,setStart] = useState('')
+
+  const [bookings,setBookings] = useState<Booking[]>([])
+
+  const loadCategories = async() => {
+    const res = await fetch('/api/admin/service-categories')
+    const data = await res.json()
+    setCategories(data)
+  }
+
+  const loadServices = async() => {
+    if(!category) return
+    const res = await fetch(`/api/admin/services-new/${category}`)
+    const data = await res.json()
+    setServices(data)
+  }
+
+  const loadStaff = async() => {
+    const res = await fetch('/api/staff')
+    const { staff: staffData } = await res.json()
+    setStaff((staffData as StaffApi[]).filter(s=>!s.removed))
+  }
+
+  useEffect(()=>{ loadCategories(); loadStaff();
+    const stored = localStorage.getItem('walkin-bookings')
+    if(stored) setBookings(JSON.parse(stored))
+  },[])
+  useEffect(()=>{ loadServices(); setSelectedSvc(''); setTiers([]); },[category])
+  useEffect(()=>{
+    if(!selectedSvc) return
+    const svc = services.find(s=>s.id===selectedSvc)
+    setTiers(svc?.tiers||[])
+  },[selectedSvc])
+  useEffect(()=>{ localStorage.setItem('walkin-bookings',JSON.stringify(bookings)) },[bookings])
+
+  const addItem = () => {
+    const tier = tiers.find(t=>t.id===selectedTier)
+    if(!tier) return
+    const price = tier.currentPrice?.offerPrice ?? tier.currentPrice?.actualPrice ?? 0
+    const duration = tier.duration || 0
+    setItems([...items,{ serviceId:selectedSvc,tierId:tier.id,name:`${services.find(s=>s.id===selectedSvc)?.name} - ${tier.name}`,duration,price }])
+    setSelectedTier('')
+  }
+
+  const totalDuration = items.reduce((acc,i)=>acc+i.duration,0)
+  const totalAmount = items.reduce((acc,i)=>acc+i.price,0)
+
+  const times = [] as string[]
+  const base = new Date(); base.setHours(9,0,0,0)
+  for(let i=0;i<48;i++){ times.push(format(new Date(base.getTime()+i*15*60000),'HH:mm')) }
+
+  const saveBooking = () => {
+    if(!customer||!phone||!items.length||!staffId||!start) return
+    const color = COLORS[bookings.length % COLORS.length]
+    setBookings([...bookings,{ id:crypto.randomUUID(), customer, phone, services:items, staffId, start, color }])
+    setCustomer(''); setPhone(''); setItems([]); setStaffId(''); setStart('')
+  }
+
+  const bookingsFor = (id:string, time:string) => bookings.filter(b=>b.staffId===id && b.start===time)
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-green-700 mb-4">Walk-in Booking</h1>
+      <div className="grid md:grid-cols-2 gap-4 bg-white p-4 rounded shadow">
+        <div className="space-y-2">
+          <input value={customer} onChange={e=>setCustomer(e.target.value)} placeholder="Customer name" className="w-full p-2 border rounded"/>
+          <input value={phone} onChange={e=>setPhone(e.target.value)} placeholder="Phone" className="w-full p-2 border rounded"/>
+          <select value={category} onChange={e=>setCategory(e.target.value)} className="w-full p-2 border rounded">
+            <option value=''>Select category</option>
+            {categories.map(c=>(<option key={c.id} value={c.id}>{c.name}</option>))}
+          </select>
+          {services.length>0 && (
+            <select value={selectedSvc} onChange={e=>setSelectedSvc(e.target.value)} className="w-full p-2 border rounded">
+              <option value=''>Select service</option>
+              {services.map(s=>(<option key={s.id} value={s.id}>{s.name}</option>))}
+            </select>
+          )}
+          {tiers.length>0 && (
+            <div className="flex gap-2">
+              <select value={selectedTier} onChange={e=>setSelectedTier(e.target.value)} className="flex-1 p-2 border rounded">
+                <option value=''>Select tier</option>
+                {tiers.map(t=> (
+                  <option key={t.id} value={t.id}>{t.name}</option>
+                ))}
+              </select>
+              <button onClick={addItem} className="bg-green-600 text-white px-3 rounded">Add</button>
+            </div>
+          )}
+          {items.length>0 && (
+            <ul className="space-y-1 text-sm">
+              {items.map(i=> (
+                <li key={i.tierId} className="flex justify-between"><span>{i.name}</span><span>{i.duration}m ₹{i.price}</span></li>
+              ))}
+            </ul>
+          )}
+          {items.length>0 && (
+            <div className="text-sm font-medium">Total: {totalDuration}m ₹{totalAmount}</div>
+          )}
+        </div>
+        <div className="space-y-2">
+          <select value={staffId} onChange={e=>setStaffId(e.target.value)} className="w-full p-2 border rounded">
+            <option value=''>Select staff</option>
+            {staff.map(s=>(<option key={s.id} value={s.id}>{s.name}</option>))}
+          </select>
+          <select value={start} onChange={e=>setStart(e.target.value)} className="w-full p-2 border rounded">
+            <option value=''>Select time</option>
+            {times.map(t=> (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          <button onClick={saveBooking} className="bg-green-700 text-white px-4 py-2 rounded">Confirm Booking</button>
+        </div>
+      </div>
+
+      <div className="overflow-auto">
+        <table className="table-fixed border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="w-20">Time</th>
+              {staff.map(s=>(<th key={s.id} className="w-40 text-left">{s.name}</th>))}
+            </tr>
+          </thead>
+          <tbody>
+            {times.map(time=> (
+              <tr key={time}>
+                <td className="border px-1 whitespace-nowrap">{time}</td>
+                {staff.map(st=> (
+                  <td key={st.id+time} className="border h-8 relative">
+                    {bookingsFor(st.id,time).map(b=>(
+                      <div key={b.id} className="absolute inset-0 text-white flex items-center justify-center text-xs" style={{background:b.color}} title={`${b.customer} - ₹${b.services.reduce((a,i)=>a+i.price,0)}`}></div>
+                    ))}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add navigation link for Walk-in bookings in admin layout
- create new admin page to manage walk-in customers and slot schedule

## Testing
- `npm run lint` *(fails: next not found before install)*
- `npm install`
- `npm run lint` *(fails with many repo lint errors)*
- `npx eslint src/app/admin/walk-in/page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_687dc939f77c8325ad1bdc9fcc783cb8