### PR TITLE
Enhance walk‑in scheduling UI

### DIFF
--- a/src/app/admin/walk-in/BookingClient.tsx
+++ b/src/app/admin/walk-in/BookingClient.tsx
@@ -755,7 +755,13 @@ export default function AdminBooking() {
                                     <SelectItem
                                       key={t}
                                       value={t}
-                                      style={isBusy ? { backgroundColor: '#fef08a' } : undefined}
+                                      data-busy={isBusy ? 'true' : undefined}
+                                      className={isBusy ? 'bg-yellow-100 text-black' : undefined}
+                                      style={
+                                        isBusy
+                                          ? { background: '#fef08a', backgroundColor: '#fef08a', color: '#000' }
+                                          : undefined
+                                      }
                                     >
                                       {t}
                                     </SelectItem>
@@ -999,7 +1005,13 @@ export default function AdminBooking() {
                         <SelectItem
                           key={t}
                           value={t}
-                          style={isBusy ? { backgroundColor: '#fef08a' } : undefined}
+                          data-busy={isBusy ? 'true' : undefined}
+                          className={isBusy ? 'bg-yellow-100 text-black' : undefined}
+                          style={
+                            isBusy
+                              ? { background: '#fef08a', backgroundColor: '#fef08a', color: '#000' }
+                              : undefined
+                          }
                         >
                           {t}
                         </SelectItem>

--- a/src/app/admin/walk-in/BookingClient.tsx
+++ b/src/app/admin/walk-in/BookingClient.tsx
@@ -755,7 +755,7 @@ export default function AdminBooking() {
                                     <SelectItem
                                       key={t}
                                       value={t}
-                                      className={isBusy ? 'bg-yellow-200' : ''}
+                                      style={isBusy ? { backgroundColor: '#fef08a' } : undefined}
                                     >
                                       {t}
                                     </SelectItem>
@@ -999,7 +999,7 @@ export default function AdminBooking() {
                         <SelectItem
                           key={t}
                           value={t}
-                          className={isBusy ? 'bg-yellow-200' : ''}
+                          style={isBusy ? { backgroundColor: '#fef08a' } : undefined}
                         >
                           {t}
                         </SelectItem>

--- a/src/app/admin/walk-in/BookingClient.tsx
+++ b/src/app/admin/walk-in/BookingClient.tsx
@@ -292,7 +292,7 @@ export default function AdminBooking() {
       for (let m = 0; m < dur; m += 15) {
         const d = new Date(date)
         d.setHours(0, 0, 0, 0)
-        slots.add(format(new Date(d.getTime() + minutes * 60000), 'HH:mm'))
+        slots.add(format(new Date(d.getTime() + minutes * 60000), "HH:mm"))
         minutes += 15
       }
     }
@@ -310,6 +310,23 @@ export default function AdminBooking() {
       mark(it.start, it.duration)
     }
     return slots
+  }
+
+  const hasBusyRange = (
+    busy: Set<string>,
+    start: string,
+    duration: number,
+  ) => {
+    let minutes = toMin(start)
+    for (let m = 0; m < duration; m += 15) {
+      const d = new Date(date)
+      d.setHours(0, 0, 0, 0)
+      if (busy.has(format(new Date(d.getTime() + minutes * 60000), "HH:mm"))) {
+        return true
+      }
+      minutes += 15
+    }
+    return false
   }
 
   const saveBooking = async () => {
@@ -729,16 +746,16 @@ export default function AdminBooking() {
                               </SelectTrigger>
                               <SelectContent>
                                 {timeOptionsFor(item.duration).map((t) => {
-                                  const busy = item.staffId ? busySlots(item.staffId, idx) : null
+                                  const busy = item.staffId
+                                    ? busySlots(item.staffId, idx)
+                                    : null
+                                  const isBusy =
+                                    busy && hasBusyRange(busy, t, item.duration)
                                   return (
                                     <SelectItem
                                       key={t}
                                       value={t}
-                                      style={
-                                        busy && busy.has(t)
-                                          ? { backgroundColor: '#fef08a' }
-                                          : undefined
-                                      }
+                                      className={isBusy ? 'bg-yellow-200' : ''}
                                     >
                                       {t}
                                     </SelectItem>
@@ -974,12 +991,15 @@ export default function AdminBooking() {
                   </SelectTrigger>
                   <SelectContent>
                     {allTimes.map((t) => {
-                      const busy = editItemStaffId ? busySlots(editItemStaffId, undefined, editItem.id) : null
+                      const busy = editItemStaffId
+                        ? busySlots(editItemStaffId, undefined, editItem.id)
+                        : null
+                      const isBusy = busy && hasBusyRange(busy, t, editItem.duration)
                       return (
                         <SelectItem
                           key={t}
                           value={t}
-                          style={busy && busy.has(t) ? { backgroundColor: '#fef08a' } : undefined}
+                          className={isBusy ? 'bg-yellow-200' : ''}
                         >
                           {t}
                         </SelectItem>

--- a/src/app/admin/walk-in/BookingClient.tsx
+++ b/src/app/admin/walk-in/BookingClient.tsx
@@ -745,28 +745,23 @@ export default function AdminBooking() {
                                 <SelectValue placeholder={item.staffId ? "Select time" : "Select staff first"} />
                               </SelectTrigger>
                               <SelectContent>
-                                {timeOptionsFor(item.duration).map((t) => {
-                                  const busy = item.staffId
-                                    ? busySlots(item.staffId, idx)
-                                    : null
-                                  const isBusy =
-                                    busy && hasBusyRange(busy, t, item.duration)
-                                  return (
-                                    <SelectItem
-                                      key={t}
-                                      value={t}
-                                      data-busy={isBusy ? 'true' : undefined}
-                                      className={isBusy ? '!bg-yellow-200 !text-black' : undefined}
-                                      style={
-                                        isBusy
-                                          ? { background: '#fef08a', backgroundColor: '#fef08a', color: '#000' }
-                                          : undefined
-                                      }
-                                    >
-                                      {t}
-                                    </SelectItem>
-                                  )
-                                })}
+                                {(() => {
+                                  const busy = item.staffId ? busySlots(item.staffId, idx) : null
+                                  return timeOptionsFor(item.duration).map((t) => {
+                                    const isBusy = busy && hasBusyRange(busy, t, item.duration)
+                                    return (
+                                      <SelectItem
+                                        key={t}
+                                        value={t}
+                                        data-busy={isBusy ? 'true' : undefined}
+                                        className={isBusy ? 'option-busy' : undefined}
+                                        style={isBusy ? { backgroundColor: '#fef08a', color: '#000' } : undefined}
+                                      >
+                                        {t}
+                                      </SelectItem>
+                                    )
+                                  })
+                                })()}
                               </SelectContent>
                             </Select>
                           </div>
@@ -996,27 +991,25 @@ export default function AdminBooking() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {allTimes.map((t) => {
+                    {(() => {
                       const busy = editItemStaffId
                         ? busySlots(editItemStaffId, undefined, editItem.id)
                         : null
-                      const isBusy = busy && hasBusyRange(busy, t, editItem.duration)
-                      return (
-                        <SelectItem
-                          key={t}
-                          value={t}
-                          data-busy={isBusy ? 'true' : undefined}
-                          className={isBusy ? '!bg-yellow-200 !text-black' : undefined}
-                          style={
-                            isBusy
-                              ? { background: '#fef08a', backgroundColor: '#fef08a', color: '#000' }
-                              : undefined
-                          }
-                        >
-                          {t}
-                        </SelectItem>
-                      )
-                    })}
+                      return allTimes.map((t) => {
+                        const isBusy = busy && hasBusyRange(busy, t, editItem.duration)
+                        return (
+                          <SelectItem
+                            key={t}
+                            value={t}
+                            data-busy={isBusy ? 'true' : undefined}
+                            className={isBusy ? 'option-busy' : undefined}
+                            style={isBusy ? { backgroundColor: '#fef08a', color: '#000' } : undefined}
+                          >
+                            {t}
+                          </SelectItem>
+                        )
+                      })
+                    })()}
                   </SelectContent>
                 </Select>
               </div>

--- a/src/app/admin/walk-in/BookingClient.tsx
+++ b/src/app/admin/walk-in/BookingClient.tsx
@@ -756,7 +756,7 @@ export default function AdminBooking() {
                                       key={t}
                                       value={t}
                                       data-busy={isBusy ? 'true' : undefined}
-                                      className={isBusy ? 'bg-yellow-100 text-black' : undefined}
+                                      className={isBusy ? '!bg-yellow-200 !text-black' : undefined}
                                       style={
                                         isBusy
                                           ? { background: '#fef08a', backgroundColor: '#fef08a', color: '#000' }
@@ -1006,7 +1006,7 @@ export default function AdminBooking() {
                           key={t}
                           value={t}
                           data-busy={isBusy ? 'true' : undefined}
-                          className={isBusy ? 'bg-yellow-100 text-black' : undefined}
+                          className={isBusy ? '!bg-yellow-200 !text-black' : undefined}
                           style={
                             isBusy
                               ? { background: '#fef08a', backgroundColor: '#fef08a', color: '#000' }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,7 +73,8 @@ input[type="number"] {
 }
 
 /* Highlight busy time slots in native selects */
-select option[data-busy="true"] {
+select option[data-busy="true"],
+.option-busy {
   background-color: #fef08a !important;
   color: #000 !important;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -74,7 +74,7 @@ input[type="number"] {
 
 /* Highlight busy time slots in native selects */
 select option[data-busy="true"] {
-  background-color: #fef08a;
-  color: #000;
+  background-color: #fef08a !important;
+  color: #000 !important;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -72,3 +72,9 @@ input[type="number"] {
   transform: translateY(-5px);
 }
 
+/* Highlight busy time slots in native selects */
+select option[data-busy="true"] {
+  background-color: #fef08a;
+  color: #000;
+}
+


### PR DESCRIPTION
## Summary
- highlight time options that overlap with existing bookings
- show service workload infographic for each staff member

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68826bea45e48325a31179fde105a280