### PR TITLE
Fix tier history page load time

### DIFF
--- a/src/app/admin/tier-price-history/page.tsx
+++ b/src/app/admin/tier-price-history/page.tsx
@@ -19,20 +19,6 @@ interface Entry {
   endDate?: string | null
 }
 
-function getCurrentAndNext(entries: Entry[]) {
-  const now = new Date()
-  const sorted = [...entries].sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
-  let current: Entry | undefined
-  let upcoming: Entry | undefined
-  for (const e of sorted) {
-    const start = new Date(e.startDate)
-    const end = e.endDate ? new Date(e.endDate) : null
-    if (!current && start <= now && (!end || now < end)) current = e
-    if (!upcoming && start > now) upcoming = e
-  }
-  return { current, upcoming }
-}
-
 export default function TierPriceHistoryPage() {
   const empty: Partial<Entry> = { id: '', actualPrice: 0, startDate: '' }
   const [rows, setRows] = useState<TierRow[]>([])
@@ -45,16 +31,7 @@ export default function TierPriceHistoryPage() {
 
   const loadRows = async () => {
     const tiers = await fetch('/api/admin/service-tiers/all').then(r => r.json())
-    const histories = await Promise.all(
-      tiers.map((t: TierRow) =>
-        fetch(`/api/admin/tier-price-history/${t.id}`).then(r => r.json())
-      )
-    )
-    const enriched: TierRow[] = tiers.map((t: TierRow, i: number) => {
-      const { current, upcoming } = getCurrentAndNext(histories[i] as Entry[])
-      return { ...t, current, upcoming }
-    })
-    setRows(enriched)
+    setRows(tiers)
   }
 
   const open = async (tierId: string) => {

--- a/src/app/admin/tier-price-history/page.tsx
+++ b/src/app/admin/tier-price-history/page.tsx
@@ -45,12 +45,15 @@ export default function TierPriceHistoryPage() {
 
   const loadRows = async () => {
     const tiers = await fetch('/api/admin/service-tiers/all').then(r => r.json())
-    const enriched: TierRow[] = []
-    for (const t of tiers) {
-      const hist: Entry[] = await fetch(`/api/admin/tier-price-history/${t.id}`).then(r => r.json())
-      const { current, upcoming } = getCurrentAndNext(hist)
-      enriched.push({ ...t, current, upcoming })
-    }
+    const histories = await Promise.all(
+      tiers.map((t: TierRow) =>
+        fetch(`/api/admin/tier-price-history/${t.id}`).then(r => r.json())
+      )
+    )
+    const enriched: TierRow[] = tiers.map((t: TierRow, i: number) => {
+      const { current, upcoming } = getCurrentAndNext(histories[i] as Entry[])
+      return { ...t, current, upcoming }
+    })
     setRows(enriched)
   }
 

--- a/src/app/api/admin/service-tiers/all/route.ts
+++ b/src/app/api/admin/service-tiers/all/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
 export async function GET() {
+  const now = new Date()
   const tiers = await prisma.serviceTier.findMany({
     include: {
       service: {
@@ -10,16 +11,36 @@ export async function GET() {
           category: { select: { name: true } },
         },
       },
+      priceHistory: {
+        where: {
+          OR: [
+            {
+              startDate: { lte: now },
+              OR: [{ endDate: null }, { endDate: { gt: now } }],
+            },
+            { startDate: { gt: now } },
+          ],
+        },
+        orderBy: { startDate: 'asc' },
+      },
     },
     orderBy: { name: 'asc' },
   })
 
-  const response = tiers.map(t => ({
-    id: t.id,
-    tierName: t.name,
-    serviceName: t.service.name,
-    categoryName: t.service.category.name,
-  }))
+  const response = tiers.map(t => {
+    const current = t.priceHistory.find(
+      p => p.startDate <= now && (!p.endDate || p.endDate > now)
+    )
+    const upcoming = t.priceHistory.find(p => p.startDate > now)
+    return {
+      id: t.id,
+      tierName: t.name,
+      serviceName: t.service.name,
+      categoryName: t.service.category.name,
+      current,
+      upcoming,
+    }
+  })
 
   return NextResponse.json(response)
 }


### PR DESCRIPTION
## Summary
- parallelize history fetch calls

## Testing
- `npm run lint` *(fails: many lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_687fb942cc688325b4f2c11b5b94d9ce