### PR TITLE
Improve walk‑in booking

### DIFF
--- a/pages/api/bookings.ts
+++ b/pages/api/bookings.ts
@@ -15,34 +15,55 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
   if (req.method === 'POST') {
     const data = req.body
+    const firstItem = data.items?.[0]
     const booking = await prisma.booking.create({
       data: {
         customer: data.customer,
         phone: data.phone,
-        staffId: data.staffId,
+        staffId: firstItem?.staffId || data.staffId,
         date: data.date,
-        start: data.start,
+        start: firstItem?.start || data.start,
         color: data.color,
         items: {
-          create: (data.items as {
-            serviceId: string
-            tierId: string
-            name: string
-            duration: number
-            price: number
-          }[] | undefined)?.map((i) => ({
-            serviceId: i.serviceId,
-            tierId: i.tierId,
-            name: i.name,
-            duration: i.duration,
-            price: i.price,
-          })) || [],
+          create:
+            (data.items as {
+              serviceId: string
+              tierId: string
+              name: string
+              duration: number
+              price: number
+              staffId: string
+              start: string
+            }[] | undefined)?.map((i) => ({
+              serviceId: i.serviceId,
+              tierId: i.tierId,
+              name: i.name,
+              duration: i.duration,
+              price: i.price,
+              staffId: i.staffId,
+              start: i.start,
+            })) || [],
         },
       },
       include: { items: true },
     })
     return res.status(200).json(booking)
   }
-  res.setHeader('Allow', ['GET', 'POST'])
+  if (req.method === 'PUT') {
+    const { id, staffId, start } = req.body
+    const booking = await prisma.booking.update({
+      where: { id },
+      data: { staffId, start },
+      include: { items: true },
+    })
+    return res.status(200).json(booking)
+  }
+  if (req.method === 'DELETE') {
+    const id = (req.query.id as string) || req.body.id
+    await prisma.bookingItem.deleteMany({ where: { bookingId: id } })
+    await prisma.booking.delete({ where: { id } })
+    return res.status(204).end()
+  }
+  res.setHeader('Allow', ['GET', 'POST', 'PUT', 'DELETE'])
   return res.status(405).end(`Method ${req.method} Not Allowed`)
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,4 +177,6 @@ model BookingItem {
   name      String  @db.VarChar(191)
   duration  Int
   price     Float
+  staffId   String  @db.VarChar(191)
+  start     String  @db.VarChar(5)
 }

