### PR TITLE
fix loader timer handling

### DIFF
--- a/src/contexts/LoadingContext.tsx
+++ b/src/contexts/LoadingContext.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import React, { createContext, useContext, useEffect, useState, useRef, ReactNode } from 'react'
 
 interface LoadingValue {
   loading: boolean
@@ -15,8 +15,13 @@ export function LoadingProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(false)
   const [progress, setProgress] = useState(0)
   const [active, setActive] = useState(0)
+  const hideRef = useRef<NodeJS.Timeout | null>(null)
 
   const start = () => {
+    if (hideRef.current) {
+      clearTimeout(hideRef.current)
+      hideRef.current = null
+    }
     setActive(n => n + 1)
     if (!loading) {
       setProgress(0)
@@ -29,9 +34,10 @@ export function LoadingProvider({ children }: { children: React.ReactNode }) {
       const next = n - 1
       if (next <= 0) {
         setProgress(100)
-        setTimeout(() => {
+        hideRef.current = setTimeout(() => {
           setLoading(false)
           setProgress(0)
+          hideRef.current = null
         }, 300)
         return 0
       }


### PR DESCRIPTION
## Summary
- prevent pending loader hide timer in `LoadingContext`
- store hide timer handle with a ref to avoid flicker

## Testing
- `npm run lint` *(fails: fs defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687fb598d6f08325996ee50d9a0a0f1a