### PR TITLE
Use local upload for hero tab images

### DIFF
--- a/src/app/admin/hero-tabs/page.tsx
+++ b/src/app/admin/hero-tabs/page.tsx
@@ -65,7 +65,10 @@ export default function HeroTabsPage() {
     if (!file) return
     const fd = new FormData()
     fd.append('file', file)
-    const res = await fetch('/api/upload', { method: 'POST', body: fd })
+    const endpoint = file.type.startsWith('image/')
+      ? '/api/upload-local'
+      : '/api/upload'
+    const res = await fetch(endpoint, { method: 'POST', body: fd })
     const data = await res.json()
     setForm({ ...form, [field]: data.url })
   }


### PR DESCRIPTION
## Summary
- update hero tabs admin page to store images locally instead of using Cloudinary

## Testing
- `npm install`
- `npm run lint` *(fails: multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68833794fc588325bde649b739ab13f2