### PR TITLE
Enhance hero tab pages with layout and service details

### DIFF
--- a/src/app/api/hero-tabs/[id]/route.ts
+++ b/src/app/api/hero-tabs/[id]/route.ts
@@ -40,9 +40,13 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
       v.serviceTier.actualPrice
     return {
       id: v.serviceTier.id,
+      serviceId: v.serviceTier.service.id,
       name: v.serviceTier.name,
       serviceName: v.serviceTier.service.name,
       categoryName: v.serviceTier.service.category.name,
+      caption: v.serviceTier.service.caption ?? null,
+      description: v.serviceTier.service.description ?? null,
+      imageUrl: v.serviceTier.service.imageUrl ?? null,
       price,
     }
   })

--- a/src/app/api/hero-tabs/route.ts
+++ b/src/app/api/hero-tabs/route.ts
@@ -39,9 +39,13 @@ export async function GET(req: NextRequest) {
         v.serviceTier.actualPrice
       return {
         id: v.serviceTier.id,
+        serviceId: v.serviceTier.service.id,
         name: v.serviceTier.name,
         serviceName: v.serviceTier.service.name,
         categoryName: v.serviceTier.service.category.name,
+        caption: v.serviceTier.service.caption ?? null,
+        description: v.serviceTier.service.description ?? null,
+        imageUrl: v.serviceTier.service.imageUrl ?? null,
         price,
       }
     })

--- a/src/app/hero/[id]/page.tsx
+++ b/src/app/hero/[id]/page.tsx
@@ -1,6 +1,10 @@
 import Link from 'next/link'
 import { headers } from 'next/headers'
 
+function stripHtml(html: string) {
+  return html.replace(/<[^>]*>?/gm, '')
+}
+
 export default async function HeroTabPage({ params }: { params: { id: string } }) {
   const { id } = params
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headers().get('host')}`
@@ -9,27 +13,48 @@ export default async function HeroTabPage({ params }: { params: { id: string } }
   const tab = await res.json()
 
   return (
-    <div className="max-w-3xl mx-auto my-12 bg-gray-900 rounded-2xl p-8 text-gray-100">
-      <h1 className="text-3xl font-bold mb-4" style={{ color: '#41eb70' }}>{tab.heroTitle}</h1>
-      {tab.heroDescription && (
-        <div className="prose prose-invert mb-6" dangerouslySetInnerHTML={{ __html: tab.heroDescription }} />
-      )}
+    <section className="max-w-5xl mx-auto my-12 px-4 space-y-8">
+      <div className="bg-gray-900 rounded-2xl p-8 text-gray-100 shadow">
+        <h1 className="text-3xl font-bold mb-4" style={{ color: '#41eb70' }}>{tab.heroTitle}</h1>
+        {tab.heroDescription && (
+          <div className="prose prose-invert mb-6" dangerouslySetInnerHTML={{ __html: tab.heroDescription }} />
+        )}
+      </div>
+
       {tab.variants && tab.variants.length > 0 && (
-        <div>
-          <h2 className="text-2xl font-semibold mb-4" style={{ color: '#41eb70' }}>Featured Services</h2>
-          <ul className="space-y-3">
-            {tab.variants.map((v: any) => (
-              <li key={v.id} className="flex items-center justify-between bg-gray-800 p-4 rounded-xl">
-                <span>{v.serviceName} - {v.name}</span>
-                <span className="font-bold" style={{ color: '#41eb70' }}>₹{v.price}</span>
-              </li>
-            ))}
-          </ul>
+        <div className="space-y-6">
+          {tab.variants.map((v: any) => (
+            <div key={v.id} className="bg-gray-800 rounded-xl p-4 flex flex-col md:flex-row gap-4 shadow">
+              {v.imageUrl && (
+                <img
+                  src={v.imageUrl}
+                  alt={v.serviceName}
+                  className="w-full md:w-40 h-40 object-cover rounded-lg"
+                />
+              )}
+              <div className="flex-1">
+                <h3 className="text-xl font-semibold mb-2" style={{ color: '#41eb70' }}>
+                  {v.serviceName} - {v.name}
+                </h3>
+                {v.caption && <p className="text-gray-300 mb-1">{v.caption}</p>}
+                {v.description && (
+                  <p className="text-gray-400 text-sm mb-2">
+                    {stripHtml(v.description).slice(0, 120)}{v.description.length > 120 ? '...' : ''}
+                  </p>
+                )}
+                <p className="font-bold" style={{ color: '#41eb70' }}>₹{v.price}</p>
+                <Link href={`/services/${v.serviceId}`} className="text-green-400 underline text-sm mt-2 inline-block">
+                  View Details
+                </Link>
+              </div>
+            </div>
+          ))}
         </div>
       )}
-      <div className="mt-8">
+
+      <div className="text-center">
         <Link href="/" className="text-green-400 underline">Back to Home</Link>
       </div>
-    </div>
+    </section>
   )
 }

--- a/src/app/hero/layout.tsx
+++ b/src/app/hero/layout.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+
+export default function HeroLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="bg-gray-900 min-h-screen font-sans text-gray-100">
+      <Header />
+      {children}
+      <Footer />
+    </main>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function Footer() {
+  const year = new Date().getFullYear()
+  return (
+    <footer className="text-center py-8 text-gray-400 bg-gray-900 border-t border-gray-800">
+      <div className="container mx-auto px-6">
+        <p className="text-sm">&copy; {year} Greens Beauty Salon. All rights reserved.</p>
+      </div>
+    </footer>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable `Footer` component
- create layout for hero pages using header and footer
- expose service data in hero tab API
- show detailed service cards on hero detail pages

## Testing
- `npm install`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884b6852d548325a9484476b6936a59