### PR TITLE
Update walk-in booking form

### DIFF
--- a/pages/api/bookings.ts
+++ b/pages/api/bookings.ts
@@ -20,6 +20,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       data: {
         customer: data.customer,
         phone: data.phone,
+        gender: data.gender,
+        age: data.age !== null && data.age !== undefined ? Number(data.age) : null,
         staffId: firstItem?.staffId || data.staffId,
         date: data.date,
         start: firstItem?.start || data.start,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -157,8 +157,10 @@ model ServiceTierPriceHistory {
 
 model Booking {
   id        String   @id @default(uuid())
-  customer  String   @db.VarChar(191)
-  phone     String   @db.VarChar(191)
+  customer  String?  @db.VarChar(191)
+  phone     String?  @db.VarChar(191)
+  gender    String   @db.VarChar(191)
+  age       Int?
   staffId   String   @db.VarChar(191)
   staff     User     @relation(fields: [staffId], references: [id])
   date      String   @db.VarChar(10)

--- a/src/app/api/admin/services-walkin/[categoryId]/route.ts
+++ b/src/app/api/admin/services-walkin/[categoryId]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(req: Request, { params }: { params: { categoryId: string } }) {
+  const { categoryId } = params
+  const services = await prisma.serviceNew.findMany({
+    where: { categoryId },
+    include: {
+      tiers: { include: { priceHistory: true } },
+    },
+    orderBy: { name: 'asc' },
+  })
+  const now = new Date()
+  const response = services.map(svc => ({
+    id: svc.id,
+    name: svc.name,
+    caption: svc.caption,
+    description: svc.description,
+    imageUrl: svc.imageUrl,
+    variants: svc.tiers.map(t => {
+      const current = t.priceHistory.find(ph => ph.startDate <= now && (!ph.endDate || ph.endDate > now))
+      return {
+        id: t.id,
+        name: t.name,
+        duration: t.duration ?? 0,
+        currentPrice: current
+          ? { actualPrice: current.actualPrice, offerPrice: current.offerPrice }
+          : null,
+      }
+    }),
+  }))
+  return NextResponse.json(response)
+}


### PR DESCRIPTION
## Summary
- add gender and age fields to bookings schema
- create services-walkin API for variant fetching
- capture gender and age in walk-in bookings UI
- make name & phone optional and add validations
- simplify service loading with single API call

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688096b85ee48325b5fcc79845d27442