### PR TITLE
Implement voucher details in billing history

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -185,6 +185,7 @@ model BookingItem {
 
 model Billing {
   id             String   @id @default(uuid())
+  billId         String   @db.VarChar(191)
   customerId     String?  @db.VarChar(191)
   phone          String?  @db.VarChar(191)
   billingName    String?  @db.VarChar(191)

--- a/src/app/admin/billing/page.tsx
+++ b/src/app/admin/billing/page.tsx
@@ -86,6 +86,7 @@ export default function BillingPage() {
     const svcData = selected
       .map(id => services.find(s => s.id === id)!)
       .map(s => ({
+        phone: s.phone,
         category: s.category,
         service: s.service,
         variant: s.variant,
@@ -93,13 +94,16 @@ export default function BillingPage() {
         amountAfter: s.price * (finalTotal / totalBefore || 1),
         scheduledAt: s.scheduledAt,
       }))
+    const phones = Array.from(
+      new Set(svcData.map(s => s.phone).filter(Boolean))
+    ) as string[]
     await fetch('/api/billing', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         billingName: billingName || null,
         billingAddress: billingAddress || null,
-        phone: services.find(s => s.id === selected[0])?.phone || null,
+        phones,
         voucherCode: coupon?.code || null,
         services: svcData,
       }),


### PR DESCRIPTION
## Summary
- show voucher codes and actual vs. net totals when listing bills
- include voucher and amount details in printable bill text

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881cae5c94c8325bb5b2029ee1efc9b