### PR TITLE
Add backend booking support

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,8 @@ model User {
   createdAt   DateTime  @default(now()) @db.Timestamp(3)
   updatedAt   DateTime  @default(now()) @updatedAt @db.Timestamp(3)
 
-  
+  bookings    Booking[]
+
 }
 
 model Branch {
@@ -152,4 +153,28 @@ model ServiceTierPriceHistory {
   changedAt   DateTime    @default(now()) @map("changed_at") @db.Timestamp(3)
 
   @@map("servicetierpricehistory")
+}
+
+model Booking {
+  id        String   @id @default(uuid())
+  customer  String   @db.VarChar(191)
+  phone     String   @db.VarChar(191)
+  staffId   String   @db.VarChar(191)
+  staff     User     @relation(fields: [staffId], references: [id])
+  date      String   @db.VarChar(10)
+  start     String   @db.VarChar(5)
+  color     String   @db.VarChar(191)
+  createdAt DateTime @default(now()) @db.Timestamp(3)
+  items     BookingItem[]
+}
+
+model BookingItem {
+  id        String  @id @default(uuid())
+  bookingId String  @db.VarChar(191)
+  booking   Booking @relation(fields: [bookingId], references: [id])
+  serviceId String  @db.VarChar(191)
+  tierId    String  @db.VarChar(191)
+  name      String  @db.VarChar(191)
+  duration  Int
+  price     Float
 }

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const date = searchParams.get('date')
+  const where: { date?: string } = {}
+  if (date) where.date = date
+  const bookings = await prisma.booking.findMany({
+    where,
+    include: { items: true },
+    orderBy: { start: 'asc' }
+  })
+  return NextResponse.json(bookings)
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const booking = await prisma.booking.create({
+    data: {
+      customer: data.customer,
+      phone: data.phone,
+      staffId: data.staffId,
+      date: data.date,
+      start: data.start,
+      color: data.color,
+      items: {
+        create: (data.items as {
+          serviceId: string
+          tierId: string
+          name: string
+          duration: number
+          price: number
+        }[] | undefined)?.map((i) => ({
+          serviceId: i.serviceId,
+          tierId: i.tierId,
+          name: i.name,
+          duration: i.duration,
+          price: i.price
+        })) || []
+      }
+    },
+    include: { items: true }
+  })
+  return NextResponse.json(booking)
+}


### PR DESCRIPTION
## Summary
- add Prisma models for booking storage
- create API route for saving and retrieving bookings
- hook walk-in UI to fetch from API and save bookings
- confirm total amount before saving

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687de17d183483259dc3a783553138f6