### PR TITLE
Rename tiers to variants

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -37,7 +37,7 @@ const sections: {
         icon: MdCategory,
       },
       { href: '/admin/services', label: 'Services', icon: MdDesignServices },
-      { href: '/admin/tier-price-history', label: 'Tier Price History', icon: MdHistory },
+      { href: '/admin/variant-price-history', label: 'Variant Price History', icon: MdHistory },
       { href: '/admin/walk-in', label: 'Walk-in', icon: MdEvent },
     ],
   },

--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -31,7 +31,7 @@ interface Category {
   name: string
 }
 
-interface Tier {
+interface Variant {
   id: string
   name: string
   duration?: number | null
@@ -50,7 +50,7 @@ interface Service {
   caption?: string | null
   description?: string | null
   imageUrl?: string | null
-  tiers: Tier[]
+  variants: Variant[]
 }
 
 export default function ServicesAdmin() {
@@ -73,12 +73,12 @@ export default function ServicesAdmin() {
     setServiceForm({ ...serviceForm, imageUrl: data.url })
   }
 
-  const emptyTier: Partial<Tier> = { id: "", name: "", duration: null }
-  const [tiers, setTiers] = useState<Tier[]>([])
-  const [tierForm, setTierForm] = useState<Partial<Tier>>({})
-  const [showTierModal, setShowTierModal] = useState(false)
-  const [editingTier, setEditingTier] = useState(false)
-  const [tierServiceId, setTierServiceId] = useState("")
+  const emptyVariant: Partial<Variant> = { id: "", name: "", duration: null }
+  const [variants, setVariants] = useState<Variant[]>([])
+  const [variantForm, setVariantForm] = useState<Partial<Variant>>({})
+  const [showVariantModal, setShowVariantModal] = useState(false)
+  const [editingVariant, setEditingVariant] = useState(false)
+  const [variantServiceId, setVariantServiceId] = useState("")
 
   const emptyImage: Partial<Image> = { id: "", imageUrl: "", caption: "" }
   const [images, setImages] = useState<Image[]>([])
@@ -161,62 +161,62 @@ export default function ServicesAdmin() {
     loadServices()
   }
 
-  const openTierManager = async (svc: Service) => {
-    setTierServiceId(svc.id)
-    const res = await fetch(`/api/admin/service-tiers/${svc.id}`)
+  const openVariantManager = async (svc: Service) => {
+    setVariantServiceId(svc.id)
+    const res = await fetch(`/api/admin/service-variants/${svc.id}`)
     const data = await res.json()
-    setTiers(data)
-    setTierForm({} as Partial<Tier>)
-    setShowTierModal(true)
+    setVariants(data)
+    setVariantForm({} as Partial<Variant>)
+    setShowVariantModal(true)
   }
 
-  const openAddTier = () => {
-    setTierForm({ ...emptyTier, id: crypto.randomUUID() })
-    setEditingTier(false)
+  const openAddVariant = () => {
+    setVariantForm({ ...emptyVariant, id: crypto.randomUUID() })
+    setEditingVariant(false)
   }
 
-  const openEditTier = (t: Tier) => {
-    setTierForm({ ...t })
-    setEditingTier(true)
+  const openEditVariant = (v: Variant) => {
+    setVariantForm({ ...v })
+    setEditingVariant(true)
   }
 
-  const saveTier = async (e: React.FormEvent) => {
+  const saveVariant = async (e: React.FormEvent) => {
     e.preventDefault()
     const body = {
-      id: tierForm.id,
-      name: tierForm.name,
-      duration: tierForm.duration ? Number(tierForm.duration) : null,
+      id: variantForm.id,
+      name: variantForm.name,
+      duration: variantForm.duration ? Number(variantForm.duration) : null,
     }
-    if (editingTier) {
-      await fetch(`/api/admin/service-tiers/${tierServiceId}`, {
+    if (editingVariant) {
+      await fetch(`/api/admin/service-variants/${variantServiceId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       })
     } else {
-      await fetch(`/api/admin/service-tiers/${tierServiceId}`, {
+      await fetch(`/api/admin/service-variants/${variantServiceId}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       })
     }
-    const res = await fetch(`/api/admin/service-tiers/${tierServiceId}`)
+    const res = await fetch(`/api/admin/service-variants/${variantServiceId}`)
     const data = await res.json()
-    setTiers(data)
-    setTierForm({} as Partial<Tier>)
-    setEditingTier(false)
+    setVariants(data)
+    setVariantForm({} as Partial<Variant>)
+    setEditingVariant(false)
   }
 
-  const deleteTier = async (id: string) => {
-    if (!confirm("Delete this tier?")) return
-    await fetch(`/api/admin/service-tiers/${tierServiceId}`, {
+  const deleteVariant = async (id: string) => {
+    if (!confirm("Delete this variant?")) return
+    await fetch(`/api/admin/service-variants/${variantServiceId}`, {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id }),
     })
-    const res = await fetch(`/api/admin/service-tiers/${tierServiceId}`)
+    const res = await fetch(`/api/admin/service-variants/${variantServiceId}`)
     const data = await res.json()
-    setTiers(data)
+    setVariants(data)
   }
 
   const openImageManager = async (svc: Service) => {
@@ -281,7 +281,7 @@ export default function ServicesAdmin() {
           <h1 className="text-4xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent mb-2">
             Services Management
           </h1>
-          <p className="text-slate-600">Manage your services, tiers, and media content</p>
+          <p className="text-slate-600">Manage your services, variants, and media content</p>
         </div>
 
         {/* Category Selection */}
@@ -343,7 +343,7 @@ export default function ServicesAdmin() {
                   )}
                   <div className="absolute top-4 right-4">
                     <Badge variant="secondary" className="bg-white/90 text-slate-700">
-                      {service.tiers.length} tiers
+                      {service.variants.length} variants
                     </Badge>
                   </div>
                 </div>
@@ -365,11 +365,11 @@ export default function ServicesAdmin() {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => openTierManager(service)}
+                      onClick={() => openVariantManager(service)}
                       className="flex-1 hover:bg-green-50 hover:border-green-200"
                     >
                       <DollarSign className="h-4 w-4 mr-1" />
-                      Tiers
+                      Variants
                     </Button>
                     <Button
                       variant="outline"
@@ -488,20 +488,20 @@ export default function ServicesAdmin() {
           </div>
         )}
 
-        {/* Tier Management Modal */}
-        {showTierModal && (
+        {/* Variant Management Modal */}
+        {showVariantModal && (
           <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
             <Card className="w-full max-w-4xl max-h-[90vh] overflow-y-auto shadow-2xl border-0">
               <CardHeader className="bg-gradient-to-r from-green-500 to-emerald-600 text-slate-800">
                 <CardTitle className="flex items-center justify-between">
                   <span className="flex items-center gap-2">
                     <DollarSign className="h-5 w-5" />
-                    Manage Service Tiers
+                    Manage Service Variants
                   </span>
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => setShowTierModal(false)}
+                    onClick={() => setShowVariantModal(false)}
                     className="text-slate-800 hover:bg-white/20"
                   >
                     <X className="h-4 w-4" />
@@ -509,31 +509,31 @@ export default function ServicesAdmin() {
                 </CardTitle>
               </CardHeader>
               <CardContent className="p-6">
-                {/* Existing Tiers */}
+                {/* Existing Variants */}
                 <div className="mb-6">
                   <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-lg font-semibold text-slate-800">Current Tiers</h3>
+                    <h3 className="text-lg font-semibold text-slate-800">Current Variants</h3>
                     <Button
-                      onClick={openAddTier}
+                      onClick={openAddVariant}
                       size="sm"
                       className="bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700"
                     >
                       <Plus className="h-4 w-4 mr-2" />
-                      Add Tier
+                      Add Variant
                     </Button>
                   </div>
 
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    {tiers.map((tier) => (
-                      <Card key={tier.id} className="border border-slate-200 hover:shadow-md transition-shadow">
+                    {variants.map((variant) => (
+                      <Card key={variant.id} className="border border-slate-200 hover:shadow-md transition-shadow">
                         <CardContent className="p-4">
                           <div className="flex items-start justify-between mb-3">
-                            <h4 className="font-medium text-slate-800">{tier.name}</h4>
+                            <h4 className="font-medium text-slate-800">{variant.name}</h4>
                             <div className="flex gap-1">
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                onClick={() => openEditTier(tier)}
+                                onClick={() => openEditVariant(variant)}
                                 className="h-8 w-8 p-0 hover:bg-blue-100"
                               >
                                 <Edit3 className="h-3 w-3" />
@@ -541,7 +541,7 @@ export default function ServicesAdmin() {
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                onClick={() => deleteTier(tier.id)}
+                                onClick={() => deleteVariant(variant.id)}
                                 className="h-8 w-8 p-0 hover:bg-red-100 text-red-600"
                               >
                                 <Trash2 className="h-3 w-3" />
@@ -552,26 +552,26 @@ export default function ServicesAdmin() {
                             <div className="flex items-center gap-2">
                               <DollarSign className="h-3 w-3 text-slate-500" />
                               <span className="text-slate-600">Current Price:</span>
-                              {tier.currentPrice ? (
+                              {variant.currentPrice ? (
                                 <span className="font-medium">
-                                  ₹{tier.currentPrice.offerPrice ?? tier.currentPrice.actualPrice}
+                                  ₹{variant.currentPrice.offerPrice ?? variant.currentPrice.actualPrice}
                                 </span>
                               ) : (
                                 <span className="text-red-600 font-medium">
                                   Not set
                                 </span>
                               )}
-                              {!tier.currentPrice && (
-                                <a href="/admin/tier-price-history" className="text-blue-600 underline ml-2 text-xs">
+                              {!variant.currentPrice && (
+                                <a href="/admin/variant-price-history" className="text-blue-600 underline ml-2 text-xs">
                                   Update price
                                 </a>
                               )}
                             </div>
-                            {tier.duration && (
+                            {variant.duration && (
                               <div className="flex items-center gap-2">
                                 <Clock className="h-3 w-3 text-slate-500" />
                                 <span className="text-slate-600">Duration: </span>
-                                <span className="font-medium">{tier.duration} min</span>
+                                <span className="font-medium">{variant.duration} min</span>
                               </div>
                             )}
                           </div>
@@ -581,22 +581,22 @@ export default function ServicesAdmin() {
                   </div>
                 </div>
 
-                {/* Tier Form */}
-                {tierForm.name !== undefined && (
+                {/* Variant Form */}
+                {variantForm.name !== undefined && (
                   <Card className="border-2 border-green-200 bg-green-50/50">
                     <CardHeader className="pb-4">
                       <CardTitle className="text-lg text-green-800">
-                        {editingTier ? "Edit Tier" : "Add New Tier"}
+                        {editingVariant ? "Edit Variant" : "Add New Variant"}
                       </CardTitle>
                     </CardHeader>
                     <CardContent>
-                      <form onSubmit={saveTier} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <form onSubmit={saveVariant} className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div className="space-y-2">
-                          <Label htmlFor="tierName">Tier Name</Label>
+                          <Label htmlFor="variantName">Variant Name</Label>
                           <Input
-                            id="tierName"
-                            value={tierForm.name || ""}
-                            onChange={(e) => setTierForm({ ...tierForm, name: e.target.value })}
+                            id="variantName"
+                            value={variantForm.name || ""}
+                            onChange={(e) => setVariantForm({ ...variantForm, name: e.target.value })}
                             placeholder="e.g., Basic, Premium"
                             required
                           />
@@ -608,10 +608,10 @@ export default function ServicesAdmin() {
                           <Input
                             id="duration"
                             type="number"
-                            value={tierForm.duration ?? ""}
+                            value={variantForm.duration ?? ""}
                             onChange={(e) =>
-                              setTierForm({
-                                ...tierForm,
+                              setVariantForm({
+                                ...variantForm,
                                 duration: e.target.value ? Number.parseInt(e.target.value) : null,
                               })
                             }
@@ -624,8 +624,8 @@ export default function ServicesAdmin() {
                             type="button"
                             variant="outline"
                             onClick={() => {
-                              setTierForm({} as Partial<Tier>)
-                              setEditingTier(false)
+                              setVariantForm({} as Partial<Variant>)
+                              setEditingVariant(false)
                             }}
                           >
                             Cancel
@@ -635,7 +635,7 @@ export default function ServicesAdmin() {
                             className="bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700"
                           >
                             <Save className="h-4 w-4 mr-2" />
-                            {editingTier ? "Update" : "Add"} Tier
+                            {editingVariant ? "Update" : "Add"} Variant
                           </Button>
                         </div>
                       </form>

--- a/src/app/admin/variant-price-history/page.tsx
+++ b/src/app/admin/variant-price-history/page.tsx
@@ -10,6 +10,7 @@ import {
   Tag,
   Sparkles,
   Info,
+  X,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -28,9 +29,9 @@ import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
-interface TierRow {
+interface VariantRow {
   id: string
-  tierName: string
+  variantName: string
   serviceName: string
   categoryName: string
   current?: Entry
@@ -59,9 +60,9 @@ const formatDateForInput = (dateString: string | null | undefined): string => {
   }
 }
 
-export default function TierPriceHistoryPage() {
+export default function VariantPriceHistoryPage() {
   const empty: Partial<Entry> = { id: "", actualPrice: 0, startDate: "" }
-  const [rows, setRows] = useState<TierRow[]>([])
+  const [rows, setRows] = useState<VariantRow[]>([])
   const [selected, setSelected] = useState("")
   const [entries, setEntries] = useState<Entry[]>([])
   const [form, setForm] = useState<Partial<Entry>>(empty)
@@ -79,20 +80,20 @@ export default function TierPriceHistoryPage() {
   }, [])
 
   const loadRows = async () => {
-    const tiers = await fetch("/api/admin/service-tiers/all").then((r) => r.json())
-    setRows(tiers)
+    const variants = await fetch("/api/admin/service-variants/all").then((r) => r.json())
+    setRows(variants)
   }
 
-  const open = async (tierId: string) => {
-    setSelected(tierId)
-    const hist = await fetch(`/api/admin/tier-price-history/${tierId}`).then((r) => r.json())
+  const open = async (variantId: string) => {
+    setSelected(variantId)
+    const hist = await fetch(`/api/admin/variant-price-history/${variantId}`).then((r) => r.json())
     setEntries(hist)
     setForm({ ...empty, id: crypto.randomUUID() })
     setEditing(false)
     setIsDialogOpen(true)
   }
 
-  const closeTierDetails = () => {
+  const closeVariantDetails = () => {
     setSelected("")
     setEntries([])
     setIsDialogOpen(false)
@@ -107,13 +108,13 @@ export default function TierPriceHistoryPage() {
       endDate: form.endDate || null,
     }
     if (editing) {
-      await fetch(`/api/admin/tier-price-history/${selected}`, {
+      await fetch(`/api/admin/variant-price-history/${selected}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: form.id, ...body }),
       })
     } else {
-      await fetch(`/api/admin/tier-price-history/${selected}`, {
+      await fetch(`/api/admin/variant-price-history/${selected}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -121,7 +122,7 @@ export default function TierPriceHistoryPage() {
     }
     setForm({ ...empty, id: crypto.randomUUID() })
     setEditing(false)
-    const hist = await fetch(`/api/admin/tier-price-history/${selected}`).then((r) => r.json())
+    const hist = await fetch(`/api/admin/variant-price-history/${selected}`).then((r) => r.json())
     setEntries(hist)
     loadRows()
   }
@@ -133,12 +134,12 @@ export default function TierPriceHistoryPage() {
 
   const del = async (id: string) => {
     if (!confirm("Are you sure you want to delete this price entry?")) return
-    await fetch(`/api/admin/tier-price-history/${selected}`, {
+      await fetch(`/api/admin/variant-price-history/${selected}`, {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id }),
     })
-    const hist = await fetch(`/api/admin/tier-price-history/${selected}`).then((r) => r.json())
+    const hist = await fetch(`/api/admin/variant-price-history/${selected}`).then((r) => r.json())
     setEntries(hist)
     loadRows()
   }
@@ -150,7 +151,7 @@ export default function TierPriceHistoryPage() {
         (row) =>
           row.categoryName.toLowerCase().includes(searchTerm.toLowerCase()) ||
           row.serviceName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          row.tierName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          row.variantName.toLowerCase().includes(searchTerm.toLowerCase()) ||
           row.current?.actualPrice?.toString().includes(searchTerm) ||
           row.upcoming?.actualPrice?.toString().includes(searchTerm),
       )
@@ -160,13 +161,13 @@ export default function TierPriceHistoryPage() {
       if (cat !== 0) return cat
       const serv = a.serviceName.localeCompare(b.serviceName)
       if (serv !== 0) return serv
-      return a.tierName.localeCompare(b.tierName)
+      return a.variantName.localeCompare(b.variantName)
     })
   }, [rows, searchTerm])
 
-  const tiersWithCurrentPrice = rows.filter((row) => row.current).length
-  const tiersWithUpcomingPrice = rows.filter((row) => row.upcoming).length
-  const tiersWithoutPrice = rows.filter((row) => !row.current && !row.upcoming).length
+  const variantsWithCurrentPrice = rows.filter((row) => row.current).length
+  const variantsWithUpcomingPrice = rows.filter((row) => row.upcoming).length
+  const variantsWithoutPrice = rows.filter((row) => !row.current && !row.upcoming).length
 
   // Determine if the current form's start date is in the past (for disabling)
   const isStartDateInPast = useMemo(() => {
@@ -192,55 +193,55 @@ export default function TierPriceHistoryPage() {
       <div className="container mx-auto py-8 px-4 md:px-6 bg-gray-50 min-h-screen">
         <h1 className="text-4xl font-extrabold mb-2 text-gray-900 tracking-tight">Salon Pricing & Offers</h1>
         <p className="text-lg text-muted-foreground mb-8">
-          Effortlessly manage and update all service tier prices and special offers.
+          Effortlessly manage and update all service variant prices and special offers.
         </p>
         {/* Info Graphics / Summary Cards */}
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-10">
           <Card className="shadow-lg border-l-4 border-blue-500">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium text-blue-700">Total Service Tiers</CardTitle>
+              <CardTitle className="text-sm font-medium text-blue-700">Total Service Variants</CardTitle>
               <Tag className="h-5 w-5 text-blue-500" />
             </CardHeader>
             <CardContent>
               <div className="text-3xl font-bold text-gray-900">{rows.length}</div>
-              <p className="text-xs text-muted-foreground mt-1">All available service tiers</p>
+              <p className="text-xs text-muted-foreground mt-1">All available service variants</p>
             </CardContent>
           </Card>
           <Card className="shadow-lg border-l-4 border-green-500">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium text-green-700">Tiers with Active Pricing</CardTitle>
+              <CardTitle className="text-sm font-medium text-green-700">Variants with Active Pricing</CardTitle>
               <IndianRupee className="h-5 w-5 text-green-500" />
             </CardHeader>
             <CardContent>
-              <div className="text-3xl font-bold text-gray-900">{tiersWithCurrentPrice}</div>
+              <div className="text-3xl font-bold text-gray-900">{variantsWithCurrentPrice}</div>
               <p className="text-xs text-muted-foreground mt-1">Currently configured prices</p>
             </CardContent>
           </Card>
           <Card className="shadow-lg border-l-4 border-purple-500">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium text-purple-700">Tiers with Upcoming Offers</CardTitle>
+              <CardTitle className="text-sm font-medium text-purple-700">Variants with Upcoming Offers</CardTitle>
               <Calendar className="h-5 w-5 text-purple-500" />
             </CardHeader>
             <CardContent>
-              <div className="text-3xl font-bold text-gray-900">{tiersWithUpcomingPrice}</div>
+              <div className="text-3xl font-bold text-gray-900">{variantsWithUpcomingPrice}</div>
               <p className="text-xs text-muted-foreground mt-1">Future price changes or promotions</p>
             </CardContent>
           </Card>
           <Card className="shadow-lg border-l-4 border-red-500">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium text-red-700">Tiers Needing Price Setup</CardTitle>
+              <CardTitle className="text-sm font-medium text-red-700">Variants Needing Price Setup</CardTitle>
               <Info className="h-5 w-5 text-red-500" />
             </CardHeader>
             <CardContent>
-              <div className="text-3xl font-bold text-gray-900">{tiersWithoutPrice}</div>
-              <p className="text-xs text-muted-foreground mt-1">Tiers without any price configuration</p>
+              <div className="text-3xl font-bold text-gray-900">{variantsWithoutPrice}</div>
+              <p className="text-xs text-muted-foreground mt-1">Variants without any price configuration</p>
             </CardContent>
           </Card>
         </div>
         <Card className="shadow-lg">
           <CardHeader>
-            <CardTitle className="text-2xl font-semibold">Service Tier Price List</CardTitle>
-            <CardDescription>Browse, filter, and manage pricing details for each service tier.</CardDescription>
+            <CardTitle className="text-2xl font-semibold">Service Variant Price List</CardTitle>
+            <CardDescription>Browse, filter, and manage pricing details for each service variant.</CardDescription>
           </CardHeader>
           <CardContent>
             {/* Search and Filters */}
@@ -248,7 +249,7 @@ export default function TierPriceHistoryPage() {
               <div className="relative col-span-full xl:col-span-2">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
-                  placeholder="Search by category, service, or tier..."
+                  placeholder="Search by category, service, or variant..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="pl-9 pr-4 py-2 rounded-md border focus-visible:ring-blue-500"
@@ -263,7 +264,7 @@ export default function TierPriceHistoryPage() {
                     <TableHead className="w-[60px] text-center">Sl No.</TableHead>
                     <TableHead>Category</TableHead>
                     <TableHead>Service</TableHead>
-                    <TableHead>Tier</TableHead>
+                    <TableHead>Variant</TableHead>
                     <TableHead>Current Price</TableHead>
                     <TableHead>Current Ends</TableHead>
                     <TableHead>Upcoming Price</TableHead>
@@ -278,7 +279,7 @@ export default function TierPriceHistoryPage() {
                         <TableCell className="font-medium text-center text-muted-foreground">{index + 1}</TableCell>
                         <TableCell className="font-semibold text-gray-800">{row.categoryName}</TableCell>
                         <TableCell>{row.serviceName}</TableCell>
-                        <TableCell>{row.tierName}</TableCell>
+                        <TableCell>{row.variantName}</TableCell>
                         <TableCell>
                           {row.current ? (
                             <div className="flex flex-col items-start gap-1">
@@ -348,14 +349,12 @@ export default function TierPriceHistoryPage() {
                       <TableCell colSpan={9} className="h-32 text-center text-muted-foreground">
                         <div className="flex flex-col items-center justify-center gap-2">
                           <Sparkles className="h-8 w-8 text-gray-400" />
-                          <p>No matching service tiers found.</p>
+                          <p>No matching service variants found.</p>
                           <Button
                             variant="link"
                             onClick={() => {
                               setSearchTerm("")
-                              setCategoryFilter([])
-                              setServiceFilter([])
-                              setTierFilter([])
+                              // reset additional filters here if added
                             }}
                           >
                             Clear all filters
@@ -373,9 +372,14 @@ export default function TierPriceHistoryPage() {
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <DialogContent className="sm:max-w-[500px] p-6 max-h-[80vh] overflow-y-auto text-gray-900">
 
-            <DialogHeader>
-              <DialogTitle className="text-2xl font-bold">Edit Price History</DialogTitle>
-              <DialogDescription>Manage individual price entries for this service tier.</DialogDescription>
+            <DialogHeader className="flex items-start justify-between">
+              <div>
+                <DialogTitle className="text-2xl font-bold">Edit Price History</DialogTitle>
+                <DialogDescription>Manage individual price entries for this service variant.</DialogDescription>
+              </div>
+              <Button variant="ghost" size="sm" onClick={closeVariantDetails} className="text-gray-500 hover:bg-gray-100">
+                <X className="h-4 w-4" />
+              </Button>
             </DialogHeader>
             <Separator className="my-4" />
             <form onSubmit={save} className="space-y-4">
@@ -442,7 +446,7 @@ export default function TierPriceHistoryPage() {
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={closeTierDetails}
+                  onClick={closeVariantDetails}
                   className="hover:bg-gray-100 bg-transparent"
                 >
                   Cancel

--- a/src/app/admin/walk-in/page.tsx
+++ b/src/app/admin/walk-in/page.tsx
@@ -28,7 +28,7 @@ interface Category {
   name: string
 }
 
-interface Tier {
+interface Variant {
   id: string
   name: string
   duration?: number | null
@@ -38,7 +38,7 @@ interface Tier {
 interface Service {
   id: string
   name: string
-  tiers: Tier[]
+  variants: Variant[]
 }
 
 interface Staff {
@@ -52,7 +52,7 @@ interface StaffApi extends Staff {
 
 interface Selected {
   serviceId: string
-  tierId: string
+  variantId: string
   name: string
   duration: number
   price: number
@@ -78,7 +78,7 @@ export default function AdminBooking() {
   const [category, setCategory] = useState("")
   const [services, setServices] = useState<Service[]>([])
   const [selectedSvc, setSelectedSvc] = useState("")
-  const [tiers, setTiers] = useState<Tier[]>([])
+  const [variants, setVariants] = useState<Variant[]>([])
   const [selectedTier, setSelectedTier] = useState("")
   const [items, setItems] = useState<Selected[]>([])
   const [staff, setStaff] = useState<Staff[]>([])
@@ -107,7 +107,7 @@ export default function AdminBooking() {
   const loadServices = async () => {
     if (!category) {
       setServices([])
-      setTiers([])
+      setVariants([])
       setSelectedSvc("")
       return
     }
@@ -117,10 +117,10 @@ export default function AdminBooking() {
       const data: Service[] = await res.json()
       const enriched: Service[] = []
       for (const svc of data) {
-        const tRes = await fetch(`/api/admin/service-tiers/${svc.id}`)
-        const tiers: Tier[] = await tRes.json()
-        if (tiers.some((t) => t.currentPrice)) {
-          enriched.push({ ...svc, tiers })
+        const tRes = await fetch(`/api/admin/service-variants/${svc.id}`)
+        const variants: Variant[] = await tRes.json()
+        if (variants.some((t) => t.currentPrice)) {
+          enriched.push({ ...svc, variants })
         }
       }
       setServices(enriched)
@@ -167,12 +167,12 @@ export default function AdminBooking() {
   useEffect(() => {
     loadServices()
     setSelectedSvc("")
-    setTiers([])
+    setVariants([])
   }, [category])
   useEffect(() => {
     if (!selectedSvc) return
     const svc = services.find((s) => s.id === selectedSvc)
-    setTiers(svc?.tiers || [])
+    setVariants(svc?.variants || [])
   }, [selectedSvc])
   useEffect(() => {
     localStorage.setItem("walkin-bookings", JSON.stringify(bookings))
@@ -185,19 +185,19 @@ export default function AdminBooking() {
   }, [edit])
 
   const addItem = () => {
-    const tier = tiers.find((t) => t.id === selectedTier)
-    if (!tier) return
+    const variant = variants.find((t) => t.id === selectedTier)
+    if (!variant) return
 
-    const price = tier.currentPrice?.offerPrice ?? tier.currentPrice?.actualPrice ?? 0
-    const duration = tier.duration || 0
+    const price = variant.currentPrice?.offerPrice ?? variant.currentPrice?.actualPrice ?? 0
+    const duration = variant.duration || 0
     const serviceName = services.find((s) => s.id === selectedSvc)?.name || ""
 
     setItems([
       ...items,
       {
         serviceId: selectedSvc,
-        tierId: tier.id,
-        name: `${serviceName} - ${tier.name}`,
+        variantId: variant.id,
+        name: `${serviceName} - ${variant.name}`,
         duration,
         price,
         staffId: "",
@@ -423,7 +423,7 @@ export default function AdminBooking() {
                 <Scissors className="h-5 w-5 text-green-600" /> Select Services
               </CardTitle>
               <CardDescription className="text-sm text-gray-500">
-                Choose the services and tiers, then assign staff and time for each.
+                Choose the services and variants, then assign staff and time for each.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -463,16 +463,16 @@ export default function AdminBooking() {
                 )}
               </div>
 
-              {tiers.length > 0 && (
+              {variants.length > 0 && (
                 <div className="space-y-2">
-                  <Label className="text-sm">Tier</Label>
+                  <Label className="text-sm">Variant</Label>
                   <div className="flex gap-2">
                     <Select value={selectedTier} onValueChange={setSelectedTier}>
                       <SelectTrigger className="flex-1 h-9">
-                        <SelectValue placeholder="Select tier" />
+                        <SelectValue placeholder="Select variant" />
                       </SelectTrigger>
                       <SelectContent>
-                        {tiers.map((t) => (
+                        {variants.map((t) => (
                           <SelectItem key={t.id} value={t.id}>
                             {t.name} ({t.duration}m) - ₹{t.currentPrice?.actualPrice}
                           </SelectItem>
@@ -494,7 +494,7 @@ export default function AdminBooking() {
                   </Label>
                   <div className="space-y-3 max-h-60 overflow-y-auto pr-2">
                     {items.map((item, idx) => (
-                      <div key={item.tierId} className="border rounded-md p-3 bg-gray-50">
+                      <div key={item.variantId} className="border rounded-md p-3 bg-gray-50">
                         <div className="flex items-center justify-between mb-2">
                           <span className="font-medium text-sm truncate" title={item.name}>
                             {item.name}

--- a/src/app/api/admin/service-variants/[serviceId]/route.ts
+++ b/src/app/api/admin/service-variants/[serviceId]/route.ts
@@ -5,13 +5,13 @@ const prisma = new PrismaClient()
 
 export async function GET(req: Request, { params }: { params: { serviceId: string } }) {
   const { serviceId } = await params
-  const tiers = await prisma.serviceTier.findMany({
+  const variants = await prisma.serviceTier.findMany({
     where: { serviceId },
     include: { priceHistory: true },
     orderBy: { name: 'asc' },
   })
   const now = new Date()
-  const response = tiers.map(t => {
+  const response = variants.map(t => {
     const current = t.priceHistory.find(ph => {
       const start = ph.startDate
       const end = ph.endDate
@@ -32,7 +32,7 @@ export async function GET(req: Request, { params }: { params: { serviceId: strin
 export async function POST(req: Request, { params }: { params: { serviceId: string } }) {
   const { serviceId } = await params
   const data = await req.json()
-  const tier = await prisma.serviceTier.create({
+  const variant = await prisma.serviceTier.create({
     data: {
       serviceId,
       name: data.name,
@@ -47,13 +47,13 @@ export async function POST(req: Request, { params }: { params: { serviceId: stri
   if (data.actualPrice !== undefined || data.offerPrice !== undefined) {
     await prisma.serviceTierPriceHistory.create({
       data: {
-        tierId: tier.id,
-        actualPrice: tier.actualPrice,
-        offerPrice: tier.offerPrice,
+        tierId: variant.id,
+        actualPrice: variant.actualPrice,
+        offerPrice: variant.offerPrice,
       },
     })
   }
-  return NextResponse.json(tier)
+  return NextResponse.json(variant)
 }
 
 export async function PUT(req: Request, { params }: { params: { serviceId: string } }) {
@@ -65,22 +65,22 @@ export async function PUT(req: Request, { params }: { params: { serviceId: strin
   if (data.offerPrice !== undefined) updateData.offerPrice =
     data.offerPrice === null ? null : Number(data.offerPrice)
 
-  const tier = await prisma.serviceTier.update({ where: { id: data.id }, data: updateData })
+  const variant = await prisma.serviceTier.update({ where: { id: data.id }, data: updateData })
 
   if (
     existing &&
-    (('actualPrice' in updateData && existing.actualPrice !== tier.actualPrice) ||
-      ('offerPrice' in updateData && existing.offerPrice !== tier.offerPrice))
+    (('actualPrice' in updateData && existing.actualPrice !== variant.actualPrice) ||
+      ('offerPrice' in updateData && existing.offerPrice !== variant.offerPrice))
   ) {
     await prisma.serviceTierPriceHistory.create({
       data: {
-        tierId: tier.id,
-        actualPrice: tier.actualPrice,
-        offerPrice: tier.offerPrice,
+        tierId: variant.id,
+        actualPrice: variant.actualPrice,
+        offerPrice: variant.offerPrice,
       },
     })
   }
-  return NextResponse.json(tier)
+  return NextResponse.json(variant)
 }
 
 export async function DELETE(req: Request, { params }: { params: { serviceId: string } }) {

--- a/src/app/api/admin/service-variants/all/route.ts
+++ b/src/app/api/admin/service-variants/all/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma'
 
 export async function GET() {
   const now = new Date()
-  const tiers = await prisma.serviceTier.findMany({
+  const variants = await prisma.serviceTier.findMany({
     include: {
       service: {
         select: {
@@ -27,14 +27,14 @@ export async function GET() {
     orderBy: { name: 'asc' },
   })
 
-  const response = tiers.map(t => {
+  const response = variants.map(t => {
     const current = t.priceHistory.find(
       p => p.startDate <= now && (!p.endDate || p.endDate > now)
     )
     const upcoming = t.priceHistory.find(p => p.startDate > now)
     return {
       id: t.id,
-      tierName: t.name,
+      variantName: t.name,
       serviceName: t.service.name,
       categoryName: t.service.category.name,
       current,

--- a/src/app/api/admin/variant-price-history/[variantId]/route.ts
+++ b/src/app/api/admin/variant-price-history/[variantId]/route.ts
@@ -1,21 +1,21 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
-export async function GET(req: Request, { params }: { params: { tierId: string } }) {
-  const { tierId } = await params
+export async function GET(req: Request, { params }: { params: { variantId: string } }) {
+  const { variantId } = await params
   const entries = await prisma.serviceTierPriceHistory.findMany({
-    where: { tierId },
+    where: { tierId: variantId },
     orderBy: { startDate: 'desc' },
   })
   return NextResponse.json(entries)
 }
 
-export async function POST(req: Request, { params }: { params: { tierId: string } }) {
-  const { tierId } = await params
+export async function POST(req: Request, { params }: { params: { variantId: string } }) {
+  const { variantId } = await params
   const data = await req.json()
   const entry = await prisma.serviceTierPriceHistory.create({
     data: {
-      tierId,
+      tierId: variantId,
       actualPrice: Number(data.actualPrice),
       offerPrice: data.offerPrice === null || data.offerPrice === undefined ? null : Number(data.offerPrice),
       startDate: data.startDate ? new Date(data.startDate) : new Date(),
@@ -25,7 +25,7 @@ export async function POST(req: Request, { params }: { params: { tierId: string 
   return NextResponse.json(entry)
 }
 
-export async function PUT(req: Request, { params }: { params: { tierId: string } }) {
+export async function PUT(req: Request, { params }: { params: { variantId: string } }) {
   const data = await req.json()
   const entry = await prisma.serviceTierPriceHistory.update({
     where: { id: data.id },
@@ -39,7 +39,7 @@ export async function PUT(req: Request, { params }: { params: { tierId: string }
   return NextResponse.json(entry)
 }
 
-export async function DELETE(req: Request, { params }: { params: { tierId: string } }) {
+export async function DELETE(req: Request, { params }: { params: { variantId: string } }) {
   const { id } = await req.json()
   await prisma.serviceTierPriceHistory.delete({ where: { id } })
   return NextResponse.json({ success: true })

--- a/src/app/api/v2/services/[id]/route.ts
+++ b/src/app/api/v2/services/[id]/route.ts
@@ -28,7 +28,7 @@ export async function GET(req, { params }: { params: { id: string } }) {
     })
 
     const now = new Date()
-    const tiers = await Promise.all(
+    const variants = await Promise.all(
       service.tiers.map(async (t) => {
         const current = await prisma.serviceTierPriceHistory.findFirst({
           where: {
@@ -59,7 +59,7 @@ export async function GET(req, { params }: { params: { id: string } }) {
         imageUrl: img.imageUrl,
         caption: img.caption ?? null,
       })),
-      tiers,
+      variants,
     }
 
     return NextResponse.json(result)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -407,7 +407,7 @@ export default function HomePage() {
               💫 Why Choose Greens Beauty?
             </h2>
             <p className="text-xl text-gray-400 max-w-3xl mx-auto">
-              Experience the difference with our premium service tiers and professional expertise
+              Experience the difference with our premium service variants and professional expertise
             </p>
           </motion.div>
 

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -30,7 +30,7 @@ export default async function ServiceDetailsPage({ params }: { params: { id: str
       <h1 className="text-3xl font-bold mb-2" style={{ color: '#41eb70' }}>{service.name}</h1>
       {service.caption && <p className="text-lg text-gray-300 mb-4">{service.caption}</p>}
       <div className="prose prose-invert mb-6" dangerouslySetInnerHTML={{ __html: service.description || '' }} />
-      <h2 className="text-2xl font-semibold mb-4" style={{ color: '#41eb70' }}>Tiers</h2>
+      <h2 className="text-2xl font-semibold mb-4" style={{ color: '#41eb70' }}>Variants</h2>
       <ul className="space-y-3">
         {service.tiers.map(t => (
           <li key={t.id} className="flex items-center justify-between bg-gray-800 rounded-xl p-4">


### PR DESCRIPTION
## Summary
- rename Tier naming to Variant across admin panels and APIs
- adjust service management screens for variant naming
- update price history modal with a new close button
- update references and routes to use `variant` terminology

## Testing
- `npm install`
- `npm run lint` *(fails: next not found / lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68805e6997c083259578ede22b85585b