### PR TITLE
Fix billing timezone handling

### DIFF
--- a/pages/api/billing-services.ts
+++ b/pages/api/billing-services.ts
@@ -29,17 +29,27 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const billed = await prisma.billing.findMany({
       where: {
         scheduledAt: {
-          gte: startOfDay(new Date(date)),
-          lt: endOfDay(new Date(date)),
+          gte: startOfDay(new Date(`${date}T00:00:00Z`)),
+          lt: endOfDay(new Date(`${date}T00:00:00Z`)),
         },
       },
       select: { scheduledAt: true },
     })
     const billedSet = new Set(billed.map(b => b.scheduledAt.toISOString()))
-    const services = [] as any[]
+    const services: {
+      id: string
+      phone: string | null
+      customer: string | null
+      category: string
+      service: string
+      variant: string
+      start: string
+      price: number
+      scheduledAt: string
+    }[] = []
     bookings.forEach(b => {
       b.items.forEach(it => {
-        const scheduledAt = new Date(`${b.date}T${it.start}:00`)
+        const scheduledAt = new Date(`${b.date}T${it.start}:00Z`)
         if (billedSet.has(scheduledAt.toISOString())) return
         const tier = tierMap[it.tierId]
         services.push({

--- a/pages/api/bookings.ts
+++ b/pages/api/bookings.ts
@@ -17,8 +17,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const billed = await prisma.billing.findMany({
         where: {
           scheduledAt: {
-            gte: startOfDay(new Date(date)),
-            lt: endOfDay(new Date(date)),
+            gte: startOfDay(new Date(`${date}T00:00:00Z`)),
+            lt: endOfDay(new Date(`${date}T00:00:00Z`)),
           },
         },
         select: { scheduledAt: true },
@@ -26,7 +26,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const billedSet = new Set(billed.map(b => b.scheduledAt.toISOString()))
       bookings.forEach(b => {
         b.items = b.items.map(it => {
-          const scheduledAt = new Date(`${b.date}T${it.start}:00`).toISOString()
+          const scheduledAt = new Date(`${b.date}T${it.start}:00Z`).toISOString()
           return { ...it, billed: billedSet.has(scheduledAt) }
         }) as typeof b.items
       })


### PR DESCRIPTION
## Summary
- ensure billing queries use UTC timestamps
- generate billing item timestamps in UTC

## Testing
- `npm run lint` (fails: numerous existing issues)
- `npx eslint pages/api/billing-services.ts pages/api/bookings.ts`
- `node - <<'NODE'
const {startOfDay,endOfDay} = require('date-fns');
const date='2024-05-05';
const scheduledAt=new Date(`${date}T09:00:00Z`);
console.log('scheduledAt ISO',scheduledAt.toISOString());
console.log('within day',scheduledAt>=startOfDay(new Date(`${date}T00:00:00Z`)) && scheduledAt<endOfDay(new Date(`${date}T00:00:00Z`)));
NODE`
- `TZ=America/Los_Angeles node -e "console.log('LA', new Date('2024-05-05T09:00:00Z').toString())"`
- `TZ=Asia/Tokyo node -e "console.log('Tokyo', new Date('2024-05-05T09:00:00Z').toString())"`


------
https://chatgpt.com/codex/tasks/task_e_688f3f2a67248325b179050c4360ceb8