### PR TITLE
Fix service page image uploads

### DIFF
--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -68,7 +68,7 @@ export default function ServicesAdmin() {
     if (!file) return
     const fd = new FormData()
     fd.append("file", file)
-    const res = await fetch("/api/upload-local", { method: "POST", body: fd })
+    const res = await fetch("/api/upload", { method: "POST", body: fd })
     const data = await res.json()
     setServiceForm({ ...serviceForm, imageUrl: data.url })
   }
@@ -92,7 +92,7 @@ export default function ServicesAdmin() {
     if (!file) return
     const fd = new FormData()
     fd.append("file", file)
-    const res = await fetch("/api/upload-local", { method: "POST", body: fd })
+    const res = await fetch("/api/upload", { method: "POST", body: fd })
     const data = await res.json()
     setImageForm({ ...imageForm, imageUrl: data.url })
   }


### PR DESCRIPTION
## Summary
- use `/api/upload` for images in `admin/services`

## Testing
- `npm run lint` *(fails: various lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ae38013f88325975e81821f3e1704