### PR TITLE
feat: allow promoting customers to staff

### DIFF
--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -17,8 +17,8 @@ export async function GET() {
     ] = await prisma.$transaction([
       prisma.service.count(),
       prisma.branch.count(),
-      prisma.user.count({ where: { role: 'STAFF', removed: false } }),
-      prisma.user.count({ where: { role: 'STAFF', removed: true } }),
+      prisma.user.count({ where: { role: { in: ['staff', 'customer_staff'] }, removed: false } }),
+      prisma.user.count({ where: { role: { in: ['staff', 'customer_staff'] }, removed: true } }),
       prisma.booking.count(),
       prisma.booking.count({ where: { date: today } }),
       prisma.booking.findMany({

--- a/src/app/api/branch/[id]/data/route.ts
+++ b/src/app/api/branch/[id]/data/route.ts
@@ -5,7 +5,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   const branchId = (await params).id;
   try {
     const staff = await prisma.user.findMany({
-      where: { role: 'staff', branchId },
+      where: { role: { in: ['staff', 'customer_staff'] }, branchId },
       select: { id: true, name: true },
       orderBy: { name: 'asc' },
     });

--- a/src/app/api/branch/data/route.ts
+++ b/src/app/api/branch/data/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: Request) {
   }
   try {
     const staff = await prisma.user.findMany({
-      where: { role: 'staff', branchId: id },
+      where: { role: { in: ['staff', 'customer_staff'] }, branchId: id },
       select: { id: true, name: true },
       orderBy: { name: 'asc' },
     })

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url)
     const branchId = searchParams.get('branchId')
-    const where: any = { role: 'customer' }
+    const where: any = { role: { in: ['customer', 'customer_staff'] } }
     if (branchId) where.branchId = branchId
     const customers = await prisma.user.findMany({
       where,

--- a/src/app/api/staff.ts
+++ b/src/app/api/staff.ts
@@ -6,7 +6,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method !== "GET") return res.status(405).end();
   try {
     const staff = await prisma.user.findMany({
-      where: { role: "staff", removed: false },
+      where: { role: { in: ["staff", "customer_staff"] }, removed: false },
       select: { id: true, name: true },
       orderBy: { name: "asc" },
     });

--- a/src/app/api/staff/check/route.ts
+++ b/src/app/api/staff/check/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const phone = searchParams.get('phone');
+    if (!phone) {
+      return NextResponse.json({ success: false, error: 'Phone required' }, { status: 400 });
+    }
+    const user = await prisma.user.findUnique({ where: { phone } });
+    if (!user) {
+      return NextResponse.json({ success: true, exists: false });
+    }
+    return NextResponse.json({ success: true, exists: true, user });
+  } catch (err: any) {
+    console.error('Check staff error:', err);
+    return NextResponse.json({ success: false, error: err.message }, { status: 500 });
+  }
+}

--- a/src/app/api/staff/route.ts
+++ b/src/app/api/staff/route.ts
@@ -8,7 +8,7 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const branchId = searchParams.get('branchId');
 
-    const where: any = { role: 'staff' };
+    const where: any = { role: { in: ['staff', 'customer_staff'] } };
     if (branchId) where.branchId = branchId;
 
     const staff = await prisma.user.findMany({

--- a/src/app/api/staff/update/route.ts
+++ b/src/app/api/staff/update/route.ts
@@ -21,6 +21,12 @@ export async function POST(req: Request) {
     if (!id) throw new Error('Missing staff ID');
 
     // Extract other fields
+    const existing = await prisma.user.findUnique({ where: { id } });
+    let role = form.get('role') as string;
+    if (existing?.role === 'customer' && role === 'staff') {
+      role = 'customer_staff';
+    }
+
     const data: any = {
       name:        form.get('name') as string,
       email:       form.get('email') as string,
@@ -31,7 +37,7 @@ export async function POST(req: Request) {
       designation: form.get('designation') as string,
       experience:  form.get('experience') as string,
       startDate:   form.get('startDate') ? new Date(form.get('startDate') as string) : undefined,
-      role:        form.get('role') as string,
+      role,
       branchId:    form.get('branchId') as string,
     };
 

--- a/src/app/staff/page.tsx
+++ b/src/app/staff/page.tsx
@@ -31,6 +31,9 @@ export default function StaffPage() {
   const [searchTerm, setSearchTerm]       = useState('');
   const [showAddModal, setShowAddModal]   = useState(false);
   const [selectedStaff, setSelectedStaff] = useState<Staff|null>(null);
+  const [existingCustomer, setExistingCustomer] = useState<Partial<Staff>|null>(null);
+  const [phoneVerified, setPhoneVerified] = useState(false);
+  const [newPhone, setNewPhone] = useState('');
 
   // fetch data
   const fetchStaff = async() => {
@@ -112,6 +115,28 @@ const handleExport = () => {
       return s.name.toLowerCase().includes(q) || s.email.toLowerCase().includes(q);
     });
 
+  const handlePhoneCheck = async(e:FormEvent<HTMLFormElement>)=>{
+    e.preventDefault();
+    if (!/^\d{10}$/.test(newPhone)) {
+      toast.error('Phone must be 10 digits');
+      return;
+    }
+    const res = await fetch(`/api/staff/check?phone=${newPhone}`);
+    const data = await res.json();
+    if (data.exists) {
+      if (data.user.role !== 'customer') {
+        toast.error('User already staff');
+        return;
+      }
+      const ok = window.confirm('Customer exists with this number. Add as staff?');
+      if (!ok) return;
+      setExistingCustomer(data.user);
+    } else {
+      setExistingCustomer(null);
+    }
+    setPhoneVerified(true);
+  };
+
   // Add Staff
   const handleAdd = async(e:FormEvent<HTMLFormElement>)=>{
     e.preventDefault();
@@ -122,14 +147,25 @@ const handleExport = () => {
       toast.error('Phone must be 10 digits');
       return;
     }
-    const res = await fetch('/api/staff/add',{
-      method:'POST', body: fd
-    });
+    let res: Response;
+    if (existingCustomer) {
+      fd.append('id', existingCustomer.id);
+      const role = fd.get('role');
+      if (role === 'staff') {
+        fd.set('role', 'customer_staff');
+      }
+      res = await fetch('/api/staff/update',{ method:'POST', body: fd });
+    } else {
+      res = await fetch('/api/staff/add',{ method:'POST', body: fd });
+    }
     const { success } = await res.json();
     if (success) {
       toast.success('Staff added!');
       form.reset();
       setShowAddModal(false);
+      setPhoneVerified(false);
+      setExistingCustomer(null);
+      setNewPhone('');
       fetchStaff();
     } else {
       toast.error('Failed to add');
@@ -300,149 +336,184 @@ const handleExport = () => {
         <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
           <div className="bg-white p-6 rounded-xl w-full max-w-2xl border border-gray-300 overflow-auto max-h-[90vh]">
             <h2 className="text-2xl mb-4">Add New Staff</h2>
-            <form
-              onSubmit={handleAdd}
-              encType="multipart/form-data"
-              className="grid grid-cols-2 gap-4 text-gray-900"
-            >
-              {/* Profile Pic */}
-              <div className="col-span-2">
-                <label className="block mb-1">Profile Pic</label>
-                <input type="file" name="image" accept="image/*" className="w-full"/>
-                <small className="text-gray-400">optional JPG/PNG</small>
-              </div>
-              {/* Name */}
-              <div>
-                <label className="block mb-1">Name*</label>
-                <input
-                  name="name"
-                  required
-                  className="w-full p-2 rounded bg-gray-200"
-                />
-              </div>
-              {/* Email */}
-              <div>
-                <label className="block mb-1">Email*</label>
-                <input
-                  name="email"
-                  type="email"
-                  required
-                  className="w-full p-2 rounded bg-gray-200"
-                />
-              </div>
-              {/* Phone */}
-              <div>
-                <label className="block mb-1">Phone*</label>
-                <input
-                  name="phone"
-                  required maxLength={10} pattern="\d{10}"
-                  className="w-full p-2 rounded bg-gray-200"
-                />
-              </div>
-              {/* Gender */}
-              <div>
-                <label className="block mb-1">Gender*</label>
-                <select
-                  name="gender"
-                  required
-                  className="w-full p-2 rounded bg-gray-200"
-                >
-                  <option value="">— select —</option>
-                  <option>Male</option>
-                  <option>Female</option>
-                  <option>Other</option>
-                </select>
-              </div>
-              {/* DOB */}
-              <div>
-                <label className="block mb-1">DOB*</label>
-                <input
-                  name="dob"
-                  type="date"
-                  required
-                  className="w-full p-2 rounded bg-gray-200"
-                />
-              </div>
-              {/* Address */}
-              <div className="col-span-2">
-                <label className="block mb-1">Address*</label>
-                <input
-                  name="address"
-                  required
-                  className="w-full p-2 rounded bg-gray-200"
-                />
-              </div>
-              {/* Designation */}
-              <div>
-                <label className="block mb-1">Designation*</label>
-                <input
-                  name="designation"
-                  required
-                  className="w-full p-2 rounded bg-gray-200"
-                />
-              </div>
-              {/* Experience */}
-              <div>
-                <label className="block mb-1">Experience</label>
-                <input
-                  name="experience"
-                  className="w-full p-2 rounded bg-gray-200"
-                />
-              </div>
-              {/* Start Date */}
-              <div>
-                <label className="block mb-1">Start Date*</label>
-                <input
-                  name="startDate"
-                  type="date"
-                  required
-                  className="w-full p-2 rounded bg-gray-200"
-                />
-              </div>
-              {/* Role */}
-              <div>
-                <label className="block mb-1">Role*</label>
-                <select
-                  name="role"
-                  required
-                  className="w-full p-2 rounded bg-gray-200"
-                >
-                  <option>customer</option>
-                  <option>staff</option>
-                  <option>manager</option>
-                </select>
-              </div>
-              {/* Branch */}
-              <div>
-                <label className="block mb-1">Branch*</label>
-                <select
-                  name="branchId"
-                  required
-                  className="w-full p-2 rounded bg-gray-200"
-                >
-                  <option value="">— select —</option>
-                  {branches.map(b=>(
-                    <option key={b.id} value={b.id}>{b.name}</option>
-                  ))}
-                </select>
-              </div>
-              {/* Buttons */}
-              <div className="col-span-2 flex justify-end gap-2 mt-4">
-                <button
-                  type="button"
-                  onClick={()=>setShowAddModal(false)}
-                  className="px-4 py-2 bg-gray-300 rounded"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  className="px-4 py-2 bg-green-600 rounded"
-                >
-                  Add
-                </button>
-              </div>
-            </form>
+            {!phoneVerified ? (
+              <form onSubmit={handlePhoneCheck} className="grid grid-cols-2 gap-4 text-gray-900">
+                <div className="col-span-2">
+                  <label className="block mb-1">Phone*</label>
+                  <input
+                    value={newPhone}
+                    onChange={e=>setNewPhone(e.target.value)}
+                    required maxLength={10} pattern="\d{10}"
+                    className="w-full p-2 rounded bg-gray-200"
+                  />
+                </div>
+                <div className="col-span-2 flex justify-end gap-2 mt-4">
+                  <button
+                    type="button"
+                    onClick={()=>{setShowAddModal(false);setNewPhone('');setPhoneVerified(false);setExistingCustomer(null);}}
+                    className="px-4 py-2 bg-gray-300 rounded"
+                  >
+                    Cancel
+                  </button>
+                  <button type="submit" className="px-4 py-2 bg-green-600 rounded">
+                    Next
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <form
+                onSubmit={handleAdd}
+                encType="multipart/form-data"
+                className="grid grid-cols-2 gap-4 text-gray-900"
+              >
+                {/* Profile Pic */}
+                <div className="col-span-2">
+                  <label className="block mb-1">Profile Pic</label>
+                  <input type="file" name="image" accept="image/*" className="w-full"/>
+                  <small className="text-gray-400">optional JPG/PNG</small>
+                </div>
+                {/* Name */}
+                <div>
+                  <label className="block mb-1">Name*</label>
+                  <input
+                    name="name"
+                    defaultValue={existingCustomer?.name}
+                    required
+                    className="w-full p-2 rounded bg-gray-200"
+                  />
+                </div>
+                {/* Email */}
+                <div>
+                  <label className="block mb-1">Email*</label>
+                  <input
+                    name="email"
+                    type="email"
+                    defaultValue={existingCustomer?.email}
+                    required
+                    className="w-full p-2 rounded bg-gray-200"
+                  />
+                </div>
+                {/* Phone */}
+                <div>
+                  <label className="block mb-1">Phone*</label>
+                  <input
+                    name="phone"
+                    value={newPhone}
+                    readOnly
+                    className="w-full p-2 rounded bg-gray-200"
+                  />
+                </div>
+                {/* Gender */}
+                <div>
+                  <label className="block mb-1">Gender*</label>
+                  <select
+                    name="gender"
+                    defaultValue={existingCustomer?.gender || ''}
+                    required
+                    className="w-full p-2 rounded bg-gray-200"
+                  >
+                    <option value="">— select —</option>
+                    <option>Male</option>
+                    <option>Female</option>
+                    <option>Other</option>
+                  </select>
+                </div>
+                {/* DOB */}
+                <div>
+                  <label className="block mb-1">DOB*</label>
+                  <input
+                    name="dob"
+                    type="date"
+                    defaultValue={existingCustomer?.dob?.split?.('T')[0]}
+                    required
+                    className="w-full p-2 rounded bg-gray-200"
+                  />
+                </div>
+                {/* Address */}
+                <div className="col-span-2">
+                  <label className="block mb-1">Address*</label>
+                  <input
+                    name="address"
+                    defaultValue={existingCustomer?.address}
+                    required
+                    className="w-full p-2 rounded bg-gray-200"
+                  />
+                </div>
+                {/* Designation */}
+                <div>
+                  <label className="block mb-1">Designation*</label>
+                  <input
+                    name="designation"
+                    defaultValue={existingCustomer?.designation}
+                    required
+                    className="w-full p-2 rounded bg-gray-200"
+                  />
+                </div>
+                {/* Experience */}
+                <div>
+                  <label className="block mb-1">Experience</label>
+                  <input
+                    name="experience"
+                    defaultValue={existingCustomer?.experience}
+                    className="w-full p-2 rounded bg-gray-200"
+                  />
+                </div>
+                {/* Start Date */}
+                <div>
+                  <label className="block mb-1">Start Date*</label>
+                  <input
+                    name="startDate"
+                    type="date"
+                    required
+                    className="w-full p-2 rounded bg-gray-200"
+                  />
+                </div>
+                {/* Role */}
+                <div>
+                  <label className="block mb-1">Role*</label>
+                  <select
+                    name="role"
+                    defaultValue="staff"
+                    required
+                    className="w-full p-2 rounded bg-gray-200"
+                  >
+                    <option value="staff">staff</option>
+                    <option value="customer_staff">staff & customer</option>
+                    <option value="manager">manager</option>
+                  </select>
+                </div>
+                {/* Branch */}
+                <div>
+                  <label className="block mb-1">Branch*</label>
+                  <select
+                    name="branchId"
+                    required
+                    className="w-full p-2 rounded bg-gray-200"
+                  >
+                    <option value="">— select —</option>
+                    {branches.map(b=>(
+                      <option key={b.id} value={b.id}>{b.name}</option>
+                    ))}
+                  </select>
+                </div>
+                {/* Buttons */}
+                <div className="col-span-2 flex justify-end gap-2 mt-4">
+                  <button
+                    type="button"
+                    onClick={()=>{setShowAddModal(false);setPhoneVerified(false);setExistingCustomer(null);setNewPhone('');}}
+                    className="px-4 py-2 bg-gray-300 rounded"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    className="px-4 py-2 bg-green-600 rounded"
+                  >
+                    Add
+                  </button>
+                </div>
+              </form>
+            )}
           </div>
         </div>
       )}
@@ -581,9 +652,9 @@ const handleExport = () => {
                   required
                   className="w-full p-2 rounded bg-gray-100"
                 >
-                  <option>customer</option>
-                  <option>staff</option>
-                  <option>manager</option>
+                  <option value="staff">staff</option>
+                  <option value="customer_staff">staff & customer</option>
+                  <option value="manager">manager</option>
                 </select>
               </div>
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,7 +3,7 @@ import React, {createContext, useContext, useState, ReactNode, useEffect} from '
 
 interface User {
   name: string
-  role: 'customer' | 'staff' | 'admin'
+  role: 'customer' | 'staff' | 'admin' | 'customer_staff' | 'manager'
 }
 
 interface AuthValue {


### PR DESCRIPTION
## Summary
- treat customer-staff as a combined role across APIs
- promote existing customers by switching their role to `customer_staff`
- expose a "staff & customer" option in the staff UI

## Testing
- `npm run lint` (fails: Unexpected any and other pre-existing lint errors)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_688f420f82fc832589f73174d3ed1aed