### PR TITLE
Fix admin tier price history build

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export const Command = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col', className)} {...props} />
+)
+
+export const CommandInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+  <input className="mb-2 w-full border px-2 py-1" {...props} />
+)
+
+export const CommandList = ({ className, ...props }: React.HTMLAttributes<HTMLUListElement>) => (
+  <ul className={cn('max-h-60 overflow-auto', className)} {...props} />
+)
+
+export const CommandEmpty = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('p-2 text-sm text-gray-500', className)} {...props} />
+)
+
+export const CommandGroup = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('p-1', className)} {...props} />
+)
+
+export const CommandItem = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('cursor-pointer px-2 py-1 hover:bg-gray-100', className)} {...props} />
+)
+
+export const CommandSeparator = ({ className, ...props }: React.HTMLAttributes<HTMLHRElement>) => (
+  <hr className={cn('my-1', className)} {...props} />
+)

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface DialogProps extends React.HTMLAttributes<HTMLDivElement> {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+export function Dialog({ open, onOpenChange, children }: DialogProps) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => onOpenChange?.(false)}>
+      {children}
+    </div>
+  )
+}
+
+export const DialogContent = ({ className, onClick, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('bg-white rounded-lg shadow-lg w-full max-w-lg', className)}
+    onClick={(e) => {
+      e.stopPropagation()
+      onClick?.(e)
+    }}
+    {...props}
+  />
+)
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('border-b px-4 py-2', className)} {...props} />
+)
+
+export const DialogTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <h2 className={cn('text-lg font-semibold', className)} {...props} />
+)
+
+export const DialogDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+  <p className={cn('text-sm text-gray-500', className)} {...props} />
+)
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex justify-end gap-2 mt-4', className)} {...props} />
+)

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const PopoverContext = React.createContext<{open:boolean; setOpen:(o:boolean)=>void} | null>(null)
+
+export function Popover({children}: {children: React.ReactNode}) {
+  const [open, setOpen] = React.useState(false)
+  return <PopoverContext.Provider value={{open, setOpen}}>{children}</PopoverContext.Provider>
+}
+
+export function PopoverTrigger({className, children}: React.HTMLAttributes<HTMLButtonElement>) {
+  const ctx = React.useContext(PopoverContext)
+  if(!ctx) return null
+  return <button className={className} onClick={() => ctx.setOpen(!ctx.open)}>{children}</button>
+}
+
+interface ContentProps extends React.HTMLAttributes<HTMLDivElement> { align?: string }
+export function PopoverContent({className, children, ...props}: ContentProps) {
+  const ctx = React.useContext(PopoverContext)
+  if(!ctx?.open) return null
+  return (
+    <div className={cn('absolute z-50 mt-2 rounded border bg-white shadow p-2', className)} {...props}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(function Table({className, ...props}, ref) {
+  return <table ref={ref} className={cn('w-full text-sm', className)} {...props} />
+})
+
+export const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(function TableHeader({className, ...props}, ref) {
+  return <thead ref={ref} className={cn('bg-gray-50', className)} {...props} />
+})
+
+export const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(function TableBody({className, ...props}, ref) {
+  return <tbody ref={ref} className={cn('', className)} {...props} />
+})
+
+export const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(function TableRow({className, ...props}, ref) {
+  return <tr ref={ref} className={cn('border-b', className)} {...props} />
+})
+
+export const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(function TableHead({className, ...props}, ref) {
+  return <th ref={ref} className={cn('px-3 py-2 text-left font-semibold', className)} {...props} />
+})
+
+export const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(function TableCell({className, ...props}, ref) {
+  return <td ref={ref} className={cn('px-3 py-2', className)} {...props} />
+})
+
+export default Table

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const TooltipContext = React.createContext<boolean>(false)
+
+export const TooltipProvider: React.FC<{children: React.ReactNode}> = ({children}) => <>{children}</>
+
+export const Tooltip = ({children}: {children: React.ReactNode}) => (
+  <div className="relative inline-block group">
+    <TooltipContext.Provider value={true}>{children}</TooltipContext.Provider>
+  </div>
+)
+
+export const TooltipTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(function Trigger({className, ...props}, ref){
+  return <button ref={ref} className={className} {...props} />
+})
+
+export const TooltipContent = ({ className, children }: { className?: string; children: React.ReactNode }) => (
+  <span className={cn('absolute z-50 m-1 hidden min-w-max rounded bg-black px-2 py-1 text-xs text-white group-hover:block', className)}>
+    {children}
+  </span>
+)


### PR DESCRIPTION
## Summary
- add missing UI components (table, dialog, popover, command, tooltip)
- allow `admin/tier-price-history` page to build without module errors

## Testing
- `npm run build`
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fc3dd758883258d9c43121245c0cf