### PR TITLE
refactor: redesign admin dashboard

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,16 +1,17 @@
 'use client'
 import { useEffect, useState } from 'react'
+import {
+  Banknote,
+  CalendarDays,
+  IndianRupee,
+  MessageSquare,
+  PhoneCall,
+  Scissors,
+} from 'lucide-react'
 
 interface DashboardData {
   services: number
-  branches: number
-  staff: {
-    total: number
-    active: number
-    removed: number
-  }
   bookings: {
-    total: number
     today: number
     upcoming: {
       id: string
@@ -20,10 +21,13 @@ interface DashboardData {
       staff: { name: string }
     }[]
   }
-  pricing: {
-    avgActualPrice: number
-    avgOfferPrice: number | null
-    activeOffers: number
+  billing: {
+    billedToday: number
+    pending: number
+  }
+  enquiries: {
+    today: number
+    open: number
   }
 }
 
@@ -34,62 +38,57 @@ export default function DashboardPage() {
       .then(res => res.json())
       .then(setData)
   }, [])
+  if (!data) return <p className="p-4">Loading...</p>
 
-  if (!data) return <p>Loading...</p>
+  const stats = [
+    { label: 'Active Services', value: data.services, icon: Scissors, color: 'bg-rose-500' },
+    { label: 'Appointments Today', value: data.bookings.today, icon: CalendarDays, color: 'bg-indigo-500' },
+    { label: 'Billed Today', value: data.billing.billedToday, icon: IndianRupee, color: 'bg-green-500' },
+    { label: 'Enquiries Today', value: data.enquiries.today, icon: PhoneCall, color: 'bg-purple-500' },
+    { label: 'Open Enquiries', value: data.enquiries.open, icon: MessageSquare, color: 'bg-orange-500' },
+    { label: 'Pending Billing', value: data.billing.pending, icon: Banknote, color: 'bg-yellow-500' },
+  ]
 
   return (
-    <div className="space-y-8 p-4">
-      <h1 className="text-3xl font-bold text-green-700 mb-4">Admin Dashboard</h1>
-
-      <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Services</div>
-          <div className="text-2xl font-bold">{data.services}</div>
-        </div>
-        <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Branches</div>
-          <div className="text-2xl font-bold">{data.branches}</div>
-        </div>
-        <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Total Staff</div>
-          <div className="text-2xl font-bold">{data.staff.total}</div>
-        </div>
-        <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Today's Bookings</div>
-          <div className="text-2xl font-bold">{data.bookings.today}</div>
-        </div>
+    <div className="space-y-10 p-6">
+      <section className="bg-gradient-to-r from-green-500 to-emerald-600 text-white rounded-lg p-8 shadow">
+        <h1 className="text-4xl font-bold mb-2">Salon Dashboard</h1>
+        <p className="text-green-100">Overview of your salon performance</p>
       </section>
 
-      <section className="bg-white p-4 rounded shadow space-y-2">
-        <h2 className="text-xl font-semibold">Upcoming Appointments</h2>
-        <ul className="divide-y">
-          {data.bookings.upcoming.map(b => (
-            <li key={b.id} className="py-2 flex justify-between">
-              <span>{b.date} {b.start}</span>
-              <span>{b.customer} with {b.staff.name}</span>
-            </li>
-          ))}
-          {data.bookings.upcoming.length === 0 && (
-            <li className="py-2">No upcoming appointments</li>
-          )}
-        </ul>
+      <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {stats.map(s => (
+          <div key={s.label} className="bg-white p-6 rounded-lg shadow flex items-center">
+            <div className={`${s.color} p-3 rounded-full text-white`}>
+              <s.icon className="h-6 w-6" />
+            </div>
+            <div className="ml-4">
+              <p className="text-sm text-gray-500">{s.label}</p>
+              <p className="text-2xl font-bold">{s.value}</p>
+            </div>
+          </div>
+        ))}
       </section>
 
-      <section className="grid md:grid-cols-2 gap-4">
-        <div className="bg-white p-4 rounded shadow space-y-1">
-          <h2 className="text-xl font-semibold mb-2">Staff Statistics</h2>
-          <p>Total Staff: {data.staff.total}</p>
-          <p>Active: {data.staff.active}</p>
-          <p>Removed: {data.staff.removed}</p>
-        </div>
-        <div className="bg-white p-4 rounded shadow space-y-1">
-          <h2 className="text-xl font-semibold mb-2">Pricing &amp; Offers</h2>
-          <p>Average Price: ₹{data.pricing.avgActualPrice.toFixed(2)}</p>
-          {data.pricing.avgOfferPrice !== null && (
-            <p>Average Offer: ₹{data.pricing.avgOfferPrice.toFixed(2)}</p>
-          )}
-          <p>Active Offers: {data.pricing.activeOffers}</p>
-        </div>
+      <section className="bg-white p-6 rounded-lg shadow">
+        <h2 className="text-xl font-semibold mb-4 flex items-center">
+          <CalendarDays className="h-5 w-5 text-green-600 mr-2" /> Upcoming Appointments
+        </h2>
+        {data.bookings.upcoming.length > 0 ? (
+          <ul className="divide-y">
+            {data.bookings.upcoming.map(b => (
+              <li key={b.id} className="py-3 flex justify-between">
+                <div>
+                  <p className="font-medium">{b.customer || 'Walk-in'}</p>
+                  <p className="text-sm text-gray-500">{b.date} at {b.start}</p>
+                </div>
+                <span className="text-sm text-gray-600">with {b.staff.name}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-gray-500">No upcoming appointments</p>
+        )}
       </section>
     </div>
   )


### PR DESCRIPTION
## Summary
- count active services from pricing history and expose business-focused metrics like appointments today, billed today, open enquiries, and pending billing
- streamline dashboard UI to highlight the new metrics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f502ebff08325b4d9d1c4b33d6c98