### PR TITLE
feat: add web enquiry booking and tracking

### DIFF
--- a/prisma/migrations/20250901000000_web_enquiry/migration.sql
+++ b/prisma/migrations/20250901000000_web_enquiry/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `Enquiry`
+    ADD COLUMN `name` VARCHAR(191) NULL,
+    ADD COLUMN `phone` VARCHAR(191) NULL,
+    ADD COLUMN `gender` VARCHAR(191) NULL,
+    ADD COLUMN `source` VARCHAR(191) NOT NULL DEFAULT 'admin',
+    MODIFY `customerId` VARCHAR(191) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -242,12 +242,16 @@ model HeroTabVariant {
 
 model Enquiry {
   id         String   @id @default(uuid()) @db.VarChar(191)
-  customerId String   @db.VarChar(191)
-  customer   User     @relation(fields: [customerId], references: [id])
+  customerId String?  @db.VarChar(191)
+  customer   User?    @relation(fields: [customerId], references: [id])
+  name       String?  @db.VarChar(191)
+  phone      String?  @db.VarChar(191)
+  gender     String?  @db.VarChar(191)
   enquiry    String?  @db.LongText
   variantIds String?  @db.Text
   status     String   @default("new") @db.VarChar(191)
   remark     String?  @db.Text
+  source     String   @default("admin") @db.VarChar(191)
   createdAt  DateTime @default(now()) @db.Timestamp(3)
   updatedAt  DateTime @default(now()) @updatedAt @db.Timestamp(3)
 }

--- a/src/app/admin/enquiries/page.tsx
+++ b/src/app/admin/enquiries/page.tsx
@@ -21,6 +21,7 @@ import {
   Filter,
   X,
   AlertCircle,
+  Globe,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -45,6 +46,10 @@ interface Enquiry {
   createdAt: string
   status: string
   remark?: string | null
+  source: string
+  name?: string | null
+  phone?: string | null
+  gender?: string | null
   customer?: { id: string; name: string | null; phone: string | null; gender: string | null }
 }
 
@@ -53,6 +58,8 @@ interface Stats {
   new: number
   processing: number
   closed: number
+  web: number
+  webClosed: number
 }
 
 export default function EnquiriesPage() {
@@ -63,7 +70,7 @@ export default function EnquiriesPage() {
   const [prevEnquiries, setPrevEnquiries] = useState<Enquiry[]>([])
   const [enquiries, setEnquiries] = useState<Enquiry[]>([])
   const [variants, setVariants] = useState<VariantOption[]>([])
-  const [stats, setStats] = useState<Stats>({ today: 0, new: 0, processing: 0, closed: 0 })
+  const [stats, setStats] = useState<Stats>({ today: 0, new: 0, processing: 0, closed: 0, web: 0, webClosed: 0 })
   const [selected, setSelected] = useState<Enquiry | null>(null)
   const [modalStatus, setModalStatus] = useState("")
   const [modalRemark, setModalRemark] = useState("")
@@ -81,6 +88,8 @@ export default function EnquiriesPage() {
     { key: "new", label: "New", value: stats.new, bgColor: "bg-green-500", icon: Sparkles },
     { key: "processing", label: "Processing", value: stats.processing, bgColor: "bg-yellow-500", icon: Clock },
     { key: "closed", label: "Closed", value: stats.closed, bgColor: "bg-gray-500", icon: CheckCircle2 },
+    { key: "web", label: "Web Enquiries", value: stats.web, bgColor: "bg-purple-500", icon: Globe },
+    { key: "webClosed", label: "Web Closed", value: stats.webClosed, bgColor: "bg-pink-500", icon: CheckCircle2 },
   ]
 
   const handlePhoneChange = (value: string) => {
@@ -96,7 +105,7 @@ export default function EnquiriesPage() {
   }
 
   const bookServices = () => {
-    if (!selected) return
+    if (!selected?.customer) return
     const params = new URLSearchParams()
     if (selected.customer?.name) params.set("name", selected.customer.name)
     if (selected.customer?.phone) params.set("phone", selected.customer.phone)
@@ -188,6 +197,14 @@ export default function EnquiriesPage() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ status: modalStatus, remark: modalRemark }),
     })
+    setSelected(null)
+    loadEnquiries()
+    loadStats()
+  }
+
+  const convertToCustomer = async () => {
+    if (!selected) return
+    await fetch(`/api/admin/enquiries/${selected.id}/convert`, { method: 'POST' })
     setSelected(null)
     loadEnquiries()
     loadStats()
@@ -395,6 +412,7 @@ export default function EnquiriesPage() {
                 <tr className="bg-gray-50">
                   <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Date</th>
                   <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Status</th>
+                  <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Source</th>
                   <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Remark</th>
                 </tr>
               </thead>
@@ -404,6 +422,9 @@ export default function EnquiriesPage() {
                     <td className="py-3 px-4 border-b">{new Date(p.createdAt).toLocaleDateString()}</td>
                     <td className="py-3 px-4 border-b">
                       <Badge className={`${statusColors[p.status] || ""} capitalize`}>{p.status}</Badge>
+                    </td>
+                    <td className="py-3 px-4 border-b">
+                      <Badge className="capitalize">{p.source}</Badge>
                     </td>
                     <td className="py-3 px-4 border-b">{p.remark || "-"}</td>
                   </tr>
@@ -426,6 +447,7 @@ export default function EnquiriesPage() {
                 <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Customer</th>
                 <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Phone</th>
                 <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Status</th>
+                <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Source</th>
                 <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Date</th>
                 <th className="text-left py-3 px-4 font-medium text-gray-700 border-b">Action</th>
               </tr>
@@ -442,13 +464,18 @@ export default function EnquiriesPage() {
                         {e.customer.name || "Unnamed"}
                         <ArrowUpRight className="h-4 w-4 ml-1" />
                       </Link>
+                    ) : e.name ? (
+                      <span className="text-gray-700">{e.name}</span>
                     ) : (
                       <span className="text-gray-500">-</span>
                     )}
                   </td>
-                  <td className="py-3 px-4 border-b font-mono">{e.customer?.phone || "-"}</td>
+                  <td className="py-3 px-4 border-b font-mono">{e.customer?.phone || e.phone || "-"}</td>
                   <td className="py-3 px-4 border-b">
                     <Badge className={`${statusColors[e.status] || ""} capitalize`}>{e.status}</Badge>
+                  </td>
+                  <td className="py-3 px-4 border-b">
+                    <Badge className="capitalize">{e.source}</Badge>
                   </td>
                   <td className="py-3 px-4 border-b">{new Date(e.createdAt).toLocaleDateString()}</td>
                   <td className="py-3 px-4 border-b">
@@ -489,11 +516,11 @@ export default function EnquiriesPage() {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
                     <span className="font-medium text-gray-700">Name:</span>
-                    <p className="text-gray-600 mt-1">{selected.customer?.name || "-"}</p>
+                    <p className="text-gray-600 mt-1">{selected.customer?.name || selected.name || "-"}</p>
                   </div>
                   <div>
                     <span className="font-medium text-gray-700">Phone:</span>
-                    <p className="text-gray-600 font-mono mt-1">{selected.customer?.phone || "-"}</p>
+                    <p className="text-gray-600 font-mono mt-1">{selected.customer?.phone || selected.phone || "-"}</p>
                   </div>
                 </div>
 
@@ -564,15 +591,27 @@ export default function EnquiriesPage() {
                       View Profile
                     </Link>
                   )}
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={bookServices}
-                    className="border-green-300 text-green-700 hover:bg-green-50 bg-transparent"
-                  >
-                    <BookOpen className="h-4 w-4 mr-1" />
-                    Book Services
-                  </Button>
+                  {selected.customer ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={bookServices}
+                      className="border-green-300 text-green-700 hover:bg-green-50 bg-transparent"
+                    >
+                      <BookOpen className="h-4 w-4 mr-1" />
+                      Book Services
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={convertToCustomer}
+                      className="border-green-300 text-green-700 hover:bg-green-50 bg-transparent"
+                    >
+                      <User className="h-4 w-4 mr-1" />
+                      Convert to Customer
+                    </Button>
+                  )}
                 </div>
 
                 <div className="flex gap-2">

--- a/src/app/api/admin/enquiries/[id]/convert/route.ts
+++ b/src/app/api/admin/enquiries/[id]/convert/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const enquiry = await prisma.enquiry.findUnique({ where: { id: params.id } })
+  if (!enquiry) {
+    return NextResponse.json({ success: false, error: 'Enquiry not found' }, { status: 404 })
+  }
+  if (enquiry.customerId) {
+    return NextResponse.json({ success: false, error: 'Enquiry already linked to customer' }, { status: 400 })
+  }
+  const customer = await prisma.user.create({
+    data: {
+      name: enquiry.name || undefined,
+      phone: enquiry.phone || undefined,
+      gender: enquiry.gender || undefined,
+      role: 'customer',
+    },
+  })
+  await prisma.enquiry.update({
+    where: { id: enquiry.id },
+    data: { customerId: customer.id },
+  })
+  return NextResponse.json({ success: true, customer })
+}

--- a/src/app/api/admin/enquiries/route.ts
+++ b/src/app/api/admin/enquiries/route.ts
@@ -7,10 +7,13 @@ export async function GET(req: NextRequest) {
   if (phone) {
     const customer = await prisma.user.findUnique({ where: { phone } })
     const enquiries = await prisma.enquiry.findMany({
-      where: { customer: { phone } },
+      where: {
+        OR: [{ customer: { phone } }, { phone }],
+      },
       orderBy: { createdAt: 'desc' },
+      include: { customer: true },
     })
-    const result = enquiries.map(e => ({
+    const result = enquiries.map((e) => ({
       ...e,
       variantIds: e.variantIds ? JSON.parse(e.variantIds) : [],
     }))
@@ -21,7 +24,7 @@ export async function GET(req: NextRequest) {
     orderBy: { createdAt: 'desc' },
     include: { customer: true },
   })
-  const result = data.map(e => ({
+  const result = data.map((e) => ({
     ...e,
     variantIds: e.variantIds ? JSON.parse(e.variantIds) : [],
   }))
@@ -45,9 +48,13 @@ export async function POST(req: NextRequest) {
     const saved = await prisma.enquiry.create({
       data: {
         customerId: customer.id,
+        name,
+        phone,
+        gender,
         enquiry: enquiry || null,
         variantIds: Array.isArray(variantIds) ? JSON.stringify(variantIds) : null,
         status: 'new',
+        source: 'admin',
       },
     })
 

--- a/src/app/api/admin/enquiries/stats/route.ts
+++ b/src/app/api/admin/enquiries/stats/route.ts
@@ -10,5 +10,7 @@ export async function GET() {
   const newCount = await prisma.enquiry.count({ where: { status: 'new' } })
   const processing = await prisma.enquiry.count({ where: { status: 'processing' } })
   const closed = await prisma.enquiry.count({ where: { status: 'closed' } })
-  return NextResponse.json({ today, new: newCount, processing, closed })
+  const web = await prisma.enquiry.count({ where: { source: 'web' } })
+  const webClosed = await prisma.enquiry.count({ where: { source: 'web', status: 'closed' } })
+  return NextResponse.json({ today, new: newCount, processing, closed, web, webClosed })
 }

--- a/src/app/api/web-enquiries/route.ts
+++ b/src/app/api/web-enquiries/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, phone, gender, enquiry, variantIds } = await req.json()
+    if (!name || !phone) {
+      return NextResponse.json({ success: false, error: 'Name and phone are required' }, { status: 400 })
+    }
+    const saved = await prisma.enquiry.create({
+      data: {
+        name,
+        phone,
+        gender: gender || null,
+        enquiry: enquiry || null,
+        variantIds: Array.isArray(variantIds) ? JSON.stringify(variantIds) : null,
+        status: 'new',
+        source: 'web',
+      },
+    })
+    return NextResponse.json({ success: true, enquiry: saved })
+  } catch (error) {
+    console.error('Error in POST /api/web-enquiries', error)
+    return NextResponse.json({ success: false, error: 'Failed to save enquiry' }, { status: 500 })
+  }
+}

--- a/src/app/book-appointment/page.tsx
+++ b/src/app/book-appointment/page.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import Header from "@/components/Header"
+import Footer from "@/components/Footer"
+import Select, { type MultiValue } from "react-select"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { Save } from "lucide-react"
+
+interface VariantOption {
+  id: string
+  categoryName: string
+  serviceName: string
+  variantName: string
+}
+
+export default function BookAppointmentPage() {
+  const [form, setForm] = useState({ name: "", phone: "", gender: "", enquiry: "", variantIds: [] as string[] })
+  const [variants, setVariants] = useState<VariantOption[]>([])
+  const [submitted, setSubmitted] = useState(false)
+
+  useEffect(() => {
+    fetch("/api/admin/service-variants/all")
+      .then((res) => res.json())
+      .then((data) => setVariants(data))
+  }, [])
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch("/api/web-enquiries", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(form),
+    })
+    if (res.ok) {
+      setSubmitted(true)
+      setForm({ name: "", phone: "", gender: "", enquiry: "", variantIds: [] })
+    }
+  }
+
+  return (
+    <main className="flex flex-col min-h-screen bg-white">
+      <Header />
+      <div className="flex-1 container mx-auto px-4 py-8">
+        {submitted ? (
+          <div className="max-w-xl mx-auto text-center p-6 bg-white border rounded-lg shadow">
+            <p className="text-green-600">Thank you! We will contact you shortly.</p>
+          </div>
+        ) : (
+          <form onSubmit={submit} className="max-w-xl mx-auto space-y-4 bg-white p-6 border rounded-lg shadow">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="name">Name</Label>
+                <Input
+                  id="name"
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="phone">Phone</Label>
+                <Input
+                  id="phone"
+                  value={form.phone}
+                  onChange={(e) =>
+                    setForm({ ...form, phone: e.target.value.replace(/\D/g, "").slice(0, 10) })
+                  }
+                  required
+                />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="gender">Gender</Label>
+              <select
+                id="gender"
+                className="w-full mt-1 p-2 border rounded-md"
+                value={form.gender}
+                onChange={(e) => setForm({ ...form, gender: e.target.value })}
+                required
+              >
+                <option value="">Select Gender</option>
+                <option value="male">Male</option>
+                <option value="female">Female</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
+            <div>
+              <Label>Customer Enquiry</Label>
+              <Textarea
+                className="mt-1"
+                value={form.enquiry}
+                onChange={(e) => setForm({ ...form, enquiry: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label>Services Interested In</Label>
+              <Select
+                isMulti
+                className="mt-1 text-sm"
+                classNamePrefix="select"
+                options={variants.map((v) => ({
+                  value: v.id,
+                  label: `${v.categoryName} - ${v.serviceName} (${v.variantName})`,
+                }))}
+                value={variants
+                  .filter((v) => form.variantIds.includes(v.id))
+                  .map((v) => ({
+                    value: v.id,
+                    label: `${v.categoryName} - ${v.serviceName} (${v.variantName})`,
+                  }))}
+                onChange={(vals: MultiValue<{ value: string; label: string }>) =>
+                  setForm({ ...form, variantIds: vals.map((v) => v.value) })
+                }
+              />
+            </div>
+            <Button type="submit" className="bg-green-600 hover:bg-green-700 text-white">
+              <Save className="h-4 w-4 mr-1" /> Submit
+            </Button>
+          </form>
+        )}
+      </div>
+      <Footer />
+    </main>
+  )
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -144,6 +144,11 @@ export default function HomePage() {
   return (
     <main className="bg-white min-h-screen font-sans text-gray-800">
       <Header />
+      <div className="text-center mt-4">
+        <Link href="/book-appointment" className="text-green-700 font-semibold hover:underline">
+          Book an Appointment
+        </Link>
+      </div>
 
       {/* HERO SECTION (DARK) */}
       <section className="relative flex flex-col overflow-hidden min-h-[70vh] md:min-h-[70vh] bg-gray-800">
@@ -597,6 +602,12 @@ export default function HomePage() {
           <p className="text-xs mt-2">TC 45/215, Kunjalumood Junction, Karamana PO, Trivandrum</p>
         </div>
       </footer>
+      <Link
+        href="/book-appointment"
+        className="fixed bottom-6 right-6 bg-green-600 text-white px-4 py-2 rounded-full shadow-lg"
+      >
+        Book Appointment
+      </Link>
     </main>
   )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,6 +37,9 @@ export default function Header() {
       <Link href="#" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
         My Account
       </Link>
+      <Link href="/book-appointment" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+        Book Appointment
+      </Link>
     </>
   )
 


### PR DESCRIPTION
## Summary
- add dedicated Book Appointment page and navigation links
- store and tag web enquiries without auto-creating customers
- display web enquiry stats and conversion option in admin dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / unused vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893274c3c388325961f13d54e6fe33c