### PR TITLE
Switch to light theme and clean up assets

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-.select-dark { background: #031a13 !important; color: #90EE90 !important; }
+.select-dark { background: #ffffff !important; color: #000000 !important; }
 
 .modal-scroll {
   scrollbar-width: thin;

--- a/src/app/hero/[id]/page.tsx
+++ b/src/app/hero/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { headers } from 'next/headers'
+import { notFound } from 'next/navigation'
 
 function stripHtml(html: string) {
   return html.replace(/<[^>]*>?/gm, '')
@@ -9,22 +10,22 @@ export default async function HeroTabPage({ params }: { params: { id: string } }
   const { id } = params
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headers().get('host')}`
   const res = await fetch(`${baseUrl}/api/hero-tabs/${id}`, { cache: 'no-store' })
-  if (!res.ok) return <div className="p-8 text-red-500">Unable to load tab</div>
+  if (!res.ok) return notFound()
   const tab = await res.json()
 
   return (
-    <section className="max-w-5xl mx-auto my-12 px-4 space-y-8">
-      <div className="bg-gray-900 rounded-2xl p-8 text-gray-100 shadow">
+    <section className="max-w-5xl mx-auto my-12 px-4 space-y-8 text-gray-900">
+      <div className="bg-white rounded-2xl p-8 shadow">
         <h1 className="text-3xl font-bold mb-4" style={{ color: '#41eb70' }}>{tab.heroTitle}</h1>
         {tab.heroDescription && (
-          <div className="prose prose-invert mb-6" dangerouslySetInnerHTML={{ __html: tab.heroDescription }} />
+          <div className="prose mb-6" dangerouslySetInnerHTML={{ __html: tab.heroDescription }} />
         )}
       </div>
 
       {tab.variants && tab.variants.length > 0 && (
         <div className="space-y-6">
           {tab.variants.map((v: any) => (
-            <div key={v.id} className="bg-gray-800 rounded-xl p-4 flex flex-col md:flex-row gap-4 shadow">
+            <div key={v.id} className="bg-white rounded-xl p-4 flex flex-col md:flex-row gap-4 shadow">
               {v.imageUrl && (
                 <img
                   src={v.imageUrl}
@@ -36,9 +37,9 @@ export default async function HeroTabPage({ params }: { params: { id: string } }
                 <h3 className="text-xl font-semibold mb-2" style={{ color: '#41eb70' }}>
                   {v.serviceName} - {v.name}
                 </h3>
-                {v.caption && <p className="text-gray-300 mb-1">{v.caption}</p>}
+                {v.caption && <p className="text-gray-600 mb-1">{v.caption}</p>}
                 {v.description && (
-                  <p className="text-gray-400 text-sm mb-2">
+                  <p className="text-gray-500 text-sm mb-2">
                     {stripHtml(v.description).slice(0, 120)}{v.description.length > 120 ? '...' : ''}
                   </p>
                 )}

--- a/src/app/hero/layout.tsx
+++ b/src/app/hero/layout.tsx
@@ -4,7 +4,7 @@ import Footer from '@/components/Footer'
 
 export default function HeroLayout({ children }: { children: React.ReactNode }) {
   return (
-    <main className="bg-gray-900 min-h-screen font-sans text-gray-100">
+    <main className="bg-white min-h-screen font-sans text-gray-900">
       <Header />
       {children}
       <Footer />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,8 +62,8 @@ export default function RootLayout({
         <style>{`
           body {
             margin: 0;
-            background-color: #052b1e;
-            color: #90EE90;
+            background-color: #ffffff;
+            color: #000000;
             font-family: 'Poppins', sans-serif;
           }
         `}</style>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,7 +113,7 @@ export default function HomePage() {
   }, [selectedGenderTab])
 
   return (
-    <main className="bg-gray-900 min-h-screen font-sans text-gray-100">
+    <main className="bg-white min-h-screen font-sans text-gray-900">
       {/* HEADER */}
       <Header />
 
@@ -189,8 +189,8 @@ export default function HomePage() {
                 className="absolute inset-0 z-0 w-full h-full object-cover"
               />
             )}
-            {/* Dark gradient overlay for the bottom 50% */}
-            <div className="absolute inset-x-0 bottom-0 h-[50%] bg-gradient-to-t from-gray-900 to-transparent z-10" />{" "}
+            {/* Light gradient overlay for the bottom 50% */}
+            <div className="absolute inset-x-0 bottom-0 h-[50%] bg-gradient-to-t from-white to-transparent z-10" />{" "}
             {/* Increased height and intensity */}
             <div className="relative z-20 text-white max-w-3xl space-y-2">
               <h1 className="text-2xl md:text-3xl font-bold tracking-wide text-white">
@@ -261,7 +261,7 @@ export default function HomePage() {
       </section>
 
       {/* SERVICE DIVISIONS */}
-      <section className="py-20 bg-gradient-to-b from-gray-800 to-gray-900">
+      <section className="py-20 bg-gradient-to-b from-gray-100 to-gray-200 text-gray-900">
         <div className="container mx-auto px-6">
           <motion.div
             className="text-center mb-16"
@@ -273,7 +273,7 @@ export default function HomePage() {
             <h2 className="text-4xl md:text-5xl font-bold mb-6" style={{ color: "#41eb70" }}>
               Our Service Divisions
             </h2>
-            <p className="text-xl text-gray-300 max-w-3xl mx-auto">
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
               Experience comprehensive beauty and wellness services in our luxurious environment
             </p>
           </motion.div>
@@ -337,17 +337,17 @@ export default function HomePage() {
                 viewport={{ once: true }}
                 whileHover={{ y: -10 }}
               >
-                <div className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-6 text-center shadow-xl hover:shadow-2xl transition-all duration-300 border border-gray-700/50 h-full group-hover:border-green-400/30">
+                <div className="bg-white rounded-2xl p-6 text-center shadow-xl hover:shadow-2xl transition-all duration-300 border border-gray-200 h-full">
                   <motion.div
                     className={`w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-br ${svc.gradient} flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform duration-300`}
                     whileHover={{ rotate: 5 }}
                   >
                     <i className={`${svc.icon} text-white text-2xl`}></i>
                   </motion.div>
-                  <h3 className="text-lg font-semibold text-white mb-2 group-hover:text-green-400 transition-colors">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2 group-hover:text-green-600 transition-colors">
                     {svc.title}
                   </h3>
-                  <p className="text-gray-400 text-sm leading-relaxed">{svc.desc}</p>
+                  <p className="text-gray-600 text-sm leading-relaxed">{svc.desc}</p>
                 </div>
               </motion.div>
             ))}
@@ -355,7 +355,7 @@ export default function HomePage() {
         </div>
       </section>
       {/* SERVICES SECTION */}
-      <section id="services" className="py-20 bg-gradient-to-b from-gray-900 to-gray-800">
+      <section id="services" className="py-20 bg-gradient-to-b from-gray-200 to-gray-100 text-gray-900">
         <div className="container mx-auto px-6">
           <motion.div
             className="text-center mb-12"
@@ -403,7 +403,7 @@ export default function HomePage() {
                             <h3 className="text-2xl md:text-3xl font-bold mb-2" style={{ color: "#41eb70" }}>
                               {cat.name}
                             </h3>
-                            <p className="text-gray-300 text-lg mb-4">{cat.caption}</p>
+                            <p className="text-gray-600 text-lg mb-4">{cat.caption}</p>
                           </div>
                         </div>
                         <motion.span
@@ -429,7 +429,7 @@ export default function HomePage() {
                             {subServices.map((svc) => (
                               <div
                                 key={svc.id}
-                                className="bg-gray-700/30 backdrop-blur-sm rounded-xl p-6 border border-gray-600/30 flex items-center justify-between"
+                                className="bg-gray-100 rounded-xl p-6 border border-gray-200 flex items-center justify-between"
                               >
                                 <div className="flex items-center gap-6">
                                   <img
@@ -442,7 +442,7 @@ export default function HomePage() {
                                     <h4 className="font-bold text-xl" style={{ color: "#41eb70" }}>
                                       {svc.name}
                                     </h4>
-                                    <p className="text-gray-300 text-sm mb-1">{svc.caption}</p>
+                                    <p className="text-gray-600 text-sm mb-1">{svc.caption}</p>
                                     {svc.minPrice != null && (
                                       <span className="font-bold" style={{ color: "#41eb70" }}>
                                         From ₹{svc.minPrice}
@@ -503,7 +503,7 @@ export default function HomePage() {
         )}
       </AnimatePresence>
       {/* ABOUT SECTION */}
-      <section className="py-20 bg-gray-900">
+      <section className="py-20 bg-gray-100 text-gray-900">
         <div className="container mx-auto px-6">
           <motion.div
             className="text-center mb-16"
@@ -523,7 +523,7 @@ export default function HomePage() {
             {Object.entries(TIER_LABELS).map(([k, { label, icon }], idx) => (
               <motion.div
                 key={k}
-                className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-8 text-center shadow-xl hover:shadow-2xl hover:shadow-green-400/10 transition-all duration-300 border border-gray-700/50"
+                className="bg-white rounded-2xl p-8 text-center shadow-xl hover:shadow-2xl transition-all duration-300 border border-gray-200"
                 initial={{ opacity: 0, y: 30 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.6, delay: idx * 0.2 }}
@@ -534,7 +534,7 @@ export default function HomePage() {
                 <h3 className="text-2xl font-bold mb-4" style={{ color: "#41eb70" }}>
                   {label}
                 </h3>
-                <p className="text-gray-300 leading-relaxed">
+                <p className="text-gray-600 leading-relaxed">
                   {k === "deluxe" &&
                     "Luxury brands and exclusive treatments. For those who demand the best in care and results. Shahnaz Husain, L'Oréal and more."}
                   {k === "premium" &&
@@ -546,7 +546,7 @@ export default function HomePage() {
             ))}
           </div>
           <motion.div
-            className="text-center bg-gray-800/30 backdrop-blur-sm rounded-2xl p-8 border border-gray-700/50 max-w-4xl mx-auto"
+            className="text-center bg-white rounded-2xl p-8 border border-gray-200 max-w-4xl mx-auto"
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
@@ -555,7 +555,7 @@ export default function HomePage() {
             <h3 className="text-2xl font-bold mb-4" style={{ color: "#41eb70" }}>
               Our Promise
             </h3>
-            <p className="text-gray-300 leading-relaxed text-lg">
+            <p className="text-gray-600 leading-relaxed text-lg">
               We believe in comfort, care, and giving you the best advice—always. Ask us anything, and our team will
               guide you for the perfect service and product choice.
             </p>
@@ -579,7 +579,7 @@ export default function HomePage() {
           </motion.div>
           <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8">
             <motion.div
-              className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-8 shadow-xl border border-gray-700/50"
+              className="bg-white rounded-2xl p-8 shadow-xl border border-gray-200"
               initial={{ opacity: 0, x: -30 }}
               whileInView={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.8 }}
@@ -588,12 +588,12 @@ export default function HomePage() {
               <h3 className="text-2xl font-bold mb-6 flex items-center gap-3" style={{ color: "#41eb70" }}>
                 <FiMapPin style={{ color: "#41eb70" }} /> Visit Us
               </h3>
-              <p className="text-gray-300 text-lg leading-relaxed">
+              <p className="text-gray-600 text-lg leading-relaxed">
                 TC 45/215, Kunjalumood Junction, Karamana PO, Trivandrum
               </p>
             </motion.div>
             <motion.div
-              className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-8 shadow-xl border border-gray-700/50"
+              className="bg-white rounded-2xl p-8 shadow-xl border border-gray-200"
               initial={{ opacity: 0, x: 30 }}
               whileInView={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.8 }}
@@ -650,7 +650,7 @@ export default function HomePage() {
         </div>
       </section>
       {/* FOOTER */}
-      <footer className="text-center py-8 text-gray-400 bg-gray-900 border-t border-gray-800">
+      <footer className="text-center py-8 text-gray-600 bg-gray-200 border-t border-gray-300">
         <div className="container mx-auto px-6">
           <p className="text-sm">&copy; {new Date().getFullYear()} Greens Beauty Salon. All rights reserved.</p>
         </div>

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -16,7 +16,7 @@ export default async function ServiceDetailsPage({ params }: { params: { id: str
   }
 
   return (
-    <div className="max-w-3xl mx-auto my-12 bg-gray-900 rounded-2xl p-8 shadow text-gray-100">
+    <div className="max-w-3xl mx-auto my-12 bg-white rounded-2xl p-8 shadow text-gray-900">
       {service.imageUrl && (
         <img src={service.imageUrl} alt={service.name} className="mb-6 rounded-xl w-full max-h-64 object-cover" />
       )}
@@ -28,12 +28,12 @@ export default async function ServiceDetailsPage({ params }: { params: { id: str
         </div>
       )}
       <h1 className="text-3xl font-bold mb-2" style={{ color: '#41eb70' }}>{service.name}</h1>
-      {service.caption && <p className="text-lg text-gray-300 mb-4">{service.caption}</p>}
-      <div className="prose prose-invert mb-6" dangerouslySetInnerHTML={{ __html: service.description || '' }} />
+      {service.caption && <p className="text-lg text-gray-600 mb-4">{service.caption}</p>}
+      <div className="prose mb-6" dangerouslySetInnerHTML={{ __html: service.description || '' }} />
       <h2 className="text-2xl font-semibold mb-4" style={{ color: '#41eb70' }}>Variants</h2>
       <ul className="space-y-3">
         {service.tiers.map(t => (
-          <li key={t.id} className="flex items-center justify-between bg-gray-800 rounded-xl p-4">
+          <li key={t.id} className="flex items-center justify-between bg-gray-100 rounded-xl p-4">
             <span className="font-medium">{t.name}</span>
             <span className="font-bold" style={{ color: '#41eb70' }}>₹{t.offerPrice ?? t.actualPrice}</span>
           </li>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 export default function Footer() {
   const year = new Date().getFullYear()
   return (
-    <footer className="text-center py-8 text-gray-400 bg-gray-900 border-t border-gray-800">
+    <footer className="text-center py-8 text-gray-600 bg-gray-200 border-t border-gray-300">
       <div className="container mx-auto px-6">
         <p className="text-sm">&copy; {year} Greens Beauty Salon. All rights reserved.</p>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,7 +41,15 @@ export default function Header() {
   )
 
   return (
-    <header className="bg-[#052b1e] text-white py-4 px-6 flex items-center justify-between w-full relative z-50">
+    <header
+      className="text-white py-4 px-6 flex items-center justify-between w-full relative z-50"
+      style={{
+        backgroundColor: '#052b1e',
+        backgroundImage: "url('/grass-texture.jpg')",
+        backgroundSize: 'cover',
+        backgroundRepeat: 'repeat',
+      }}
+    >
       <div className="flex items-center gap-4">
         <Link href="/" className="flex items-center">
           <Image src="/logo.png" alt="Greens Beauty Salon Logo" width={100} height={30} />
@@ -62,7 +70,13 @@ export default function Header() {
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: "100%" }}
             transition={{ duration: 0.3, ease: "easeOut" }}
-            className="fixed inset-0 bg-[#052b1e] z-40 flex flex-col items-center justify-center gap-8 text-lg md:hidden"
+            className="fixed inset-0 z-40 flex flex-col items-center justify-center gap-8 text-lg md:hidden"
+            style={{
+              backgroundColor: '#052b1e',
+              backgroundImage: "url('/grass-texture.jpg')",
+              backgroundSize: 'cover',
+              backgroundRepeat: 'repeat',
+            }}
           >
             <button className="absolute top-4 right-4 text-white" onClick={() => setIsMobileMenuOpen(false)}>
               <X size={32} />


### PR DESCRIPTION
## Summary
- use light colors globally
- update hero layout and hero tab page for light theme and 404 fallback
- style header with grass texture (image not included)
- remove stray grass texture image from repo

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails with multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884bff1d1d483258e9ccce4db02cf4f