### PR TITLE
feat: add admin enquiry management

### DIFF
--- a/prisma/migrations/20250805000000_create_enquiries/migration.sql
+++ b/prisma/migrations/20250805000000_create_enquiries/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE `Enquiry` (
+  `id` VARCHAR(191) NOT NULL,
+  `customerId` VARCHAR(191) NOT NULL,
+  `variantIds` TEXT NULL,
+  `enquiry` LONGTEXT NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+  PRIMARY KEY (`id`),
+  CONSTRAINT `Enquiry_customerId_fkey` FOREIGN KEY (`customerId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   updatedAt   DateTime  @default(now()) @updatedAt @db.Timestamp(3)
 
   bookings Booking[]
+  enquiries Enquiry[]
 }
 
 model Branch {
@@ -223,4 +224,13 @@ model HeroTabVariant {
   serviceTier   ServiceTier @relation(fields: [serviceTierId], references: [id])
 
   @@id([heroTabId, serviceTierId])
+}
+
+model Enquiry {
+  id         String   @id @default(uuid()) @db.VarChar(191)
+  customerId String   @db.VarChar(191)
+  customer   User     @relation(fields: [customerId], references: [id])
+  enquiry    String?  @db.LongText
+  variantIds String?  @db.Text
+  createdAt  DateTime @default(now()) @db.Timestamp(3)
 }

--- a/src/app/admin/enquiries/page.tsx
+++ b/src/app/admin/enquiries/page.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import WysiwygEditor from '@/app/components/WysiwygEditor'
+import Select from 'react-select'
+
+interface VariantOption {
+  id: string
+  variantName: string
+  serviceName: string
+  categoryName: string
+}
+
+interface Enquiry {
+  id: string
+  enquiry: string | null
+  variantIds: string[]
+  createdAt: string
+  customer: { name: string | null; phone: string | null; gender: string | null }
+}
+
+export default function EnquiriesPage() {
+  const empty = { name: '', phone: '', gender: '', enquiry: '', variantIds: [] as string[] }
+  const [form, setForm] = useState(empty)
+  const [enquiries, setEnquiries] = useState<Enquiry[]>([])
+  const [variants, setVariants] = useState<VariantOption[]>([])
+
+  const load = async () => {
+    const res = await fetch('/api/admin/enquiries')
+    if (res.ok) {
+      const data = await res.json()
+      setEnquiries(data)
+    }
+  }
+
+  const loadVariants = async () => {
+    const res = await fetch('/api/admin/service-variants/all')
+    if (res.ok) {
+      const data = await res.json()
+      setVariants(data)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    loadVariants()
+  }, [])
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await fetch('/api/admin/enquiries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+    setForm(empty)
+    load()
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Enquiries</h1>
+      <form onSubmit={save} className="space-y-4 bg-white p-6 rounded shadow border mb-6">
+        <div>
+          <label className="block font-medium mb-1">Name</label>
+          <input
+            className="w-full p-2 rounded border"
+            value={form.name}
+            onChange={e => setForm({ ...form, name: e.target.value })}
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Mobile</label>
+          <input
+            className="w-full p-2 rounded border"
+            value={form.phone}
+            onChange={e => setForm({ ...form, phone: e.target.value })}
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Gender</label>
+          <select
+            className="w-full p-2 rounded border"
+            value={form.gender}
+            onChange={e => setForm({ ...form, gender: e.target.value })}
+            required
+          >
+            <option value="">Select</option>
+            <option value="male">Male</option>
+            <option value="female">Female</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Enquiry</label>
+          <WysiwygEditor value={form.enquiry} onChange={val => setForm({ ...form, enquiry: val })} />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Services</label>
+          <Select
+            isMulti
+            classNamePrefix="select"
+            options={variants.map(v => ({
+              value: v.id,
+              label: `${v.categoryName} - ${v.serviceName} (${v.variantName})`,
+            }))}
+            value={variants
+              .filter(v => form.variantIds.includes(v.id))
+              .map(v => ({
+                value: v.id,
+                label: `${v.categoryName} - ${v.serviceName} (${v.variantName})`,
+              }))}
+            onChange={(vals: any) => setForm({ ...form, variantIds: vals.map((v: any) => v.value) })}
+          />
+        </div>
+        <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">
+          Save Enquiry
+        </button>
+      </form>
+      <table className="w-full text-left text-sm bg-white rounded shadow border">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2">Customer</th>
+            <th className="px-3 py-2">Phone</th>
+            <th className="px-3 py-2">Services</th>
+            <th className="px-3 py-2">Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {enquiries.map(e => (
+            <tr key={e.id} className="border-t">
+              <td className="px-3 py-2">{e.customer?.name || '-'}</td>
+              <td className="px-3 py-2">{e.customer?.phone || '-'}</td>
+              <td className="px-3 py-2">{e.variantIds.length}</td>
+              <td className="px-3 py-2">{new Date(e.createdAt).toLocaleDateString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -20,6 +20,7 @@ import {
   MdReceipt,
   MdMenu,
   MdViewCarousel,
+  MdQuestionAnswer,
 } from 'react-icons/md'
 import type { IconType } from 'react-icons'
 
@@ -45,6 +46,7 @@ const sections: {
     items: [
       { href: '/admin/staff', label: 'Staff', icon: MdPeople },
       { href: '/admin/customers', label: 'Customers', icon: MdPeople },
+      { href: '/admin/enquiries', label: 'Enquiries', icon: MdQuestionAnswer },
     ],
   },
   {

--- a/src/app/api/admin/enquiries/route.ts
+++ b/src/app/api/admin/enquiries/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const data = await prisma.enquiry.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: { customer: true },
+  })
+  const result = data.map(e => ({
+    ...e,
+    variantIds: e.variantIds ? JSON.parse(e.variantIds) : [],
+  }))
+  return NextResponse.json(result)
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, phone, gender, enquiry, variantIds } = await req.json()
+
+    if (!phone) {
+      return NextResponse.json({ success: false, error: 'Phone required' }, { status: 400 })
+    }
+
+    const customer = await prisma.user.upsert({
+      where: { phone },
+      update: { name, gender, role: 'customer' },
+      create: { name, phone, gender, role: 'customer' },
+    })
+
+    const saved = await prisma.enquiry.create({
+      data: {
+        customerId: customer.id,
+        enquiry: enquiry || null,
+        variantIds: Array.isArray(variantIds) ? JSON.stringify(variantIds) : null,
+      },
+    })
+
+    return NextResponse.json({ success: true, enquiry: saved })
+  } catch (error) {
+    console.error('Error in POST /api/admin/enquiries', error)
+    return NextResponse.json({ success: false, error: 'Failed to save enquiry' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add Enquiry model and migration
- create API and admin page to record customer enquiries with service selections
- link enquiries page in admin navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx prisma generate`
- `DATABASE_URL="mysql://user:pass@localhost:3306/db" npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f1ce8300c83259a0b34cd4849d556