### PR TITLE
Add gender applicability to services

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,6 +126,7 @@ model ServiceNew {
   caption     String?
   description String?         @db.LongText
   imageUrl    String?
+  applicableTo String         @map("applicable_to") @db.VarChar(191)
   images      ServiceImage[]
   tiers       ServiceTier[]
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -46,6 +46,7 @@ async function main() {
           name: row['Sub category'],
           caption: row['Service Description']?.slice(0, 120) || null,
           description: row['Service Description'] || null,
+          applicableTo: row['Applicable to'] || 'female',
         },
       });
       serviceMap.set(svcKey, svc);

--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -15,9 +15,10 @@ import {
   DollarSign,
   Clock,
   Tag,
-  FileText,
-  Grid3X3,
-} from "lucide-react"
+    FileText,
+    Grid3X3,
+    Users,
+  } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -50,6 +51,7 @@ interface Service {
   caption?: string | null
   description?: string | null
   imageUrl?: string | null
+  applicableTo: string
   variants: Variant[]
 }
 
@@ -58,7 +60,7 @@ export default function ServicesAdmin() {
   const [category, setCategory] = useState("")
   const [services, setServices] = useState<Service[]>([])
 
-  const emptyService: Partial<Service> = { id: "", name: "", caption: "", description: "", imageUrl: "" }
+  const emptyService: Partial<Service> = { id: "", name: "", caption: "", description: "", imageUrl: "", applicableTo: "" }
   const [serviceForm, setServiceForm] = useState<Partial<Service>>(emptyService)
   const [showServiceForm, setShowServiceForm] = useState(false)
   const [editingService, setEditingService] = useState(false)
@@ -130,6 +132,7 @@ export default function ServicesAdmin() {
       caption: svc.caption || "",
       description: svc.description || "",
       imageUrl: svc.imageUrl || "",
+      applicableTo: svc.applicableTo,
     })
     setEditingService(true)
     setShowServiceForm(true)
