### PR TITLE
Use local uploads for hero tab images

### DIFF
--- a/src/app/admin/hero-tabs/page.tsx
+++ b/src/app/admin/hero-tabs/page.tsx
@@ -60,12 +60,18 @@ export default function HeroTabsPage() {
     loadVariants()
   }, [])
 
-  const handleImage = async (e: React.ChangeEvent<HTMLInputElement>, field: string) => {
+  const handleImage = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+    field: string,
+  ) => {
     const file = e.target.files?.[0]
     if (!file) return
     const fd = new FormData()
     fd.append('file', file)
-    const res = await fetch('/api/upload', { method: 'POST', body: fd })
+    const endpoint = file.type.startsWith('image/')
+      ? '/api/upload-local'
+      : '/api/upload'
+    const res = await fetch(endpoint, { method: 'POST', body: fd })
     const data = await res.json()
     setForm({ ...form, [field]: data.url })
   }

--- a/src/app/api/hero-tabs/[id]/route.ts
+++ b/src/app/api/hero-tabs/[id]/route.ts
@@ -1,8 +1,11 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
-export async function GET(req: Request, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   const { id } = params
+  const host = req.headers.get('host')
+  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https'
+  const base = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`
   const tab = await prisma.heroTab.findUnique({
     where: { id },
     include: {
@@ -37,12 +40,15 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
       }
     })
   )
+  const iconUrl = tab.iconUrl && tab.iconUrl.startsWith('/') ? `${base}${tab.iconUrl}` : tab.iconUrl
+  const backgroundUrl = tab.backgroundUrl && tab.backgroundUrl.startsWith('/') ? `${base}${tab.backgroundUrl}` : tab.backgroundUrl
+  const videoSrc = tab.videoSrc && tab.videoSrc.startsWith('/') ? `${base}${tab.videoSrc}` : tab.videoSrc
   return NextResponse.json({
     id: tab.id,
     name: tab.name,
-    iconUrl: tab.iconUrl,
-    backgroundUrl: tab.backgroundUrl,
-    videoSrc: tab.videoSrc,
+    iconUrl,
+    backgroundUrl,
+    videoSrc,
     heroTitle: tab.heroTitle,
     heroDescription: tab.heroDescription,
     buttonLabel: tab.buttonLabel,

--- a/src/app/api/hero-tabs/route.ts
+++ b/src/app/api/hero-tabs/route.ts
@@ -1,7 +1,10 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const host = req.headers.get('host')
+  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https'
+  const base = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`
   const tabs = await prisma.heroTab.findMany({
     orderBy: { order: 'asc' },
     include: {
@@ -39,12 +42,15 @@ export async function GET() {
           }
         })
       )
+      const iconUrl = t.iconUrl && t.iconUrl.startsWith('/') ? `${base}${t.iconUrl}` : t.iconUrl
+      const backgroundUrl = t.backgroundUrl && t.backgroundUrl.startsWith('/') ? `${base}${t.backgroundUrl}` : t.backgroundUrl
+      const videoSrc = t.videoSrc && t.videoSrc.startsWith('/') ? `${base}${t.videoSrc}` : t.videoSrc
       return {
         id: t.id,
         name: t.name,
-        iconUrl: t.iconUrl,
-        backgroundUrl: t.backgroundUrl,
-        videoSrc: t.videoSrc,
+        iconUrl,
+        backgroundUrl,
+        videoSrc,
         heroTitle: t.heroTitle,
         heroDescription: t.heroDescription,
         buttonLabel: t.buttonLabel,


### PR DESCRIPTION
## Summary
- route hero tab image uploads to the local API
- prefix icon/background/video URLs with the site base URL in hero tab API responses

## Testing
- `npm install`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68833794fc588325bde649b739ab13f2