### PR TITLE
Improve walk‑in booking

### DIFF
--- a/pages/api/bookings.ts
+++ b/pages/api/bookings.ts
@@ -15,28 +15,34 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
   if (req.method === 'POST') {
     const data = req.body
+    const firstItem = data.items?.[0]
     const booking = await prisma.booking.create({
       data: {
         customer: data.customer,
         phone: data.phone,
-        staffId: data.staffId,
+        staffId: firstItem?.staffId || data.staffId,
         date: data.date,
-        start: data.start,
+        start: firstItem?.start || data.start,
         color: data.color,
         items: {
-          create: (data.items as {
-            serviceId: string
-            tierId: string
-            name: string
-            duration: number
-            price: number
-          }[] | undefined)?.map((i) => ({
-            serviceId: i.serviceId,
-            tierId: i.tierId,
-            name: i.name,
-            duration: i.duration,
-            price: i.price,
-          })) || [],
+          create:
+            (data.items as {
+              serviceId: string
+              tierId: string
+              name: string
+              duration: number
+              price: number
+              staffId: string
+              start: string
+            }[] | undefined)?.map((i) => ({
+              serviceId: i.serviceId,
+              tierId: i.tierId,
+              name: i.name,
+              duration: i.duration,
+              price: i.price,
+              staffId: i.staffId,
+              start: i.start,
+            })) || [],
         },
       },
       include: { items: true },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,4 +177,6 @@ model BookingItem {
   name      String  @db.VarChar(191)
   duration  Int
   price     Float
+  staffId   String  @db.VarChar(191)
+  start     String  @db.VarChar(5)
 }


### PR DESCRIPTION
## Summary
- support staff and start time per booking item
- filter services to only show ones with active tiers
- track staff/time for items and highlight occupied slots
- allow booking only on or after today
- persist staff/time info in BookingItem

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e210e5c488325aed2578eb6aa9a8f