@@ -142,6 +145,7 @@ export default function ServicesAdmin() {
       caption: serviceForm.caption,
       description: serviceForm.description,
       imageUrl: serviceForm.imageUrl,
+      applicableTo: serviceForm.applicableTo,
     }
     if (editingService) {
       await fetch(`/api/admin/service-new/${serviceForm.id}`, {
@@ -436,6 +440,27 @@ export default function ServicesAdmin() {
                       placeholder="Short tagline for the service"
                       className="focus:ring-2 focus:ring-blue-500"
                     />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="applicableTo" className="flex items-center gap-2">
+                      <Users className="h-4 w-4" />
+                      Applicable To
+                    </Label>
+                    <Select
+                      value={serviceForm.applicableTo || ""}
+                      onValueChange={(val) => setServiceForm({ ...serviceForm, applicableTo: val })}
+                      required
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select gender" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="male">Male</SelectItem>
+                        <SelectItem value="female">Female</SelectItem>
+                        <SelectItem value="children">Children under 10 years</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
 
                   <div className="space-y-2">

--- a/src/app/api/admin/service-new/[id]/route.ts
+++ b/src/app/api/admin/service-new/[id]/route.ts
@@ -11,6 +11,7 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
       caption: data.caption || null,
       description: data.description || null,
       imageUrl: data.imageUrl || null,
+      applicableTo: data.applicableTo,
     },
   })
   return NextResponse.json(service)

--- a/src/app/api/admin/services-new/[categoryId]/route.ts
+++ b/src/app/api/admin/services-new/[categoryId]/route.ts
@@ -15,6 +15,7 @@ export async function GET(req: Request, { params }: { params: { categoryId: stri
     caption: svc.caption,
     description: svc.description,
     imageUrl: svc.imageUrl,
+    applicableTo: svc.applicableTo,
     variants: svc.tiers.map((t) => ({
       id: t.id,
       name: t.name,
@@ -35,6 +36,7 @@ export async function POST(req: Request, { params }: { params: { categoryId: str
       caption: data.caption || null,
       description: data.description || null,
       imageUrl: data.imageUrl || null,
+      applicableTo: data.applicableTo,
     },
   })
   return NextResponse.json(service)

--- a/src/app/api/admin/services-walkin/[categoryId]/route.ts
+++ b/src/app/api/admin/services-walkin/[categoryId]/route.ts
@@ -7,19 +7,20 @@ export async function GET(
 ) {
   const { categoryId } = params
   const now = new Date()
-  const services = await prisma.serviceNew.findMany({
-    where: { categoryId },
-    select: {
-      id: true,
-      name: true,
-      caption: true,
-      description: true,
-      imageUrl: true,
-      tiers: {
-        select: {
-          id: true,
-          name: true,
-          duration: true,
+    const services = await prisma.serviceNew.findMany({
+      where: { categoryId },
+      select: {
+        id: true,
+        name: true,
+        caption: true,
+        description: true,
+        imageUrl: true,
+        applicableTo: true,
+        tiers: {
+          select: {
+            id: true,
+            name: true,
+            duration: true,
           priceHistory: {
             where: {
               startDate: { lte: now },
@@ -35,17 +36,18 @@ export async function GET(
     orderBy: { name: 'asc' },
   })
 
-  const response = services.map((svc) => ({
-    id: svc.id,
-    name: svc.name,
-    caption: svc.caption,
-    description: svc.description,
-    imageUrl: svc.imageUrl,
-    variants: svc.tiers.map((t) => ({
-      id: t.id,
-      name: t.name,
-      duration: t.duration ?? 0,
-      currentPrice: t.priceHistory[0]
+    const response = services.map((svc) => ({
+      id: svc.id,
+      name: svc.name,
+      caption: svc.caption,
+      description: svc.description,
+      imageUrl: svc.imageUrl,
+      applicableTo: svc.applicableTo,
+      variants: svc.tiers.map((t) => ({
+        id: t.id,
+        name: t.name,
+        duration: t.duration ?? 0,
+        currentPrice: t.priceHistory[0]
         ? {
             actualPrice: t.priceHistory[0].actualPrice,
             offerPrice: t.priceHistory[0].offerPrice,

--- a/src/app/api/services/[id]/route.ts
+++ b/src/app/api/services/[id]/route.ts
@@ -35,17 +35,18 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
       }
     })
 
-    return NextResponse.json({
-      id: service.id,
-      name: service.name,
-      caption: service.caption,
-      description: service.description,
-      imageUrl: service.imageUrl,
-      images: service.images,
-      tiers,
-    })
-  } catch (err) {
-    console.error('/api/services/[id] error:', err)
-    return NextResponse.json({ error: 'Failed to load service' }, { status: 500 })
-  }
+      return NextResponse.json({
+        id: service.id,
+        name: service.name,
+        caption: service.caption,
+        description: service.description,
+        imageUrl: service.imageUrl,
+        applicableTo: service.applicableTo,
+        images: service.images,
+        tiers,
+      })
+    } catch (err) {
+      console.error('/api/services/[id] error:', err)
+      return NextResponse.json({ error: 'Failed to load service' }, { status: 500 })
+    }
 }

--- a/src/app/api/v2/services/[id]/route.ts
+++ b/src/app/api/v2/services/[id]/route.ts
@@ -48,19 +48,20 @@ export async function GET(req, { params }: { params: { id: string } }) {
       })
     )
 
-    const result = {
-      id: service.id,
-      name: service.name,
-      caption: service.caption ?? '',
-      description: service.description ?? '',
-      imageUrl: service.imageUrl ?? null,
-      images: images.map((img) => ({
-        id: img.id,
-        imageUrl: img.imageUrl,
-        caption: img.caption ?? null,
-      })),
-      variants,
-    }
+      const result = {
+        id: service.id,
+        name: service.name,
+        caption: service.caption ?? '',
+        description: service.description ?? '',
+        imageUrl: service.imageUrl ?? null,
+        applicableTo: service.applicableTo,
+        images: images.map((img) => ({
+          id: img.id,
+          imageUrl: img.imageUrl,
+          caption: img.caption ?? null,
+        })),
+        variants,
+      }
 
     return NextResponse.json(result)
   } catch (err) {


### PR DESCRIPTION
## Summary
- add `applicableTo` column for gender targeting on `ServiceNew`
- allow admins to choose male, female or children for each service
- expose gender applicability through service APIs

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unused vars, and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891756194748325b97fd439923d86f7