### PR TITLE
Enhanced admin dashboard metrics

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,14 +1,34 @@
 'use client'
 import { useEffect, useState } from 'react'
 
-interface Metrics {
+interface DashboardData {
   services: number
-  staff: number
   branches: number
+  staff: {
+    total: number
+    active: number
+    removed: number
+  }
+  bookings: {
+    total: number
+    today: number
+    upcoming: {
+      id: string
+      customer: string
+      date: string
+      start: string
+      staff: { name: string }
+    }[]
+  }
+  pricing: {
+    avgActualPrice: number
+    avgOfferPrice: number | null
+    activeOffers: number
+  }
 }
 
 export default function DashboardPage() {
-  const [data, setData] = useState<Metrics | null>(null)
+  const [data, setData] = useState<DashboardData | null>(null)
   useEffect(() => {
     fetch('/api/admin/dashboard')
       .then(res => res.json())
@@ -18,22 +38,59 @@ export default function DashboardPage() {
   if (!data) return <p>Loading...</p>
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold text-green-700">Admin Dashboard</h1>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <div className="space-y-8 p-4">
+      <h1 className="text-3xl font-bold text-green-700 mb-4">Admin Dashboard</h1>
+
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-white p-4 rounded shadow border">
           <div className="text-sm text-gray-500">Services</div>
           <div className="text-2xl font-bold">{data.services}</div>
         </div>
         <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Staff</div>
-          <div className="text-2xl font-bold">{data.staff}</div>
-        </div>
-        <div className="bg-white p-4 rounded shadow border">
           <div className="text-sm text-gray-500">Branches</div>
           <div className="text-2xl font-bold">{data.branches}</div>
         </div>
-      </div>
+        <div className="bg-white p-4 rounded shadow border">
+          <div className="text-sm text-gray-500">Total Staff</div>
+          <div className="text-2xl font-bold">{data.staff.total}</div>
+        </div>
+        <div className="bg-white p-4 rounded shadow border">
+          <div className="text-sm text-gray-500">Today's Bookings</div>
+          <div className="text-2xl font-bold">{data.bookings.today}</div>
+        </div>
+      </section>
+
+      <section className="bg-white p-4 rounded shadow space-y-2">
+        <h2 className="text-xl font-semibold">Upcoming Appointments</h2>
+        <ul className="divide-y">
+          {data.bookings.upcoming.map(b => (
+            <li key={b.id} className="py-2 flex justify-between">
+              <span>{b.date} {b.start}</span>
+              <span>{b.customer} with {b.staff.name}</span>
+            </li>
+          ))}
+          {data.bookings.upcoming.length === 0 && (
+            <li className="py-2">No upcoming appointments</li>
+          )}
+        </ul>
+      </section>
+
+      <section className="grid md:grid-cols-2 gap-4">
+        <div className="bg-white p-4 rounded shadow space-y-1">
+          <h2 className="text-xl font-semibold mb-2">Staff Statistics</h2>
+          <p>Total Staff: {data.staff.total}</p>
+          <p>Active: {data.staff.active}</p>
+          <p>Removed: {data.staff.removed}</p>
+        </div>
+        <div className="bg-white p-4 rounded shadow space-y-1">
+          <h2 className="text-xl font-semibold mb-2">Pricing &amp; Offers</h2>
+          <p>Average Price: ₹{data.pricing.avgActualPrice.toFixed(2)}</p>
+          {data.pricing.avgOfferPrice !== null && (
+            <p>Average Offer: ₹{data.pricing.avgOfferPrice.toFixed(2)}</p>
+          )}
+          <p>Active Offers: {data.pricing.activeOffers}</p>
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -3,12 +3,53 @@ import { prisma } from '@/lib/prisma'
 
 export async function GET() {
   try {
-    const [services, staff, branches] = await Promise.all([
+    const today = new Date().toISOString().split('T')[0]
+    const [
+      servicesCount,
+      branchesCount,
+      activeStaff,
+      removedStaff,
+      totalBookings,
+      todayBookings,
+      upcoming,
+      priceAvg,
+      activeOffers,
+    ] = await prisma.$transaction([
       prisma.service.count(),
-      prisma.user.count({ where: { role: 'STAFF', removed: false } }),
       prisma.branch.count(),
+      prisma.user.count({ where: { role: 'STAFF', removed: false } }),
+      prisma.user.count({ where: { role: 'STAFF', removed: true } }),
+      prisma.booking.count(),
+      prisma.booking.count({ where: { date: today } }),
+      prisma.booking.findMany({
+        where: { date: { gte: today } },
+        include: { staff: { select: { name: true } }, items: true },
+        orderBy: [{ date: 'asc' }, { start: 'asc' }],
+        take: 5,
+      }),
+      prisma.serviceTier.aggregate({ _avg: { actualPrice: true, offerPrice: true } }),
+      prisma.serviceTier.count({ where: { offerPrice: { not: null } } }),
     ])
-    return NextResponse.json({ services, staff, branches })
+
+    return NextResponse.json({
+      services: servicesCount,
+      branches: branchesCount,
+      staff: {
+        total: activeStaff + removedStaff,
+        active: activeStaff,
+        removed: removedStaff,
+      },
+      bookings: {
+        total: totalBookings,
+        today: todayBookings,
+        upcoming,
+      },
+      pricing: {
+        avgActualPrice: priceAvg._avg.actualPrice ?? 0,
+        avgOfferPrice: priceAvg._avg.offerPrice,
+        activeOffers,
+      },
+    })
   } catch (err: any) {
     console.error('dashboard api error', err)
     return NextResponse.json({ error: 'failed' }, { status: 500 })


### PR DESCRIPTION
## Summary
- expand dashboard API to include appointment, staff and pricing stats
- redesign dashboard page with sections for appointments and statistics

## Testing
- `npm run build` *(fails: merge conflict in existing walk-in page)*

------
https://chatgpt.com/codex/tasks/task_e_6880833f97088325a2c37523f617c415