### PR TITLE
Improve walk-in booking validations

### DIFF
--- a/src/app/admin/walk-in/page.tsx
+++ b/src/app/admin/walk-in/page.tsx
@@ -191,9 +191,11 @@ export default function AdminBooking() {
   }, [edit])
 
   const addItem = () => {
-
     const variant = variants.find((t) => t.id === selectedTier)
-    if (!variant) return
+    if (!variant) {
+      setResult({ success: false, message: "Please select a variant first." })
+      return
+    }
 
     const price = variant.currentPrice?.offerPrice ?? variant.currentPrice?.actualPrice ?? 0
     const duration = variant.duration || 0
@@ -297,6 +299,11 @@ export default function AdminBooking() {
     try {
       const color = COLORS[bookings.length % COLORS.length]
 
+      const formattedItems = items.map(({ variantId, ...rest }) => ({
+        ...rest,
+        tierId: variantId,
+      }))
+
       const res = await fetch("/api/bookings", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -307,7 +314,7 @@ export default function AdminBooking() {
           age: age ? Number(age) : null,
           date,
           color,
-          items,
+          items: formattedItems,
         }),
       })
       if (res.ok) {

--- a/src/app/api/admin/services-walkin/[categoryId]/route.ts
+++ b/src/app/api/admin/services-walkin/[categoryId]/route.ts
@@ -1,33 +1,58 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
-export async function GET(req: Request, { params }: { params: { categoryId: string } }) {
+export async function GET(
+  req: Request,
+  { params }: { params: { categoryId: string } }
+) {
   const { categoryId } = params
+  const now = new Date()
   const services = await prisma.serviceNew.findMany({
     where: { categoryId },
-    include: {
-      tiers: { include: { priceHistory: true } },
+    select: {
+      id: true,
+      name: true,
+      caption: true,
+      description: true,
+      imageUrl: true,
+      tiers: {
+        select: {
+          id: true,
+          name: true,
+          duration: true,
+          priceHistory: {
+            where: {
+              startDate: { lte: now },
+              OR: [{ endDate: null }, { endDate: { gt: now } }],
+            },
+            orderBy: { startDate: 'desc' },
+            take: 1,
+            select: { actualPrice: true, offerPrice: true },
+          },
+        },
+      },
     },
     orderBy: { name: 'asc' },
   })
-  const now = new Date()
-  const response = services.map(svc => ({
+
+  const response = services.map((svc) => ({
     id: svc.id,
     name: svc.name,
     caption: svc.caption,
     description: svc.description,
     imageUrl: svc.imageUrl,
-    variants: svc.tiers.map(t => {
-      const current = t.priceHistory.find(ph => ph.startDate <= now && (!ph.endDate || ph.endDate > now))
-      return {
-        id: t.id,
-        name: t.name,
-        duration: t.duration ?? 0,
-        currentPrice: current
-          ? { actualPrice: current.actualPrice, offerPrice: current.offerPrice }
-          : null,
-      }
-    }),
+    variants: svc.tiers.map((t) => ({
+      id: t.id,
+      name: t.name,
+      duration: t.duration ?? 0,
+      currentPrice: t.priceHistory[0]
+        ? {
+            actualPrice: t.priceHistory[0].actualPrice,
+            offerPrice: t.priceHistory[0].offerPrice,
+          }
+        : null,
+    })),
   }))
+
   return NextResponse.json(response)
 }


### PR DESCRIPTION
## Summary
- show variant required message when adding item
- fix booking POST to use `tierId`
- streamline services & variants queries

## Testing
- `npm run lint` *(fails: `next lint` errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880b89376908325b21d71c0c5be093e