--- a/src/app/admin/walk-in/page.tsx
+++ b/src/app/admin/walk-in/page.tsx
@@ -33,6 +33,8 @@ interface Selected {
   name: string
   duration: number
   price: number
+  staffId: string
+  start: string
 }
 
 interface Booking {
@@ -58,14 +60,15 @@ export default function WalkIn() {
   const [items,setItems] = useState<Selected[]>([])
 
   const [staff,setStaff] = useState<Staff[]>([])
-  const [staffId,setStaffId] = useState('')
   const [customer,setCustomer] = useState('')
   const [phone,setPhone] = useState('')
   const [date,setDate] = useState(() => format(new Date(),'yyyy-MM-dd'))
-  const [start,setStart] = useState('')
 
   const [bookings,setBookings] = useState<Booking[]>([])
   const [result,setResult] = useState<{success:boolean,message:string}|null>(null)
+  const [edit,setEdit] = useState<Booking|null>(null)
+  const [editStaffId,setEditStaffId] = useState('')
+  const [editStart,setEditStart] = useState('')
 
   const loadCategories = async() => {
     const res = await fetch('/api/admin/service-categories')
@@ -76,8 +79,16 @@ export default function WalkIn() {
   const loadServices = async() => {
     if(!category) return
     const res = await fetch(`/api/admin/services-new/${category}`)
-    const data = await res.json()
-    setServices(data)
+    const data: Service[] = await res.json()
+    const enriched: Service[] = []
+    for(const svc of data){
+      const tRes = await fetch(`/api/admin/service-tiers/${svc.id}`)
+      const tiers: Tier[] = await tRes.json()
+      if(tiers.some(t=>t.currentPrice)){
+        enriched.push({...svc, tiers})
+      }
+    }
+    setServices(enriched)
   }
 
   const loadStaff = async() => {
@@ -107,35 +118,78 @@ export default function WalkIn() {
     setTiers(svc?.tiers||[])
   },[selectedSvc])
   useEffect(()=>{ localStorage.setItem('walkin-bookings', JSON.stringify(bookings)) },[bookings])
+  useEffect(()=>{ if(edit){ setEditStaffId(edit.staffId); setEditStart(edit.start) } },[edit])
 
   const addItem = () => {
     const tier = tiers.find(t=>t.id===selectedTier)
     if(!tier) return
     const price = tier.currentPrice?.offerPrice ?? tier.currentPrice?.actualPrice ?? 0
     const duration = tier.duration || 0
-    setItems([...items,{ serviceId:selectedSvc,tierId:tier.id,name:`${services.find(s=>s.id===selectedSvc)?.name} - ${tier.name}`,duration,price }])
+    setItems([...items,{ serviceId:selectedSvc,tierId:tier.id,name:`${services.find(s=>s.id===selectedSvc)?.name} - ${tier.name}`,duration,price,staffId:'',start:'' }])
     setSelectedTier('')
   }
 
   const totalDuration = items.reduce((acc,i)=>acc+i.duration,0)
   const totalAmount = items.reduce((acc,i)=>acc+i.price,0)
 
-  const times = [] as string[]
+  const allTimes = [] as string[]
   const base = new Date(date)
   base.setHours(9,0,0,0)
   for(let i=0;i<48;i++) {
-    times.push(format(new Date(base.getTime()+i*15*60000),'HH:mm'))
+    allTimes.push(format(new Date(base.getTime()+i*15*60000),'HH:mm'))
+  }
+
+  const timeOptionsFor = (duration:number) => {
+    const slots:string[] = []
+    const startBase = new Date(date)
+    startBase.setHours(9,0,0,0)
+    const endBase = new Date(date)
+    endBase.setHours(21,0,0,0)
+    const todayStr = format(new Date(),'yyyy-MM-dd')
+    const now = new Date()
+    for(let t=new Date(startBase); t.getTime()+duration*60000<=endBase.getTime(); t=new Date(t.getTime()+15*60000)) {
+      if(date===todayStr && t<now) continue
+      slots.push(format(t,'HH:mm'))
+    }
+    return slots
+  }
+
+  const toMin = (s:string) => {
+    const [h,m] = s.split(':').map(Number)
+    return h*60+m
+  }
+
+  const hasConflict = (staffId:string,start:string,duration:number,idx:number) => {
+    if(!staffId) return false
+    const st = toMin(start)
+    const en = st + duration
+    for(const b of bookings) {
+      if(b.staffId!==staffId || b.date!==date) continue
+      const bst = toMin(b.start)
+      const ben = bst + b.items.reduce((a,i)=>a+i.duration,0)
+      if(st < ben && en > bst) return true
+    }
+    for(let i=0;i<items.length;i++) {
+      if(i===idx) continue
+      const it = items[i]
+      if(it.staffId!==staffId || !it.start) continue
+      const ist = toMin(it.start)
+      const ien = ist + it.duration
+      if(st < ien && en > ist) return true
+    }
+    return false
   }
 
   const saveBooking = async() => {
-    if(!customer||!phone||!items.length||!staffId||!start) return
+    if(!customer||!phone||!items.length) return
+    if(items.some(i=>!i.staffId || !i.start)) return
     if(!window.confirm(`Total amount ₹${totalAmount}. Confirm booking?`)) return
     const color = COLORS[bookings.length % COLORS.length]
     try {
       const res = await fetch('/api/bookings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ customer, phone, staffId, date, start, color, items })
+        body: JSON.stringify({ customer, phone, date, color, items })
       })
       if(res.ok) {
         const booking: Booking = await res.json()
@@ -152,7 +206,31 @@ export default function WalkIn() {
       setResult({success:false, message:'Failed to save booking'})
 
     } finally {
-      setCustomer(''); setPhone(''); setItems([]); setStaffId(''); setStart('')
+      setCustomer(''); setPhone(''); setItems([])
+    }
+  }
+
+  const updateBooking = async() => {
+    if(!edit) return
+    const res = await fetch('/api/bookings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: edit.id, staffId: editStaffId, start: editStart })
+    })
+    if(res.ok){
+      const updated = await res.json()
+      setBookings(bs=>bs.map(b=>b.id===updated.id?updated:b))
+      setEdit(null)
+    }
+  }
+
+  const cancelBooking = async() => {
+    if(!edit) return
+    if(!window.confirm('Cancel this booking?')) return
+    const res = await fetch(`/api/bookings?id=${edit.id}`, { method: 'DELETE' })
+    if(res.ok){
+      setBookings(bs=>bs.filter(b=>b.id!==edit.id))
+      setEdit(null)
     }
   }
 
@@ -163,52 +241,92 @@ export default function WalkIn() {
       <h1 className="text-2xl font-bold text-green-700 mb-4">Walk-in Booking</h1>
       <div className="grid md:grid-cols-2 gap-4 bg-white p-4 rounded shadow">
         <div className="space-y-2">
-          <input value={customer} onChange={e=>setCustomer(e.target.value)} placeholder="Customer name" className="w-full p-2 border rounded"/>
-          <input value={phone} onChange={e=>setPhone(e.target.value)} placeholder="Phone" className="w-full p-2 border rounded"/>
-          <select value={category} onChange={e=>setCategory(e.target.value)} className="w-full p-2 border rounded">
-            <option value=''>Select category</option>
-            {categories.map(c=>(<option key={c.id} value={c.id}>{c.name}</option>))}
-          </select>
-          {services.length>0 && (
-            <select value={selectedSvc} onChange={e=>setSelectedSvc(e.target.value)} className="w-full p-2 border rounded">
-              <option value=''>Select service</option>
-              {services.map(s=>(<option key={s.id} value={s.id}>{s.name}</option>))}
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Customer Name</label>
+            <input value={customer} onChange={e=>setCustomer(e.target.value)} className="w-full p-2 border rounded"/>
+            <p className="text-xs text-gray-500">Enter customer name</p>
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Phone</label>
+            <input value={phone} onChange={e=>setPhone(e.target.value)} className="w-full p-2 border rounded"/>
+            <p className="text-xs text-gray-500">Enter phone number</p>
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Category</label>
+            <select value={category} onChange={e=>setCategory(e.target.value)} className="w-full p-2 border rounded">
+              <option value=''>Select category</option>
+              {categories.map(c=>(<option key={c.id} value={c.id}>{c.name}</option>))}
             </select>
+            <p className="text-xs text-gray-500">Choose service category</p>
+          </div>
+          {services.length>0 && (
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Service</label>
+              <select value={selectedSvc} onChange={e=>setSelectedSvc(e.target.value)} className="w-full p-2 border rounded">
+                <option value=''>Select service</option>
+                {services.map(s=>(<option key={s.id} value={s.id}>{s.name}</option>))}
+              </select>
+              <p className="text-xs text-gray-500">Choose a service</p>
+            </div>
           )}
           {tiers.length>0 && (
-            <div className="flex gap-2">
-              <select value={selectedTier} onChange={e=>setSelectedTier(e.target.value)} className="flex-1 p-2 border rounded">
-                <option value=''>Select tier</option>
-                {tiers.map(t=> (
-                  <option key={t.id} value={t.id}>{t.name}</option>
-                ))}
-              </select>
-              <button onClick={addItem} className="bg-green-600 text-white px-3 rounded">Add</button>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Tier</label>
+              <div className="flex gap-2">
+                <select value={selectedTier} onChange={e=>setSelectedTier(e.target.value)} className="flex-1 p-2 border rounded">
+                  <option value=''>Select tier</option>
+                  {tiers.map(t=> (
+                    <option key={t.id} value={t.id}>{t.name}</option>
+                  ))}
+                </select>
+                <button onClick={addItem} className="bg-green-600 text-white px-3 rounded">Add</button>
+              </div>
+              <p className="text-xs text-gray-500">Select tier and add</p>
             </div>
           )}
           {items.length>0 && (
-            <ul className="space-y-1 text-sm">
-              {items.map(i=> (
-                <li key={i.tierId} className="flex justify-between"><span>{i.name}</span><span>{i.duration}m ₹{i.price}</span></li>
-              ))}
-            </ul>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Items</label>
+              <ul className="space-y-2 text-sm">
+                {items.map((i,idx)=> (
+                  <li key={i.tierId} className="grid grid-cols-6 gap-2 items-center">
+                    <span className="col-span-2 truncate" title={i.name}>{i.name}</span>
+                    <select
+                      value={i.staffId}
+                      onChange={e=>setItems(itms=>itms.map((it,j)=> j===idx?{...it,staffId:e.target.value,start:''}:it))}
+                      className="border rounded p-1"
+                    >
+                      <option value=''>Staff</option>
+                      {staff.map(s=>(<option key={s.id} value={s.id}>{s.name}</option>))}
+                    </select>
+                    <select
+                      value={i.start}
+                      onChange={e=>setItems(itms=>itms.map((it,j)=> j===idx?{...it,start:e.target.value}:it))}
+                      className="border rounded p-1"
+                    >
+                      <option value=''>Time</option>
+                      {timeOptionsFor(i.duration).map(t=> (
+                        <option key={t} value={t} style={{backgroundColor: i.staffId && hasConflict(i.staffId,t,i.duration,idx)?'#fef08a':undefined}}>{t}</option>
+                      ))}
+                    </select>
+                    <span>{i.duration}m ₹{i.price}</span>
+                    <button onClick={()=>setItems(itms=>itms.filter((_,j)=>j!==idx))} className="text-red-600">✕</button>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-xs text-gray-500">Assign staff and time for each service</p>
+            </div>
           )}
           {items.length>0 && (
             <div className="text-sm font-medium">Total: {totalDuration}m ₹{totalAmount}</div>
           )}
         </div>
         <div className="space-y-2">
-          <select value={staffId} onChange={e=>setStaffId(e.target.value)} className="w-full p-2 border rounded">
-            <option value=''>Select staff</option>
-            {staff.map(s=>(<option key={s.id} value={s.id}>{s.name}</option>))}
-          </select>
-          <input type="date" value={date} onChange={e=>setDate(e.target.value)} className="w-full p-2 border rounded" />
-          <select value={start} onChange={e=>setStart(e.target.value)} className="w-full p-2 border rounded">
-            <option value=''>Select time</option>
-            {times.map(t=> (
-              <option key={t} value={t}>{t}</option>
-            ))}
-          </select>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Date</label>
+            <input type="date" min={format(new Date(),'yyyy-MM-dd')} value={date} onChange={e=>setDate(e.target.value)} className="w-full p-2 border rounded" />
+            <p className="text-xs text-gray-500">Booking date</p>
+          </div>
           <button onClick={saveBooking} className="bg-green-700 text-white px-4 py-2 rounded">Confirm Booking</button>
         </div>
       </div>
@@ -222,7 +340,7 @@ export default function WalkIn() {
             </tr>
           </thead>
           <tbody>
-            {times.map(time=> (
+            {allTimes.map(time=> (
               <tr key={time}>
                 <td className="border px-1 whitespace-nowrap">{time}</td>
                 {staff.map(st=> (
@@ -230,14 +348,17 @@ export default function WalkIn() {
                     {bookingsFor(st.id,time).map((b,i,arr)=>(
                       <div
                         key={b.id}
-                        className="absolute inset-y-0 text-white flex items-center justify-center text-xs"
+                        className="absolute inset-y-0 text-white flex items-center justify-center text-[10px] cursor-pointer px-1"
                         style={{
                           background: b.color,
                           width: `${100/arr.length}%`,
                           left: `${(i*100)/arr.length}%`,
                         }}
                         title={`${b.customer} - ₹${b.items.reduce((a,i)=>a+i.price,0)}`}
-                      ></div>
+                        onClick={()=>setEdit(b)}
+                      >
+                        {b.items.map(it=>it.name).join(', ')}
+                      </div>
                     ))}
                   </td>
                 ))}
@@ -251,6 +372,32 @@ export default function WalkIn() {
           <div className="bg-white p-4 rounded shadow space-y-2">
             <p>{result.message}</p>
             <button onClick={() => setResult(null)} className="bg-green-700 text-white px-4 py-2 rounded">Close</button>
+          </div>
+        </div>
+      )}
+      {edit && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+          <div className="bg-white p-4 rounded shadow space-y-3 w-72">
+            <h2 className="font-medium">Booking Details</h2>
+            <p className="text-sm">Customer: {edit.customer}</p>
+            <p className="text-sm">Services: {edit.items.map(i=>i.name).join(', ')}</p>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Staff</label>
+              <select value={editStaffId} onChange={e=>setEditStaffId(e.target.value)} className="w-full p-2 border rounded">
+                {staff.map(s=>(<option key={s.id} value={s.id}>{s.name}</option>))}
+              </select>
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Time</label>
+              <select value={editStart} onChange={e=>setEditStart(e.target.value)} className="w-full p-2 border rounded">
+                {allTimes.map(t=>(<option key={t} value={t}>{t}</option>))}
+              </select>
+            </div>
+            <div className="flex gap-2 justify-end pt-2">
+              <button onClick={cancelBooking} className="text-red-600 px-3 py-1 border rounded">Cancel</button>
+              <button onClick={updateBooking} className="bg-green-700 text-white px-3 py-1 rounded">Save</button>
+              <button onClick={()=>setEdit(null)} className="px-3 py-1 border rounded">Close</button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- support staff and start time per booking item
- filter services to only show ones with active tiers
- track staff/time for items and highlight occupied slots
- allow booking only on or after today
- persist staff/time info in BookingItem
- add remove option per item with labels and helper text
- show service names in schedule and allow editing bookings
- enable PUT/DELETE in bookings API

## Testing
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e210e5c488325aed2578eb6aa9a8f