### PR TITLE
Fix billing print prices

### DIFF
--- a/pages/api/billing-services.ts
+++ b/pages/api/billing-services.ts
@@ -25,6 +25,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     tiers.forEach(t => {
       tierMap[t.id] = t
     })
+
     const tz = "+05:30"
     const billed = await prisma.billing.findMany({
       where: {
@@ -44,14 +45,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       service: string
       variant: string
       start: string
-      price: number
+      actualPrice: number
+      offerPrice: number
       scheduledAt: string
     }[] = []
-    bookings.forEach(b => {
-      b.items.forEach(it => {
+    for (const b of bookings) {
+      for (const it of b.items) {
         const scheduledAt = new Date(`${b.date}T${it.start}:00${tz}`)
-        if (billedSet.has(scheduledAt.toISOString())) return
+        if (billedSet.has(scheduledAt.toISOString())) continue
         const tier = tierMap[it.tierId]
+        const ph = await prisma.serviceTierPriceHistory.findFirst({
+          where: {
+            tierId: it.tierId,
+            startDate: { lte: scheduledAt },
+            OR: [{ endDate: null }, { endDate: { gte: scheduledAt } }],
+          },
+          orderBy: { startDate: 'desc' },
+        })
+        const actualPrice = ph?.actualPrice ?? tier?.actualPrice ?? it.price
+        const offerPrice = ph?.offerPrice ?? tier?.offerPrice ?? actualPrice
         services.push({
           id: it.id,
           phone: b.phone,
@@ -60,11 +72,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           service: tier?.service.name || '',
           variant: tier?.name || it.name,
           start: it.start,
-          price: it.price,
+          actualPrice,
+          offerPrice,
           scheduledAt: scheduledAt.toISOString(),
         })
-      })
-    })
+      }
+    }
     return res.status(200).json(services)
   } catch (err) {
     console.error('billing services error', err)

--- a/src/app/admin/billing/page.tsx
+++ b/src/app/admin/billing/page.tsx
@@ -33,7 +33,8 @@ interface ServiceInfo {
   service: string
   variant: string
   start: string
-  price: number
+  actualPrice: number
+  offerPrice: number
   scheduledAt: string
 }
 
@@ -76,18 +77,18 @@ export default function BillingPage() {
     return classes[idx % classes.length]
   }
 
-  const totalBefore = selected.reduce((acc, id) => {
+  const totalOffer = selected.reduce((acc, id) => {
     const s = services.find((s) => s.id === id)
-    return acc + (s?.price || 0)
+    return acc + (s?.offerPrice ?? s?.actualPrice ?? 0)
   }, 0)
 
   const discount = coupon
     ? coupon.discountType === "fixed"
       ? coupon.discountValue
-      : (coupon.discountValue / 100) * totalBefore
+      : (coupon.discountValue / 100) * totalOffer
     : 0
 
-  const finalTotal = totalBefore - discount
+  const finalTotal = totalOffer - discount
   const gstAmount = finalTotal * 0.18
 
   const applyVoucher = async () => {
@@ -110,8 +111,8 @@ export default function BillingPage() {
         category: s.category,
         service: s.service,
         variant: s.variant,
-        amountBefore: s.price,
-        amountAfter: s.price * (finalTotal / totalBefore || 1),
+        amountBefore: s.actualPrice,
+        amountAfter: (s.offerPrice ?? s.actualPrice) * (finalTotal / totalOffer || 1),
         scheduledAt: s.scheduledAt,
       }))
     const phones = Array.from(new Set(svcData.map((s) => s.phone).filter(Boolean))) as string[]
@@ -218,7 +219,7 @@ export default function BillingPage() {
                         <span className="text-muted-foreground">({s.variant})</span>
                         <span className="ml-auto font-semibold text-foreground">
                           <IndianRupee className="inline-block h-4 w-4 mr-1" />
-                          {s.price.toFixed(2)}
+                          {(s.offerPrice ?? s.actualPrice).toFixed(2)}
                         </span>
                         <span className="text-sm text-muted-foreground w-full text-right">
                           Scheduled: {format(new Date(s.scheduledAt), "MMM dd, yyyy hh:mm a")}
@@ -253,7 +254,7 @@ export default function BillingPage() {
                             </span>
                             <span className="font-medium text-foreground">
                               <IndianRupee className="inline-block h-3 w-3 mr-0.5" />
-                              {s.price.toFixed(2)}
+                              {(s.offerPrice ?? s.actualPrice).toFixed(2)}
                             </span>
                           </li>
                         )
@@ -266,7 +267,7 @@ export default function BillingPage() {
                       <span className="text-muted-foreground">Subtotal:</span>
                       <span className="font-semibold text-foreground">
                         <IndianRupee className="inline-block h-4 w-4 mr-1" />
-                        {totalBefore.toFixed(2)}
+                        {totalOffer.toFixed(2)}
                       </span>
                     </p>
                     {coupon && (


### PR DESCRIPTION
## Summary
- pull active service tier price history for scheduled services to read actual and offer prices
- calculate billing totals using offer price and store both actual and offer amounts
- fall back to tier offer price when history lacks an offer entry
- fix total offer calculation to avoid nullish coalescing syntax error

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689378c6e66083258834791ec700932d