### PR TITLE
Fix dynamic API route params for walk-in page

### DIFF
--- a/src/app/api/admin/service-images/[serviceId]/route.ts
+++ b/src/app/api/admin/service-images/[serviceId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
 export async function GET(req: Request, { params }: { params: { serviceId: string } }) {
-  const { serviceId } = params
+  const { serviceId } = await params
   const images = await prisma.serviceImage.findMany({
     where: { serviceId },
     orderBy: { id: 'asc' },
@@ -11,7 +11,7 @@ export async function GET(req: Request, { params }: { params: { serviceId: strin
 }
 
 export async function POST(req: Request, { params }: { params: { serviceId: string } }) {
-  const { serviceId } = params
+  const { serviceId } = await params
   const data = await req.json()
   const image = await prisma.serviceImage.create({
     data: {
@@ -45,7 +45,7 @@ export async function POST(req: Request, { params }: { params: { serviceId: stri
 }
 
 export async function PUT(req: Request, { params }: { params: { serviceId: string } }) {
-  const { serviceId } = params
+  const { serviceId } = await params
   const data = await req.json()
   const image = await prisma.serviceImage.update({
     where: { id: data.id },
@@ -58,7 +58,7 @@ export async function PUT(req: Request, { params }: { params: { serviceId: strin
 }
 
 export async function DELETE(req: Request, { params }: { params: { serviceId: string } }) {
-  const { serviceId } = params
+  const { serviceId } = await params
   const { id } = await req.json()
   await prisma.serviceImage.delete({ where: { id } })
   return NextResponse.json({ success: true })

--- a/src/app/api/admin/service-new/[id]/route.ts
+++ b/src/app/api/admin/service-new/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
 export async function PUT(req: Request, { params }: { params: { id: string } }) {
-  const { id } = params
+  const { id } = await params
   const data = await req.json()
   const service = await prisma.serviceNew.update({
     where: { id },
@@ -17,7 +17,7 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
-  const { id } = params
+  const { id } = await params
   await prisma.serviceTier.deleteMany({ where: { serviceId: id } })
   await prisma.serviceNew.delete({ where: { id } })
   return NextResponse.json({ success: true })

--- a/src/app/api/admin/service-tiers/[serviceId]/route.ts
+++ b/src/app/api/admin/service-tiers/[serviceId]/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server'
 const prisma = new PrismaClient()
 
 export async function GET(req: Request, { params }: { params: { serviceId: string } }) {
-  const { serviceId } = params
+  const { serviceId } = await params
   const tiers = await prisma.serviceTier.findMany({
     where: { serviceId },
     include: { priceHistory: true },

--- a/src/app/api/admin/services-new/[categoryId]/route.ts
+++ b/src/app/api/admin/services-new/[categoryId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
 export async function GET(req: Request, { params }: { params: { categoryId: string } }) {
-  const { categoryId } = params
+  const { categoryId } = await params
   const services = await prisma.serviceNew.findMany({
     where: { categoryId },
     include: { tiers: true },
@@ -12,7 +12,7 @@ export async function GET(req: Request, { params }: { params: { categoryId: stri
 }
 
 export async function POST(req: Request, { params }: { params: { categoryId: string } }) {
-  const { categoryId } = params
+  const { categoryId } = await params
   const data = await req.json()
   const service = await prisma.serviceNew.create({
     data: {

--- a/src/app/api/admin/tier-price-history/[tierId]/route.ts
+++ b/src/app/api/admin/tier-price-history/[tierId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
 export async function GET(req: Request, { params }: { params: { tierId: string } }) {
-  const { tierId } = params
+  const { tierId } = await params
   const entries = await prisma.serviceTierPriceHistory.findMany({
     where: { tierId },
     orderBy: { startDate: 'desc' },
@@ -11,7 +11,7 @@ export async function GET(req: Request, { params }: { params: { tierId: string }
 }
 
 export async function POST(req: Request, { params }: { params: { tierId: string } }) {
-  const { tierId } = params
+  const { tierId } = await params
   const data = await req.json()
   const entry = await prisma.serviceTierPriceHistory.create({
     data: {

--- a/src/app/api/branch/[id]/data/route.ts
+++ b/src/app/api/branch/[id]/data/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
-  const branchId = params.id;
+  const branchId = (await params).id;
   try {
     const staff = await prisma.user.findMany({
       where: { role: 'staff', branchId },

--- a/src/app/api/v2/services/[id]/route.ts
+++ b/src/app/api/v2/services/[id]/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server'
 const prisma = new PrismaClient()
 
 export async function GET(req, { params }: { params: { id: string } }) {
-  const { id } = params
+  const { id } = await params
   try {
     let service = await prisma.serviceNew.findUnique({
       where: { id },


### PR DESCRIPTION
## Summary
- await dynamic API route params so they work under Next.js 15

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687deb492ff48325b9b530771195e94c