### PR TITLE
Increase service description capacity

### DIFF
--- a/prisma/migrations/20250721172300_service_new_description_longtext/README.md
+++ b/prisma/migrations/20250721172300_service_new_description_longtext/README.md
@@ -1,0 +1,1 @@
+Change ServiceNew.description to LONGTEXT for richer HTML content.

--- a/prisma/migrations/20250721172300_service_new_description_longtext/migration.sql
+++ b/prisma/migrations/20250721172300_service_new_description_longtext/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `ServiceNew`
+  MODIFY `description` LONGTEXT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,7 +125,7 @@ model ServiceNew {
   category    ServiceCategory @relation(fields: [categoryId], references: [id])
   name        String
   caption     String?
-  description String?
+  description String?  @db.LongText
   imageUrl    String?
   images      ServiceImage[]
   tiers       ServiceTier[]


### PR DESCRIPTION
## Summary
- support more HTML content in `ServiceNew.description`
- add migration for new `LONGTEXT` column type

## Testing
- `npm run lint` *(fails: various existing lint errors)*
- `npx prisma generate`

------
https://chatgpt.com/codex/tasks/task_e_687e76b77dd0832596deeeebd44c5836