### PR TITLE
Improve hero tabs loading and optimize API

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   // Only standard options here, e.g.:
   reactStrictMode: true,
+  images: {
+    domains: ['res.cloudinary.com'],
+  },
   eslint: {
     // ignore lint errors during production build until project cleanup
     ignoreDuringBuilds: true,

--- a/src/app/admin/hero-tabs/page.tsx
+++ b/src/app/admin/hero-tabs/page.tsx
@@ -68,10 +68,7 @@ export default function HeroTabsPage() {
     if (!file) return
     const fd = new FormData()
     fd.append('file', file)
-    const endpoint = file.type.startsWith('image/')
-      ? '/api/upload-local'
-      : '/api/upload'
-    const res = await fetch(endpoint, { method: 'POST', body: fd })
+    const res = await fetch('/api/upload', { method: 'POST', body: fd })
     const data = await res.json()
     setForm({ ...form, [field]: data.url })
   }
@@ -164,6 +161,7 @@ export default function HeroTabsPage() {
         <thead className="bg-gray-50">
           <tr>
             <th className="px-3 py-2">Name</th>
+            <th className="px-3 py-2">Icon</th>
             <th className="px-3 py-2">Order</th>
             <th className="px-3 py-2">Actions</th>
           </tr>
@@ -172,6 +170,7 @@ export default function HeroTabsPage() {
           {tabs.map(t => (
             <tr key={t.id} className="border-t">
               <td className="px-3 py-2">{t.name}</td>
+              <td className="px-3 py-2">{t.iconUrl ? <img src={t.iconUrl} className="h-10"/> : '—'}</td>
               <td className="px-3 py-2">{t.order ?? 0}</td>
               <td className="flex gap-2 px-3 py-2">
                 <button className="flex items-center gap-1 px-2 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded" onClick={() => edit(t)}>

--- a/src/app/api/hero-tabs/route.ts
+++ b/src/app/api/hero-tabs/route.ts
@@ -5,6 +5,7 @@ export async function GET(req: NextRequest) {
   const host = req.headers.get('host')
   const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https'
   const base = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`
+  const now = new Date()
   const tabs = await prisma.heroTab.findMany({
     orderBy: { order: 'asc' },
     include: {
@@ -13,52 +14,61 @@ export async function GET(req: NextRequest) {
           serviceTier: {
             include: {
               service: { include: { category: true } },
+              priceHistory: {
+                where: {
+                  startDate: { lte: now },
+                  OR: [{ endDate: null }, { endDate: { gt: now } }],
+                },
+                orderBy: { startDate: 'desc' },
+                take: 1,
+              },
             },
           },
         },
       },
     },
   })
-  const now = new Date()
-  const result = await Promise.all(
-    tabs.map(async (t) => {
-      const variants = await Promise.all(
-        t.variants.map(async (v) => {
-          const price = await prisma.serviceTierPriceHistory.findFirst({
-            where: {
-              tierId: v.serviceTierId,
-              startDate: { lte: now },
-              OR: [{ endDate: null }, { endDate: { gt: now } }],
-            },
-            orderBy: { startDate: 'desc' },
-          })
-          return {
-            id: v.serviceTier.id,
-            name: v.serviceTier.name,
-            serviceName: v.serviceTier.service.name,
-            categoryName: v.serviceTier.service.category.name,
-            price:
-              price?.offerPrice ?? price?.actualPrice ?? v.serviceTier.offerPrice ?? v.serviceTier.actualPrice,
-          }
-        })
-      )
-      const iconUrl = t.iconUrl && t.iconUrl.startsWith('/') ? `${base}${t.iconUrl}` : t.iconUrl
-      const backgroundUrl = t.backgroundUrl && t.backgroundUrl.startsWith('/') ? `${base}${t.backgroundUrl}` : t.backgroundUrl
-      const videoSrc = t.videoSrc && t.videoSrc.startsWith('/') ? `${base}${t.videoSrc}` : t.videoSrc
+
+  const result = tabs.map((t) => {
+    const variants = t.variants.map((v) => {
+      const priceRec = v.serviceTier.priceHistory[0]
+      const price =
+        priceRec?.offerPrice ??
+        priceRec?.actualPrice ??
+        v.serviceTier.offerPrice ??
+        v.serviceTier.actualPrice
       return {
-        id: t.id,
-        name: t.name,
-        iconUrl,
-        backgroundUrl,
-        videoSrc,
-        heroTitle: t.heroTitle,
-        heroDescription: t.heroDescription,
-        buttonLabel: t.buttonLabel,
-        buttonLink: t.buttonLink,
-        order: t.order,
-        variants,
+        id: v.serviceTier.id,
+        name: v.serviceTier.name,
+        serviceName: v.serviceTier.service.name,
+        categoryName: v.serviceTier.service.category.name,
+        price,
       }
     })
-  )
+
+    const iconUrl =
+      t.iconUrl && t.iconUrl.startsWith('/') ? `${base}${t.iconUrl}` : t.iconUrl
+    const backgroundUrl =
+      t.backgroundUrl && t.backgroundUrl.startsWith('/')
+        ? `${base}${t.backgroundUrl}`
+        : t.backgroundUrl
+    const videoSrc =
+      t.videoSrc && t.videoSrc.startsWith('/') ? `${base}${t.videoSrc}` : t.videoSrc
+
+    return {
+      id: t.id,
+      name: t.name,
+      iconUrl,
+      backgroundUrl,
+      videoSrc,
+      heroTitle: t.heroTitle,
+      heroDescription: t.heroDescription,
+      buttonLabel: t.buttonLabel,
+      buttonLink: t.buttonLink,
+      order: t.order,
+      variants,
+    }
+  })
+
   return NextResponse.json(result)
 }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -17,14 +17,16 @@ export async function POST(req: NextRequest) {
     if (!file)
       return NextResponse.json({ error: "No file" }, { status: 400 });
 
-    if (!file.type.startsWith("image/"))
+    const isVideo = file.type.startsWith("video/");
+    const isImage = file.type.startsWith("image/");
+    if (!isImage && !isVideo)
       return NextResponse.json({ error: "Invalid file type" }, { status: 400 });
 
     const buffer = Buffer.from(await file.arrayBuffer());
 
     const uploaded: UploadApiResponse = await new Promise((resolve, reject) => {
       const stream = cloudinary.uploader.upload_stream(
-        { resource_type: "image", folder: "services" },
+        { resource_type: isVideo ? "video" : "image", folder: "services" },
         (err, result) => {
           if (err || !result) return reject(err);
           resolve(result);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,6 +61,7 @@ export default function HomePage() {
   const [error, setError] = useState<string | null>(null)
   const [selectedHeroCategory, setSelectedHeroCategory] = useState<string>("") // default empty until load
   const [heroTabs, setHeroTabs] = useState<any[]>([])
+  const [heroLoading, setHeroLoading] = useState(true)
   const [selectedGenderTab, setSelectedGenderTab] = useState<"WOMEN" | "MEN">("WOMEN")
 
   useEffect(() => {
@@ -89,6 +90,7 @@ export default function HomePage() {
           setSelectedHeroCategory(data[0].id)
         }
       })
+      .finally(() => setHeroLoading(false))
   }, [])
 
   const subServices = useMemo(() => {
@@ -117,6 +119,12 @@ export default function HomePage() {
 
       {/* HERO SECTION */}
       <section className="relative flex flex-col overflow-hidden min-h-[70vh] md:min-h-[70vh]">
+        {heroLoading || heroTabs.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center text-gray-400">
+            Loading hero content...
+          </div>
+        ) : (
+        <>
         {/* Categories Section (Light Grey Bar) */}
         <div className="w-full overflow-x-auto py-2 scrollbar-hide bg-gray-100 shadow-lg">
           <div className="flex gap-0 justify-start px-4 md:justify-center">
@@ -139,12 +147,12 @@ export default function HomePage() {
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ duration: 0.3, delay: 0.1 + idx * 0.05 }}
               >
-                <Image
+                <img
                   src={cat.iconUrl || "/placeholder.svg"}
                   alt={cat.name}
-                  width={32} // Increased icon size
-                  height={32} // Increased icon size
-                  className="w-8 h-8 mb-1" // Tailwind classes for size
+                  width={32}
+                  height={32}
+                  className="w-8 h-8 mb-1"
                 />
                 <span className="text-xs font-medium whitespace-nowrap">{cat.name}</span>
               </motion.button>
@@ -174,13 +182,10 @@ export default function HomePage() {
                 <source src={currentHeroContent.videoSrc} type="video/mp4" />
               </video>
             ) : (
-              <Image
+              <img
                 src={currentHeroContent.backgroundUrl || "/placeholder.svg"}
                 alt={currentHeroContent.name || "Background"}
-                layout="fill"
-                objectFit="cover"
-                priority
-                className="absolute inset-0 z-0"
+                className="absolute inset-0 z-0 w-full h-full object-cover"
               />
             )}
             {/* Dark gradient overlay for the bottom 50% */}
@@ -206,6 +211,8 @@ export default function HomePage() {
             </div>
           </motion.div>
         </AnimatePresence>
+        </>
+        )}
       </section>
 
       {/* DISCOVER OUR RATES SECTION */}


### PR DESCRIPTION
## Summary
- consolidate price queries in `hero-tabs` API routes
- include loading placeholder in home page hero section

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884a7d5448c8325a1774efa77f3864c