### PR TITLE
Fix stats endpoint groupBy ordering

### DIFF
--- a/src/app/api/customers/stats/route.ts
+++ b/src/app/api/customers/stats/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
       // Order by the number of billing records per customer.
       // Prisma cannot order by `_all`, so count a specific column (id)
       // and use that for ordering instead.
-      orderBy: { _count: { id: 'desc' } },
+      orderBy: [{ _count: { id: 'desc' } }],
       take: 10,
     })
 

--- a/src/app/api/customers/stats/route.ts
+++ b/src/app/api/customers/stats/route.ts
@@ -5,11 +5,10 @@ export async function GET() {
     const topByServices = await prisma.billing.groupBy({
       by: ['customerId'],
       where: { customerId: { not: null } },
-      _count: { _all: true },
-      // Order by the number of billing records per customer
-      // Prisma does not support using `_all` in `orderBy`,
-      // so we sort by counting a specific column (id),
-      // which effectively orders by the total records in each group
+      _count: { id: true },
+      // Order by the number of billing records per customer.
+      // Prisma cannot order by `_all`, so count a specific column (id)
+      // and use that for ordering instead.
       orderBy: { _count: { id: 'desc' } },
       take: 10,
     })
@@ -35,7 +34,7 @@ export async function GET() {
 
     const topServices = topByServices.map(t => {
       const u = userMap.get(t.customerId!)!
-      return { id: u.id, name: u.name, phone: u.phone, count: t._count._all }
+      return { id: u.id, name: u.name, phone: u.phone, count: t._count.id }
     })
 
     const topBills = topByBills.map(t => {

--- a/src/app/api/customers/stats/route.ts
+++ b/src/app/api/customers/stats/route.ts
@@ -6,7 +6,11 @@ export async function GET() {
       by: ['customerId'],
       where: { customerId: { not: null } },
       _count: { _all: true },
-      orderBy: { _count: { _all: 'desc' } },
+      // Order by the number of billing records per customer
+      // Prisma does not support using `_all` in `orderBy`,
+      // so we sort by counting a specific column (id),
+      // which effectively orders by the total records in each group
+      orderBy: { _count: { id: 'desc' } },
       take: 10,
     })
 


### PR DESCRIPTION
## Summary
- order customer stats by record count without using unsupported _all

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unused vars, no-img-element, etc)*

------
https://chatgpt.com/codex/tasks/task_e_688f02ab179c83259b25119546acb5e6