### PR TITLE
Fix customizable Select options

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-export interface SelectProps {
+export interface SelectProps
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'value' | 'onChange'> {
   value: string
   onValueChange: (value: string) => void
   children: React.ReactNode
   className?: string
 }
 
-export const Select = ({ value, onValueChange, children, className }: SelectProps) => {
+export const Select = ({ value, onValueChange, children, className, ...props }: SelectProps) => {
   const placeholderRef = React.useRef<string>('')
-  const options: Array<{ value: string; label: React.ReactNode }> = []
+  const options: Array<{ value: string; label: React.ReactNode; props: React.OptionHTMLAttributes<HTMLOptionElement> }> = []
 
   React.Children.forEach(children, (child) => {
     if (!React.isValidElement(child)) return
@@ -24,7 +25,8 @@ export const Select = ({ value, onValueChange, children, className }: SelectProp
     if (child.type === SelectContent) {
       React.Children.forEach(child.props.children, (c) => {
         if (React.isValidElement(c) && c.type === SelectItem) {
-          options.push({ value: c.props.value, label: c.props.children })
+          const { value, children: lbl, ...rest } = c.props as SelectItemProps
+          options.push({ value, label: lbl, props: rest })
         }
       })
     }
@@ -35,6 +37,7 @@ export const Select = ({ value, onValueChange, children, className }: SelectProp
       className={cn('h-10 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500', className)}
       value={value}
       onChange={(e) => onValueChange(e.target.value)}
+      {...props}
     >
       {placeholderRef.current && (
         <option value="" disabled hidden>
@@ -42,7 +45,7 @@ export const Select = ({ value, onValueChange, children, className }: SelectProp
         </option>
       )}
       {options.map((o) => (
-        <option key={o.value} value={o.value}>
+        <option key={o.value} value={o.value} {...o.props}>
           {o.label}
         </option>
       ))}
@@ -53,7 +56,11 @@ export const Select = ({ value, onValueChange, children, className }: SelectProp
 export const SelectTrigger = ({ children }: { children: React.ReactNode }) => <>{children}</>
 export const SelectValue = ({ placeholder }: { placeholder?: string }) => null
 export const SelectContent = ({ children }: { children: React.ReactNode }) => <>{children}</>
-export const SelectItem = ({ value, children }: { value: string; children: React.ReactNode }) => (
-  <option value={value}>{children}</option>
+export interface SelectItemProps extends React.OptionHTMLAttributes<HTMLOptionElement> {
+  value: string
+  children: React.ReactNode
+}
+export const SelectItem = ({ value, children, ...props }: SelectItemProps) => (
+  <option value={value} {...props}>{children}</option>
 )
 


### PR DESCRIPTION
## Summary
- allow passing HTML props to `Select` and `SelectItem`
- forward props through to DOM `<select>` and `<option>` elements

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e832e44cc83259dde533256cdb0a4