### PR TITLE
Implement dynamic hero tabs

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,8 +30,7 @@ model User {
   createdAt   DateTime  @default(now()) @db.Timestamp(3)
   updatedAt   DateTime  @default(now()) @updatedAt @db.Timestamp(3)
 
-  bookings    Booking[]
-
+  bookings Booking[]
 }
 
 model Branch {
@@ -62,7 +61,6 @@ model Coupon {
   isActive       Boolean  @default(true)
   createdAt      DateTime @default(now()) @db.Timestamp(3)
   updatedAt      DateTime @default(now()) @updatedAt @db.Timestamp(3)
-
 }
 
 model ServiceCategory {
@@ -125,7 +123,7 @@ model ServiceNew {
   category    ServiceCategory @relation(fields: [categoryId], references: [id])
   name        String
   caption     String?
-  description String?  @db.LongText
+  description String?         @db.LongText
   imageUrl    String?
   images      ServiceImage[]
   tiers       ServiceTier[]
@@ -140,6 +138,7 @@ model ServiceTier {
   offerPrice   Float?
   duration     Int?
   priceHistory ServiceTierPriceHistory[]
+  heroTabs     HeroTabVariant[]
 }
 
 model ServiceTierPriceHistory {
@@ -156,17 +155,17 @@ model ServiceTierPriceHistory {
 }
 
 model Booking {
-  id        String   @id @default(uuid())
-  customer  String?  @db.VarChar(191)
-  phone     String?  @db.VarChar(191)
-  gender    String   @db.VarChar(191)
+  id        String        @id @default(uuid())
+  customer  String?       @db.VarChar(191)
+  phone     String?       @db.VarChar(191)
+  gender    String        @db.VarChar(191)
   age       Int?
-  staffId   String   @db.VarChar(191)
-  staff     User     @relation(fields: [staffId], references: [id])
-  date      String   @db.VarChar(10)
-  start     String   @db.VarChar(5)
-  color     String   @db.VarChar(191)
-  createdAt DateTime @default(now()) @db.Timestamp(3)
+  staffId   String        @db.VarChar(191)
+  staff     User          @relation(fields: [staffId], references: [id])
+  date      String        @db.VarChar(10)
+  start     String        @db.VarChar(5)
+  color     String        @db.VarChar(191)
+  createdAt DateTime      @default(now()) @db.Timestamp(3)
   items     BookingItem[]
 }
 
@@ -184,20 +183,44 @@ model BookingItem {
 }
 
 model Billing {
-  id             String   @id @default(uuid())
-  billId         String   @db.VarChar(191)
-  customerId     String?  @db.VarChar(191)
-  phone          String?  @db.VarChar(191)
-  billingName    String?  @db.VarChar(191)
-  billingAddress String?  @db.VarChar(191)
-  category       String   @db.VarChar(191)
-  service        String   @db.VarChar(191)
-  variant        String   @db.VarChar(191)
+  id             String    @id @default(uuid())
+  billId         String    @db.VarChar(191)
+  customerId     String?   @db.VarChar(191)
+  phone          String?   @db.VarChar(191)
+  billingName    String?   @db.VarChar(191)
+  billingAddress String?   @db.VarChar(191)
+  category       String    @db.VarChar(191)
+  service        String    @db.VarChar(191)
+  variant        String    @db.VarChar(191)
   amountBefore   Float
   amountAfter    Float
-  voucherCode    String?  @db.VarChar(191)
-  paymentMethod  String   @default("cash") @db.VarChar(191)
+  voucherCode    String?   @db.VarChar(191)
+  paymentMethod  String    @default("cash") @db.VarChar(191)
   paidAt         DateTime? @db.Timestamp(3)
-  scheduledAt    DateTime @db.Timestamp(3)
-  createdAt      DateTime @default(now()) @db.Timestamp(3)
+  scheduledAt    DateTime  @db.Timestamp(3)
+  createdAt      DateTime  @default(now()) @db.Timestamp(3)
+}
+
+model HeroTab {
+  id              String  @id @default(uuid())
+  name            String
+  iconUrl         String?
+  backgroundUrl   String?
+  videoSrc        String?
+  heroTitle       String
+  heroDescription String?
+  buttonLabel     String?
+  buttonLink      String?
+  order           Int     @default(0)
+
+  variants HeroTabVariant[]
+}
+
+model HeroTabVariant {
+  heroTabId     String
+  heroTab       HeroTab     @relation(fields: [heroTabId], references: [id])
+  serviceTierId String
+  serviceTier   ServiceTier @relation(fields: [serviceTierId], references: [id])
+
+  @@id([heroTabId, serviceTierId])
 }

--- a/src/app/admin/hero-tabs/page.tsx
+++ b/src/app/admin/hero-tabs/page.tsx
@@ -1,0 +1,184 @@
+'use client'
+import { useEffect, useState } from 'react'
+import WysiwygEditor from '@/app/components/WysiwygEditor'
+import { Pencil, Trash2 } from 'lucide-react'
+
+interface HeroTab {
+  id: string
+  name: string
+  iconUrl?: string
+  backgroundUrl?: string
+  videoSrc?: string
+  heroTitle: string
+  heroDescription?: string
+  buttonLabel?: string
+  buttonLink?: string
+  order?: number
+  variantIds: string[]
+}
+
+interface VariantOption {
+  id: string
+  variantName: string
+  serviceName: string
+  categoryName: string
+}
+
+export default function HeroTabsPage() {
+  const empty: HeroTab = {
+    id: '',
+    name: '',
+    iconUrl: '',
+    backgroundUrl: '',
+    videoSrc: '',
+    heroTitle: '',
+    heroDescription: '',
+    buttonLabel: '',
+    buttonLink: '',
+    order: 0,
+    variantIds: [],
+  }
+  const [tabs, setTabs] = useState<HeroTab[]>([])
+  const [form, setForm] = useState<HeroTab>(empty)
+  const [editing, setEditing] = useState(false)
+  const [variants, setVariants] = useState<VariantOption[]>([])
+
+  const load = async () => {
+    const res = await fetch('/api/admin/hero-tabs')
+    const data = await res.json()
+    setTabs(data)
+  }
+
+  const loadVariants = async () => {
+    const res = await fetch('/api/admin/service-variants/all')
+    const data = await res.json()
+    setVariants(data)
+  }
+
+  useEffect(() => {
+    load()
+    loadVariants()
+  }, [])
+
+  const handleImage = async (e: React.ChangeEvent<HTMLInputElement>, field: string) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const fd = new FormData()
+    fd.append('file', file)
+    const res = await fetch('/api/upload', { method: 'POST', body: fd })
+    const data = await res.json()
+    setForm({ ...form, [field]: data.url })
+  }
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const method = editing ? 'PUT' : 'POST'
+    await fetch('/api/admin/hero-tabs', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+    setForm(empty)
+    setEditing(false)
+    load()
+  }
+
+  const edit = (t: HeroTab) => {
+    setForm({ ...t })
+    setEditing(true)
+  }
+
+  const del = async (id: string) => {
+    if (!confirm('Delete this tab?')) return
+    await fetch('/api/admin/hero-tabs', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    })
+    load()
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Hero Tabs</h1>
+      <form onSubmit={save} className="space-y-4 bg-white p-6 rounded shadow border mb-6">
+        <div>
+          <label className="block font-medium mb-1">Name</label>
+          <input className="w-full p-2 rounded border" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Hero Title</label>
+          <input className="w-full p-2 rounded border" value={form.heroTitle} onChange={e => setForm({ ...form, heroTitle: e.target.value })} required />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Hero Description</label>
+          <WysiwygEditor value={form.heroDescription || ''} onChange={val => setForm({ ...form, heroDescription: val })} />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Icon Image</label>
+          <input type="file" accept="image/*" onChange={e => handleImage(e, 'iconUrl')} />
+          {form.iconUrl && <img src={form.iconUrl} className="h-16 mt-2" />}
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Background Image</label>
+          <input type="file" accept="image/*" onChange={e => handleImage(e, 'backgroundUrl')} />
+          {form.backgroundUrl && <img src={form.backgroundUrl} className="h-16 mt-2" />}
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Video Source</label>
+          <input type="file" accept="video/*" onChange={e => handleImage(e, 'videoSrc')} />
+          {form.videoSrc && <video src={form.videoSrc} className="h-16 mt-2" controls />}
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Button Label</label>
+          <input className="w-full p-2 rounded border" value={form.buttonLabel || ''} onChange={e => setForm({ ...form, buttonLabel: e.target.value })} />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Button Link</label>
+          <input className="w-full p-2 rounded border" value={form.buttonLink || ''} onChange={e => setForm({ ...form, buttonLink: e.target.value })} />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Order</label>
+          <input type="number" className="w-full p-2 rounded border" value={form.order ?? 0} onChange={e => setForm({ ...form, order: parseInt(e.target.value) })} />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Service Variants</label>
+          <select multiple className="w-full p-2 border rounded" value={form.variantIds} onChange={e => {
+            const options = Array.from(e.target.selectedOptions).map(o => o.value)
+            setForm({ ...form, variantIds: options })
+          }}>
+            {variants.map(v => (
+              <option key={v.id} value={v.id}>{`${v.categoryName} - ${v.serviceName} (${v.variantName})`}</option>
+            ))}
+          </select>
+        </div>
+        <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">{editing ? 'Update' : 'Add'} Tab</button>
+      </form>
+      <table className="w-full text-left text-sm bg-white rounded shadow border">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2">Name</th>
+            <th className="px-3 py-2">Order</th>
+            <th className="px-3 py-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tabs.map(t => (
+            <tr key={t.id} className="border-t">
+              <td className="px-3 py-2">{t.name}</td>
+              <td className="px-3 py-2">{t.order ?? 0}</td>
+              <td className="flex gap-2 px-3 py-2">
+                <button className="flex items-center gap-1 px-2 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded" onClick={() => edit(t)}>
+                  <Pencil className="h-4 w-4" /> Edit
+                </button>
+                <button className="flex items-center gap-1 px-2 py-1 text-sm bg-red-600 hover:bg-red-700 text-white rounded" onClick={() => del(t.id)}>
+                  <Trash2 className="h-4 w-4" /> Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -17,6 +17,7 @@ import {
   MdEvent,
   MdReceipt,
   MdMenu,
+  MdViewCarousel,
 } from 'react-icons/md'
 import type { IconType } from 'react-icons'
 
@@ -41,6 +42,7 @@ const sections: {
       },
       { href: '/admin/services', label: 'Services', icon: MdDesignServices },
       { href: '/admin/variant-price-history', label: 'Variant Price History', icon: MdHistory },
+      { href: '/admin/hero-tabs', label: 'Hero Tabs', icon: MdViewCarousel },
       { href: '/admin/walk-in', label: 'Walk-in', icon: MdEvent },
       { href: '/admin/billing', label: 'Billing', icon: MdReceipt },
       { href: '/admin/billing-history', label: 'Billing History', icon: MdHistory },

--- a/src/app/api/admin/hero-tabs/route.ts
+++ b/src/app/api/admin/hero-tabs/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const tabs = await prisma.heroTab.findMany({
+    orderBy: { order: 'asc' },
+    include: { variants: true },
+  })
+  const result = tabs.map(t => ({
+    ...t,
+    variantIds: t.variants.map(v => v.serviceTierId),
+  }))
+  return NextResponse.json(result)
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const tab = await prisma.heroTab.create({
+    data: {
+      name: data.name,
+      iconUrl: data.iconUrl || null,
+      backgroundUrl: data.backgroundUrl || null,
+      videoSrc: data.videoSrc || null,
+      heroTitle: data.heroTitle,
+      heroDescription: data.heroDescription || null,
+      buttonLabel: data.buttonLabel || null,
+      buttonLink: data.buttonLink || null,
+      order: data.order ?? 0,
+      variants: {
+        create: Array.isArray(data.variantIds)
+          ? data.variantIds.map((id: string) => ({ serviceTierId: id }))
+          : [],
+      },
+    },
+  })
+  return NextResponse.json(tab)
+}
+
+export async function PUT(req: NextRequest) {
+  const data = await req.json()
+  if (!data.id) return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+
+  await prisma.heroTabVariant.deleteMany({ where: { heroTabId: data.id } })
+
+  const tab = await prisma.heroTab.update({
+    where: { id: data.id },
+    data: {
+      name: data.name,
+      iconUrl: data.iconUrl || null,
+      backgroundUrl: data.backgroundUrl || null,
+      videoSrc: data.videoSrc || null,
+      heroTitle: data.heroTitle,
+      heroDescription: data.heroDescription || null,
+      buttonLabel: data.buttonLabel || null,
+      buttonLink: data.buttonLink || null,
+      order: data.order ?? 0,
+      variants: {
+        create: Array.isArray(data.variantIds)
+          ? data.variantIds.map((id: string) => ({ serviceTierId: id }))
+          : [],
+      },
+    },
+  })
+  return NextResponse.json(tab)
+}
+
+export async function DELETE(req: NextRequest) {
+  const { id } = await req.json()
+  await prisma.heroTabVariant.deleteMany({ where: { heroTabId: id } })
+  await prisma.heroTab.delete({ where: { id } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/hero-tabs/[id]/route.ts
+++ b/src/app/api/hero-tabs/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const { id } = params
+  const tab = await prisma.heroTab.findUnique({
+    where: { id },
+    include: {
+      variants: {
+        include: {
+          serviceTier: {
+            include: { service: { include: { category: true } } },
+          },
+        },
+      },
+    },
+  })
+  if (!tab) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  const now = new Date()
+  const variants = await Promise.all(
+    tab.variants.map(async (v) => {
+      const price = await prisma.serviceTierPriceHistory.findFirst({
+        where: {
+          tierId: v.serviceTierId,
+          startDate: { lte: now },
+          OR: [{ endDate: null }, { endDate: { gt: now } }],
+        },
+        orderBy: { startDate: 'desc' },
+      })
+      return {
+        id: v.serviceTier.id,
+        name: v.serviceTier.name,
+        serviceName: v.serviceTier.service.name,
+        categoryName: v.serviceTier.service.category.name,
+        price:
+          price?.offerPrice ?? price?.actualPrice ?? v.serviceTier.offerPrice ?? v.serviceTier.actualPrice,
+      }
+    })
+  )
+  return NextResponse.json({
+    id: tab.id,
+    name: tab.name,
+    iconUrl: tab.iconUrl,
+    backgroundUrl: tab.backgroundUrl,
+    videoSrc: tab.videoSrc,
+    heroTitle: tab.heroTitle,
+    heroDescription: tab.heroDescription,
+    buttonLabel: tab.buttonLabel,
+    buttonLink: tab.buttonLink,
+    order: tab.order,
+    variants,
+  })
+}

--- a/src/app/api/hero-tabs/route.ts
+++ b/src/app/api/hero-tabs/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const tabs = await prisma.heroTab.findMany({
+    orderBy: { order: 'asc' },
+    include: {
+      variants: {
+        include: {
+          serviceTier: {
+            include: {
+              service: { include: { category: true } },
+            },
+          },
+        },
+      },
+    },
+  })
+  const now = new Date()
+  const result = await Promise.all(
+    tabs.map(async (t) => {
+      const variants = await Promise.all(
+        t.variants.map(async (v) => {
+          const price = await prisma.serviceTierPriceHistory.findFirst({
+            where: {
+              tierId: v.serviceTierId,
+              startDate: { lte: now },
+              OR: [{ endDate: null }, { endDate: { gt: now } }],
+            },
+            orderBy: { startDate: 'desc' },
+          })
+          return {
+            id: v.serviceTier.id,
+            name: v.serviceTier.name,
+            serviceName: v.serviceTier.service.name,
+            categoryName: v.serviceTier.service.category.name,
+            price:
+              price?.offerPrice ?? price?.actualPrice ?? v.serviceTier.offerPrice ?? v.serviceTier.actualPrice,
+          }
+        })
+      )
+      return {
+        id: t.id,
+        name: t.name,
+        iconUrl: t.iconUrl,
+        backgroundUrl: t.backgroundUrl,
+        videoSrc: t.videoSrc,
+        heroTitle: t.heroTitle,
+        heroDescription: t.heroDescription,
+        buttonLabel: t.buttonLabel,
+        buttonLink: t.buttonLink,
+        order: t.order,
+        variants,
+      }
+    })
+  )
+  return NextResponse.json(result)
+}

--- a/src/app/hero/[id]/page.tsx
+++ b/src/app/hero/[id]/page.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link'
+import { headers } from 'next/headers'
+
+export default async function HeroTabPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headers().get('host')}`
+  const res = await fetch(`${baseUrl}/api/hero-tabs/${id}`, { cache: 'no-store' })
+  if (!res.ok) return <div className="p-8 text-red-500">Unable to load tab</div>
+  const tab = await res.json()
+
+  return (
+    <div className="max-w-3xl mx-auto my-12 bg-gray-900 rounded-2xl p-8 text-gray-100">
+      <h1 className="text-3xl font-bold mb-4" style={{ color: '#41eb70' }}>{tab.heroTitle}</h1>
+      {tab.heroDescription && (
+        <div className="prose prose-invert mb-6" dangerouslySetInnerHTML={{ __html: tab.heroDescription }} />
+      )}
+      {tab.variants && tab.variants.length > 0 && (
+        <div>
+          <h2 className="text-2xl font-semibold mb-4" style={{ color: '#41eb70' }}>Featured Services</h2>
+          <ul className="space-y-3">
+            {tab.variants.map((v: any) => (
+              <li key={v.id} className="flex items-center justify-between bg-gray-800 p-4 rounded-xl">
+                <span>{v.serviceName} - {v.name}</span>
+                <span className="font-bold" style={{ color: '#41eb70' }}>₹{v.price}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="mt-8">
+        <Link href="/" className="text-green-400 underline">Back to Home</Link>
+      </div>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,133 +30,6 @@ const TIER_LABELS = {
   },
 }
 
-const HERO_CATEGORIES = [
-  {
-    id: "home",
-    name: "Home",
-    iconUrl: "/icons/home-green-gray.png",
-    backgroundImage: "/salon_bg_poster.jpg",
-    videoSrc: "/home-bg-video.mp4",
-    heroTitle: "Welcome to Greens Beauty Salon",
-    heroDescription: "Here Beauty Begins with Peace of Mind", // Re-added description
-    buttonLink: "#services",
-    heroTitleColor: "text-white",
-    heroDescriptionColor: "text-white",
-    buttonBgColor: "bg-white",
-    buttonTextColor: "text-[#522B8C]",
-  },
-  {
-    id: "family-salon",
-    name: "Family Salon",
-    iconUrl: "/icons/users-green-gray.png",
-    backgroundImage: "/family-salon-interior.png",
-    heroTitle: "Family Salon",
-    heroDescription:
-      "Complete care for the whole family, offering a wide range of services for all ages and preferences.",
-    buttonLink: "#services",
-    heroTitleColor: "text-white",
-    heroDescriptionColor: "text-white",
-    buttonBgColor: "bg-white",
-    buttonTextColor: "text-[#522B8C]",
-  },
-  {
-    id: "beauty-studio",
-    name: "Beauty Studio",
-    iconUrl: "/icons/sparkles-green-gray.png",
-    backgroundImage: "/beauty-studio-glam.png",
-    heroTitle: "Beauty Studio",
-    heroDescription:
-      "Premium beauty treatments including facials, makeup, and skincare for a radiant and refreshed look.",
-    buttonLink: "#services",
-    heroTitleColor: "text-white",
-    heroDescriptionColor: "text-white",
-    buttonBgColor: "bg-white",
-    buttonTextColor: "text-[#522B8C]",
-  },
-  {
-    id: "celebrity-salon",
-    name: "Celebrity Salon",
-    iconUrl: "/icons/crown-green-gray.png",
-    backgroundImage: "/celebrity-hair-styling.png",
-    heroTitle: "Celebrity Salon",
-    heroDescription:
-      "Experience luxury styling and exclusive services fit for a celebrity, with top-tier products and experts.",
-    buttonLink: "#services",
-    heroTitleColor: "text-white",
-    heroDescriptionColor: "text-white",
-    buttonBgColor: "bg-white",
-    buttonTextColor: "text-[#522B8C]",
-  },
-  {
-    id: "makeover-studio",
-    name: "Makeover Studio",
-    iconUrl: "/icons/paintbrush-green-gray.png",
-    backgroundImage: "/makeover-studio-transformation.png",
-    heroTitle: "Makeover Studio",
-    heroDescription: "Complete transformation services, from hair to makeup, for any occasion or personal desire.",
-    buttonLink: "#services",
-    heroTitleColor: "text-white",
-    heroDescriptionColor: "text-white",
-    buttonBgColor: "bg-white",
-    buttonTextColor: "text-[#522B8C]",
-  },
-  {
-    id: "bridal-lounge",
-    name: "Bridal Lounge",
-    iconUrl: "/icons/heart-green-gray.png",
-    backgroundImage: "/bridal-makeup-lounge.png",
-    heroTitle: "Bridal Lounge",
-    heroDescription:
-      "Specialized bridal services to make your big day unforgettable, ensuring you look your absolute best.",
-    buttonLink: "#services",
-    heroTitleColor: "text-white",
-    heroDescriptionColor: "text-white",
-    buttonBgColor: "bg-white",
-    buttonTextColor: "text-[#522B8C]",
-  },
-  {
-    id: "floral-studio",
-    name: "Floral Studio",
-    iconUrl: "/icons/flower-green-gray.png",
-    backgroundImage: "/floral-arrangement-studio.png",
-    heroTitle: "Floral Studio",
-    heroDescription:
-      "Artistic floral designs for all your events and special moments, crafted with passion and precision.",
-    buttonLink: "#services",
-    heroTitleColor: "text-white",
-    heroDescriptionColor: "text-white",
-    buttonBgColor: "bg-white",
-    buttonTextColor: "text-[#522B8C]",
-  },
-  {
-    id: "floral-decor",
-    name: "Floral Decor",
-    iconUrl: "/icons/leaf-green-gray.png",
-    backgroundImage: "/elegant-floral-event.png",
-    heroTitle: "Floral Decor",
-    heroDescription:
-      "Comprehensive event decoration services with stunning floral arrangements to elevate any celebration.",
-    buttonLink: "#services",
-    heroTitleColor: "text-white",
-    heroDescriptionColor: "text-white",
-    buttonBgColor: "bg-white",
-    buttonTextColor: "text-[#522B8C]",
-  },
-  {
-    id: "event-portfolio",
-    name: "Event Portfolio",
-    iconUrl: "/icons/gallery-green-gray.png",
-    backgroundImage: "/event.jpg",
-    heroTitle: "Event Portfolio",
-    heroDescription:
-      "Complete event solutions, from meticulous planning to flawless execution, for seamless celebrations.",
-    buttonLink: "#services",
-    heroTitleColor: "text-white",
-    heroDescriptionColor: "text-white",
-    buttonBgColor: "bg-white",
-    buttonTextColor: "text-[#522B8C]",
-  },
-]
 
 const WOMEN_SERVICES = [
   "Shahnaz Husain Facials",
@@ -186,7 +59,8 @@ export default function HomePage() {
   const [loading, setLoading] = useState(true)
   const [expandedCat, setExpandedCat] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [selectedHeroCategory, setSelectedHeroCategory] = useState<string>("home") // Default to 'home'
+  const [selectedHeroCategory, setSelectedHeroCategory] = useState<string>("") // default empty until load
+  const [heroTabs, setHeroTabs] = useState<any[]>([])
   const [selectedGenderTab, setSelectedGenderTab] = useState<"WOMEN" | "MEN">("WOMEN")
 
   useEffect(() => {
@@ -206,6 +80,17 @@ export default function HomePage() {
       })
   }, [])
 
+  useEffect(() => {
+    fetch('/api/hero-tabs')
+      .then(res => res.json())
+      .then((data) => {
+        setHeroTabs(Array.isArray(data) ? data : [])
+        if (Array.isArray(data) && data.length > 0) {
+          setSelectedHeroCategory(data[0].id)
+        }
+      })
+  }, [])
+
   const subServices = useMemo(() => {
     if (!expandedCat) return []
     const cat = categories.find((c) => c.id === expandedCat)
@@ -217,8 +102,9 @@ export default function HomePage() {
   }
 
   const currentHeroContent = useMemo(() => {
-    return HERO_CATEGORIES.find((cat) => cat.id === selectedHeroCategory) || HERO_CATEGORIES[0]
-  }, [selectedHeroCategory])
+    if (heroTabs.length === 0) return {} as any
+    return heroTabs.find((cat) => cat.id === selectedHeroCategory) || heroTabs[0]
+  }, [selectedHeroCategory, heroTabs])
 
   const currentGenderServices = useMemo(() => {
     return selectedGenderTab === "WOMEN" ? WOMEN_SERVICES : MEN_SERVICES
@@ -234,7 +120,7 @@ export default function HomePage() {
         {/* Categories Section (Light Grey Bar) */}
         <div className="w-full overflow-x-auto py-2 scrollbar-hide bg-gray-100 shadow-lg">
           <div className="flex gap-0 justify-start px-4 md:justify-center">
-            {HERO_CATEGORIES.filter((cat) => cat.id !== "home").map((cat, idx) => (
+            {heroTabs.filter((cat) => cat.id !== "home").map((cat, idx) => (
               <motion.button
                 key={cat.id}
                 className={`flex flex-col items-center justify-center p-3 min-w-[100px] text-center transition-all duration-300 relative
@@ -244,7 +130,7 @@ export default function HomePage() {
                       : "bg-transparent text-gray-600 hover:bg-gray-200"
                   }
                   ${idx === 0 ? "rounded-tl-lg" : ""}
-                  ${idx === HERO_CATEGORIES.length - 1 ? "rounded-tr-lg" : ""}
+                  ${idx === heroTabs.length - 1 ? "rounded-tr-lg" : ""}
                 `}
                 onClick={() => setSelectedHeroCategory(cat.id)}
                 whileHover={{ scale: 1.05, y: -5 }}
@@ -283,13 +169,13 @@ export default function HomePage() {
                 muted
                 playsInline
                 className="absolute inset-0 w-full h-full object-cover"
-                poster={currentHeroContent.backgroundImage}
+                poster={currentHeroContent.backgroundUrl}
               >
                 <source src={currentHeroContent.videoSrc} type="video/mp4" />
               </video>
             ) : (
               <Image
-                src={currentHeroContent.backgroundImage || "/placeholder.svg"}
+                src={currentHeroContent.backgroundUrl || "/placeholder.svg"}
                 alt={currentHeroContent.name || "Background"}
                 layout="fill"
                 objectFit="cover"
@@ -301,20 +187,20 @@ export default function HomePage() {
             <div className="absolute inset-x-0 bottom-0 h-[50%] bg-gradient-to-t from-gray-900 to-transparent z-10" />{" "}
             {/* Increased height and intensity */}
             <div className="relative z-20 text-white max-w-3xl space-y-2">
-              <h1 className={`text-2xl md:text-3xl font-bold tracking-wide ${currentHeroContent.heroTitleColor}`}>
+              <h1 className="text-2xl md:text-3xl font-bold tracking-wide text-white">
                 {currentHeroContent.heroTitle}
               </h1>
               {selectedHeroCategory === "home" ? (
-                <p className={`text-base md:text-lg leading-relaxed ${currentHeroContent.heroDescriptionColor}`}>
+                <p className="text-base md:text-lg leading-relaxed text-white">
                   {currentHeroContent.heroDescription}
                 </p>
               ) : (
                 <Link
-                  href={currentHeroContent.buttonLink || "#"}
+                  href={currentHeroContent.buttonLink || `/hero/${currentHeroContent.id}`}
                   className="inline-flex px-8 py-2 font-semibold text-md shadow-lg transition-all duration-300 bg-transparent border-white text-[#ffffff] hover:scale-105"
                   style={{ border: "2px solid #fff" }}
                 >
-                  {"24 items | Rs. 300 onwards >"}
+                  {currentHeroContent.buttonLabel || 'Explore Now >'}
                 </Link>
               )}
             </div>


### PR DESCRIPTION
## Summary
- model HeroTab and HeroTabVariant in Prisma schema
- add admin API for CRUD on hero tabs
- expose public API for hero tabs
- add admin page to manage hero tabs
- add hero tab detail page
- fetch hero tab data on home page
- link Hero Tabs page from admin menu

## Testing
- `npm run lint` *(fails: various lint errors)*
- `npm run build`
- `npx prisma db push` *(fails: can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_68830cd4ed708325be0996c3b7a617ef