### PR TITLE
Fix hero tab image upload handling

### DIFF
--- a/src/app/admin/hero-tabs/page.tsx
+++ b/src/app/admin/hero-tabs/page.tsx
@@ -68,10 +68,7 @@ export default function HeroTabsPage() {
     if (!file) return
     const fd = new FormData()
     fd.append('file', file)
-    const endpoint = file.type.startsWith('image/')
-      ? '/api/upload-local'
-      : '/api/upload'
-    const res = await fetch(endpoint, { method: 'POST', body: fd })
+    const res = await fetch('/api/upload', { method: 'POST', body: fd })
     const data = await res.json()
     setForm({ ...form, [field]: data.url })
   }
@@ -164,6 +161,7 @@ export default function HeroTabsPage() {
         <thead className="bg-gray-50">
           <tr>
             <th className="px-3 py-2">Name</th>
+            <th className="px-3 py-2">Icon</th>
             <th className="px-3 py-2">Order</th>
             <th className="px-3 py-2">Actions</th>
           </tr>
@@ -172,6 +170,7 @@ export default function HeroTabsPage() {
           {tabs.map(t => (
             <tr key={t.id} className="border-t">
               <td className="px-3 py-2">{t.name}</td>
+              <td className="px-3 py-2">{t.iconUrl ? <img src={t.iconUrl} className="h-10"/> : '—'}</td>
               <td className="px-3 py-2">{t.order ?? 0}</td>
               <td className="flex gap-2 px-3 py-2">
                 <button className="flex items-center gap-1 px-2 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded" onClick={() => edit(t)}>

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -17,14 +17,16 @@ export async function POST(req: NextRequest) {
     if (!file)
       return NextResponse.json({ error: "No file" }, { status: 400 });
 
-    if (!file.type.startsWith("image/"))
+    const isVideo = file.type.startsWith("video/");
+    const isImage = file.type.startsWith("image/");
+    if (!isImage && !isVideo)
       return NextResponse.json({ error: "Invalid file type" }, { status: 400 });
 
     const buffer = Buffer.from(await file.arrayBuffer());
 
     const uploaded: UploadApiResponse = await new Promise((resolve, reject) => {
       const stream = cloudinary.uploader.upload_stream(
-        { resource_type: "image", folder: "services" },
+        { resource_type: isVideo ? "video" : "image", folder: "services" },
         (err, result) => {
           if (err || !result) return reject(err);
           resolve(result);


### PR DESCRIPTION
## Summary
- support uploading videos or images via Cloudinary
- upload hero tab media with `/api/upload`
- show hero tab icon in admin list

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884a7d5448c8325a1774efa77f3864c