### PR TITLE
Include gender in service slugs

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -52,7 +52,7 @@ async function main() {
         data: {
           categoryId: category.id,
           name: row['Sub category'],
-          slug: slugify(row['Sub category']),
+          slug: slugify(`${row['Sub category']} ${row['Applicable to'] || 'female'}`),
           caption: row['Service Description']?.slice(0, 120) || null,
           description: row['Service Description'] || null,
           applicableTo: row['Applicable to'] || 'female',

--- a/src/app/api/admin/service-new/[id]/route.ts
+++ b/src/app/api/admin/service-new/[id]/route.ts
@@ -9,7 +9,7 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
     where: { id },
     data: {
       name: data.name,
-      slug: slugify(data.name),
+      slug: slugify(`${data.name} ${data.applicableTo}`),
       caption: data.caption || null,
       description: data.description || null,
       imageUrl: data.imageUrl || null,

--- a/src/app/api/admin/services-new/[categoryId]/route.ts
+++ b/src/app/api/admin/services-new/[categoryId]/route.ts
@@ -41,7 +41,7 @@ export async function POST(
     data: {
       categoryId,
       name: data.name,
-      slug: slugify(data.name),
+      slug: slugify(`${data.name} ${data.applicableTo}`),
       caption: data.caption || null,
       description: data.description || null,
       imageUrl: data.imageUrl || null,

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -89,7 +89,14 @@ export default function ServiceCard({
             )}
             {!hideDetails && (
               <Link
-                href={`/services/${variant.slug ?? slugify(variant.serviceName)}`}
+                href={`/services/${
+                  variant.slug ??
+                  slugify(
+                    variant.applicableTo
+                      ? `${variant.serviceName} ${variant.applicableTo}`
+                      : variant.serviceName
+                  )
+                }`}
                 className="text-blue-600 underline text-sm"
               >
                 Details


### PR DESCRIPTION
## Summary
- ensure service slugs incorporate the applicable gender
- update seed data and ServiceCard links to use gendered slugs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68930275d5a48325ba31cd046a75253d