### PR TITLE
Refactor dashboard to load data server-side with additional metrics

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,13 +1,41 @@
 import React from 'react'
+import Link from 'next/link'
 import { getDashboardData } from '@/lib/dashboard'
+import {
+  Scissors,
+  MapPin,
+  Users,
+  User,
+  CalendarCheck,
+  IndianRupee,
+  MessageCircle,
+} from 'lucide-react'
 
-function StatCard({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div className="bg-white p-4 rounded shadow border">
-      <div className="text-sm text-gray-500">{label}</div>
-      <div className="text-2xl font-bold">{value}</div>
+interface StatCardProps {
+  label: string
+  value: React.ReactNode
+  icon: React.ComponentType<{ className?: string }>
+  color: string
+  bg: string
+  href?: string
+  subtext?: string
+}
+
+function StatCard({ label, value, icon: Icon, color, bg, href, subtext }: StatCardProps) {
+  const content = (
+    <div className="bg-white p-4 rounded shadow border flex items-center space-x-4 hover:shadow-md transition">
+      <div className={`p-2 rounded-full ${bg}`}>
+        <Icon className={`h-6 w-6 ${color}`} />
+      </div>
+      <div>
+        <div className="text-sm text-gray-500">{label}</div>
+        <div className="text-2xl font-bold leading-tight">{value}</div>
+        {subtext && <div className="text-xs text-gray-400">{subtext}</div>}
+      </div>
     </div>
   )
+
+  return href ? <Link href={href}>{content}</Link> : content
 }
 
 export default async function DashboardPage() {
@@ -18,14 +46,88 @@ export default async function DashboardPage() {
       <h1 className="text-3xl font-bold text-green-700 mb-4">Admin Dashboard</h1>
 
       <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard label="Services" value={data.services} />
-        <StatCard label="Branches" value={data.branches} />
-        <StatCard label="Total Staff" value={data.staff.total} />
-        <StatCard label="Customers" value={data.customers} />
-        <StatCard label="Today's Bookings" value={data.bookings.today} />
-        <StatCard label="Revenue" value={`₹${data.revenue.toFixed(2)}`} />
-        <StatCard label="Today's Enquiries" value={data.enquiries.today} />
-        <StatCard label="Open Enquiries" value={data.enquiries.open} />
+        <StatCard
+          label="Services"
+          value={data.services}
+          icon={Scissors}
+          color="text-blue-600"
+          bg="bg-blue-100"
+          href="/admin/services"
+        />
+        <StatCard
+          label="Branches"
+          value={data.branches}
+          icon={MapPin}
+          color="text-purple-600"
+          bg="bg-purple-100"
+          href="/admin/branches"
+        />
+        <StatCard
+          label="Total Staff"
+          value={data.staff.total}
+          icon={Users}
+          color="text-amber-600"
+          bg="bg-amber-100"
+          href="/admin/staff"
+        />
+        <StatCard
+          label="Customers"
+          value={data.customers}
+          icon={User}
+          color="text-green-600"
+          bg="bg-green-100"
+          href="/admin/customers"
+        />
+        <StatCard
+          label="Total Bookings"
+          value={data.bookings.total}
+          icon={CalendarCheck}
+          color="text-pink-600"
+          bg="bg-pink-100"
+          href="/admin/billing-history"
+        />
+        <StatCard
+          label="Today's Bookings"
+          value={data.bookings.today}
+          icon={CalendarCheck}
+          color="text-pink-600"
+          bg="bg-pink-100"
+          href="/admin/billing-history"
+        />
+        <StatCard
+          label="Total Revenue"
+          value={`₹${data.revenue.total.toFixed(2)}`}
+          subtext={`GST ₹${data.revenue.gstTotal.toFixed(2)}`}
+          icon={IndianRupee}
+          color="text-teal-600"
+          bg="bg-teal-100"
+          href="/admin/billing-history"
+        />
+        <StatCard
+          label="Today's Revenue"
+          value={`₹${data.revenue.today.toFixed(2)}`}
+          subtext={`GST ₹${data.revenue.gstToday.toFixed(2)}`}
+          icon={IndianRupee}
+          color="text-teal-600"
+          bg="bg-teal-100"
+          href="/admin/billing-history"
+        />
+        <StatCard
+          label="Today's Enquiries"
+          value={data.enquiries.today}
+          icon={MessageCircle}
+          color="text-red-600"
+          bg="bg-red-100"
+          href="/admin/enquiries"
+        />
+        <StatCard
+          label="Open Enquiries"
+          value={data.enquiries.open}
+          icon={MessageCircle}
+          color="text-red-600"
+          bg="bg-red-100"
+          href="/admin/enquiries"
+        />
       </section>
 
       <section className="bg-white p-4 rounded shadow space-y-2">

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,63 +1,31 @@
-'use client'
-import { useEffect, useState } from 'react'
+import React from 'react'
+import { getDashboardData } from '@/lib/dashboard'
 
-interface DashboardData {
-  services: number
-  branches: number
-  staff: {
-    total: number
-    active: number
-    removed: number
-  }
-  bookings: {
-    total: number
-    today: number
-    upcoming: {
-      id: string
-      customer: string
-      date: string
-      start: string
-      staff: { name: string }
-    }[]
-  }
-  pricing: {
-    avgActualPrice: number
-    avgOfferPrice: number | null
-    activeOffers: number
-  }
+function StatCard({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="bg-white p-4 rounded shadow border">
+      <div className="text-sm text-gray-500">{label}</div>
+      <div className="text-2xl font-bold">{value}</div>
+    </div>
+  )
 }
 
-export default function DashboardPage() {
-  const [data, setData] = useState<DashboardData | null>(null)
-  useEffect(() => {
-    fetch('/api/admin/dashboard')
-      .then(res => res.json())
-      .then(setData)
-  }, [])
-
-  if (!data) return <p>Loading...</p>
+export default async function DashboardPage() {
+  const data = await getDashboardData()
 
   return (
     <div className="space-y-8 p-4">
       <h1 className="text-3xl font-bold text-green-700 mb-4">Admin Dashboard</h1>
 
       <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Services</div>
-          <div className="text-2xl font-bold">{data.services}</div>
-        </div>
-        <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Branches</div>
-          <div className="text-2xl font-bold">{data.branches}</div>
-        </div>
-        <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Total Staff</div>
-          <div className="text-2xl font-bold">{data.staff.total}</div>
-        </div>
-        <div className="bg-white p-4 rounded shadow border">
-          <div className="text-sm text-gray-500">Today's Bookings</div>
-          <div className="text-2xl font-bold">{data.bookings.today}</div>
-        </div>
+        <StatCard label="Services" value={data.services} />
+        <StatCard label="Branches" value={data.branches} />
+        <StatCard label="Total Staff" value={data.staff.total} />
+        <StatCard label="Customers" value={data.customers} />
+        <StatCard label="Today's Bookings" value={data.bookings.today} />
+        <StatCard label="Revenue" value={`₹${data.revenue.toFixed(2)}`} />
+        <StatCard label="Today's Enquiries" value={data.enquiries.today} />
+        <StatCard label="Open Enquiries" value={data.enquiries.open} />
       </section>
 
       <section className="bg-white p-4 rounded shadow space-y-2">
@@ -66,7 +34,7 @@ export default function DashboardPage() {
           {data.bookings.upcoming.map(b => (
             <li key={b.id} className="py-2 flex justify-between">
               <span>{b.date} {b.start}</span>
-              <span>{b.customer} with {b.staff.name}</span>
+              <span>{b.customer ?? 'Walk-in'} with {b.staff.name}</span>
             </li>
           ))}
           {data.bookings.upcoming.length === 0 && (
@@ -75,7 +43,7 @@ export default function DashboardPage() {
         </ul>
       </section>
 
-      <section className="grid md:grid-cols-2 gap-4">
+      <section className="grid md:grid-cols-3 gap-4">
         <div className="bg-white p-4 rounded shadow space-y-1">
           <h2 className="text-xl font-semibold mb-2">Staff Statistics</h2>
           <p>Total Staff: {data.staff.total}</p>
@@ -90,7 +58,13 @@ export default function DashboardPage() {
           )}
           <p>Active Offers: {data.pricing.activeOffers}</p>
         </div>
+        <div className="bg-white p-4 rounded shadow space-y-1">
+          <h2 className="text-xl font-semibold mb-2">Enquiries</h2>
+          <p>Today's Enquiries: {data.enquiries.today}</p>
+          <p>Open Enquiries: {data.enquiries.open}</p>
+        </div>
       </section>
     </div>
   )
 }
+

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -1,57 +1,13 @@
 import { NextResponse } from 'next/server'
-import { prisma } from '@/lib/prisma'
+import { getDashboardData } from '@/lib/dashboard'
 
 export async function GET() {
   try {
-    const today = new Date().toISOString().split('T')[0]
-    const [
-      servicesCount,
-      branchesCount,
-      activeStaff,
-      removedStaff,
-      totalBookings,
-      todayBookings,
-      upcoming,
-      priceAvg,
-      activeOffers,
-    ] = await prisma.$transaction([
-      prisma.service.count(),
-      prisma.branch.count(),
-      prisma.user.count({ where: { role: { in: ['staff', 'customer_staff'] }, removed: false } }),
-      prisma.user.count({ where: { role: { in: ['staff', 'customer_staff'] }, removed: true } }),
-      prisma.booking.count(),
-      prisma.booking.count({ where: { date: today } }),
-      prisma.booking.findMany({
-        where: { date: { gte: today } },
-        include: { staff: { select: { name: true } }, items: true },
-        orderBy: [{ date: 'asc' }, { start: 'asc' }],
-        take: 5,
-      }),
-      prisma.serviceTier.aggregate({ _avg: { actualPrice: true, offerPrice: true } }),
-      prisma.serviceTier.count({ where: { offerPrice: { not: null } } }),
-    ])
-
-    return NextResponse.json({
-      services: servicesCount,
-      branches: branchesCount,
-      staff: {
-        total: activeStaff + removedStaff,
-        active: activeStaff,
-        removed: removedStaff,
-      },
-      bookings: {
-        total: totalBookings,
-        today: todayBookings,
-        upcoming,
-      },
-      pricing: {
-        avgActualPrice: priceAvg._avg.actualPrice ?? 0,
-        avgOfferPrice: priceAvg._avg.offerPrice,
-        activeOffers,
-      },
-    })
+    const data = await getDashboardData()
+    return NextResponse.json(data)
   } catch (err: any) {
     console.error('dashboard api error', err)
     return NextResponse.json({ error: 'failed' }, { status: 500 })
   }
 }
+

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -1,0 +1,105 @@
+import { prisma } from '@/lib/prisma'
+
+export interface DashboardData {
+  services: number
+  branches: number
+  staff: {
+    total: number
+    active: number
+    removed: number
+  }
+  bookings: {
+    total: number
+    today: number
+    upcoming: {
+      id: string
+      customer: string | null
+      date: string
+      start: string
+      staff: { name: string }
+    }[]
+  }
+  pricing: {
+    avgActualPrice: number
+    avgOfferPrice: number | null
+    activeOffers: number
+  }
+  customers: number
+  revenue: number
+  enquiries: {
+    today: number
+    open: number
+  }
+}
+
+export async function getDashboardData(): Promise<DashboardData> {
+  const today = new Date().toISOString().split('T')[0]
+  const startOfToday = new Date()
+  startOfToday.setHours(0, 0, 0, 0)
+  const endOfToday = new Date()
+  endOfToday.setHours(23, 59, 59, 999)
+
+  const [
+    servicesCount,
+    branchesCount,
+    activeStaff,
+    removedStaff,
+    totalBookings,
+    todayBookings,
+    upcoming,
+    priceAvg,
+    activeOffers,
+    customersCount,
+    revenueSum,
+    todayEnquiries,
+    openEnquiries,
+  ] = await prisma.$transaction([
+    prisma.service.count(),
+    prisma.branch.count(),
+    prisma.user.count({ where: { role: { in: ['staff', 'customer_staff'] }, removed: false } }),
+    prisma.user.count({ where: { role: { in: ['staff', 'customer_staff'] }, removed: true } }),
+    prisma.booking.count(),
+    prisma.booking.count({ where: { date: today } }),
+    prisma.booking.findMany({
+      where: { date: { gte: today } },
+      include: { staff: { select: { name: true } }, items: true },
+      orderBy: [{ date: 'asc' }, { start: 'asc' }],
+      take: 5,
+    }),
+    prisma.serviceTier.aggregate({ _avg: { actualPrice: true, offerPrice: true } }),
+    prisma.serviceTier.count({ where: { offerPrice: { not: null } } }),
+    prisma.user.count({ where: { role: 'customer', removed: false } }),
+    prisma.billing.aggregate({ _sum: { amountAfter: true } }),
+    prisma.enquiry.count({
+      where: { createdAt: { gte: startOfToday, lte: endOfToday } },
+    }),
+    prisma.enquiry.count({ where: { status: { not: 'closed' } } }),
+  ])
+
+  return {
+    services: servicesCount,
+    branches: branchesCount,
+    staff: {
+      total: activeStaff + removedStaff,
+      active: activeStaff,
+      removed: removedStaff,
+    },
+    bookings: {
+      total: totalBookings,
+      today: todayBookings,
+      upcoming,
+    },
+    pricing: {
+      avgActualPrice: priceAvg._avg.actualPrice ?? 0,
+      avgOfferPrice: priceAvg._avg.offerPrice,
+      activeOffers,
+    },
+    customers: customersCount,
+    revenue: revenueSum._sum.amountAfter ?? 0,
+    enquiries: {
+      today: todayEnquiries,
+      open: openEnquiries,
+    },
+  }
+}
+


### PR DESCRIPTION
## Summary
- Move admin dashboard data fetching to a shared server-side helper
- Expose new metrics (customers, revenue, enquiries) in dashboard and API
- Render dashboard page on the server for faster load

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any, unused vars, etc.)
- `npm run build` (fails: Can't resolve 'tw-animate-css')


------
https://chatgpt.com/codex/tasks/task_e_6894142c89948325934fe71715d35c43