### PR TITLE
Fix PDF font embedding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.9.1",
+        "@pdf-lib/fontkit": "^1.1.1",
         "@prisma/client": "^6.8.2",
         "@tiptap/extension-color": "^2.23.0",
         "@tiptap/extension-text-style": "^2.23.0",
@@ -1177,6 +1178,15 @@
       "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pdf-lib/fontkit": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/fontkit/-/fontkit-1.1.1.tgz",
+      "integrity": "sha512-KjMd7grNapIWS/Dm0gvfHEilSyAmeLvrEGVcqLGi0VYebuqqzTbgF29efCx7tvx+IEbG3zQciRSWl3GkUSvjZg==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
       }
     },
     "node_modules/@pdf-lib/standard-fonts": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "nodemailer": "^6.10.1",
     "papaparse": "^5.5.3",
     "pdf-lib": "^1.17.1",
+    "@pdf-lib/fontkit": "^1.1.1",
     "prisma": "^6.8.2",
     "react": "18.3.1",
     "react-datepicker": "^8.4.0",

--- a/src/app/admin/billing-history/page.tsx
+++ b/src/app/admin/billing-history/page.tsx
@@ -87,10 +87,12 @@ export default function BillingHistoryPage() {
 
   const downloadPdf = async (b: Bill) => {
     const { PDFDocument } = await import('pdf-lib')
+    const fontkit = (await import('@pdf-lib/fontkit')).default
     const fontBytes = await fetch('/fonts/NotoSans-Regular.ttf').then(res => res.arrayBuffer())
     const logoBytes = await fetch(SALON_INFO.logo).then(res => res.arrayBuffer())
 
     const pdf = await PDFDocument.create()
+    pdf.registerFontkit(fontkit)
     const font = await pdf.embedFont(fontBytes)
     const png = await pdf.embedPng(logoBytes)
     const pageHeight = 600


### PR DESCRIPTION
## Summary
- register fontkit with pdf-lib when generating PDF bills
- install `@pdf-lib/fontkit`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881da299638832598b13586da675a1a