### PR TITLE
feat: enhance admin user management

### DIFF
--- a/src/app/admin/AdminClientLayout.tsx
+++ b/src/app/admin/AdminClientLayout.tsx
@@ -46,7 +46,6 @@ const sections: {
   {
     heading: 'People',
     items: [
-      { href: '/admin/users', label: 'Users', icon: MdPeople },
       { href: '/admin/staff', label: 'Staff', icon: MdPeople },
       { href: '/admin/customers', label: 'Customers', icon: MdPeople },
 
@@ -67,6 +66,10 @@ const sections: {
       { href: '/admin/featured-services', label: 'Featured Services', icon: MdStar },
       { href: '/admin/variant-price-history', label: 'Price History', icon: MdHistory },
     ],
+  },
+  {
+    heading: 'Settings',
+    items: [{ href: '/admin/users', label: 'Staff Roles', icon: MdPeople }],
   },
 ]
 

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,6 +1,14 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import {
+  Users,
+  Shield,
+  UserCog,
+  KeyRound,
+  CheckCircle,
+  XCircle,
+} from 'lucide-react'
 
 interface User {
   id: string
@@ -8,6 +16,7 @@ interface User {
   email: string | null
   role: string
   modules: string[] | null
+  removed: boolean
 }
 
 const allModules = [
@@ -25,29 +34,56 @@ export default function UsersPage() {
   useEffect(() => {
     fetch('/api/users')
       .then((res) => res.json())
-      .then((data) =>
-        setUsers(
-          data.users.filter(
-            (u: User) => u.role === 'admin' || u.role === 'staff'
-          )
-        )
-      )
+      .then((data) => setUsers(data.users))
   }, [])
 
-  const updateUser = async (id: string, role: string, modules: string[]) => {
+  const updateUser = async (
+    id: string,
+    updates: Partial<Pick<User, 'role' | 'modules' | 'removed'>> & {
+      password?: string
+    },
+  ) => {
     await fetch('/api/users', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, role, modules }),
+      body: JSON.stringify({ id, ...updates }),
     })
-    setUsers((prev) =>
-      prev.map((u) => (u.id === id ? { ...u, role, modules } : u)),
-    )
+    setUsers((prev) => prev.map((u) => (u.id === id ? { ...u, ...updates } : u)))
   }
 
+  const adminCount = users.filter((u) => u.role === 'admin').length
+  const staffCount = users.filter((u) => u.role === 'staff').length
+
   return (
-    <div className="p-4 max-w-4xl mx-auto">
-      <h1 className="text-3xl font-bold mb-6 text-green-800">User Management</h1>
+    <div className="p-4 max-w-5xl mx-auto">
+      <h1 className="flex items-center text-3xl font-bold mb-6 text-green-800">
+        <Users className="w-8 h-8 mr-2" /> User Management
+      </h1>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div className="flex items-center p-4 bg-green-50 rounded shadow-sm">
+          <Users className="text-green-600 mr-3" />
+          <div>
+            <p className="text-sm text-gray-600">Total Users</p>
+            <p className="text-xl font-semibold">{users.length}</p>
+          </div>
+        </div>
+        <div className="flex items-center p-4 bg-green-50 rounded shadow-sm">
+          <Shield className="text-green-600 mr-3" />
+          <div>
+            <p className="text-sm text-gray-600">Admins</p>
+            <p className="text-xl font-semibold">{adminCount}</p>
+          </div>
+        </div>
+        <div className="flex items-center p-4 bg-green-50 rounded shadow-sm">
+          <UserCog className="text-green-600 mr-3" />
+          <div>
+            <p className="text-sm text-gray-600">Staff</p>
+            <p className="text-xl font-semibold">{staffCount}</p>
+          </div>
+        </div>
+      </div>
+
       <table className="w-full bg-white rounded-lg shadow overflow-hidden">
         <thead className="bg-green-100">
           <tr className="text-left">
@@ -55,18 +91,23 @@ export default function UsersPage() {
             <th className="p-3">Email</th>
             <th className="p-3">Role</th>
             <th className="p-3">Modules</th>
+            <th className="p-3 text-center">Active</th>
+            <th className="p-3 text-center">Actions</th>
           </tr>
         </thead>
         <tbody>
           {users.map((user) => (
-            <tr key={user.id} className="border-t last:border-b-0">
+            <tr
+              key={user.id}
+              className="border-t odd:bg-green-50 last:border-b-0 hover:bg-green-100"
+            >
               <td className="p-3">{user.name ?? '—'}</td>
               <td className="p-3">{user.email ?? '—'}</td>
               <td className="p-3">
                 <select
                   value={user.role}
                   onChange={(e) =>
-                    updateUser(user.id, e.target.value, user.modules ?? [])
+                    updateUser(user.id, { role: e.target.value })
                   }
                   className="border p-1 rounded"
                 >
@@ -87,7 +128,7 @@ export default function UsersPage() {
                             const modules = active
                               ? (user.modules ?? []).filter((x) => x !== m)
                               : [...(user.modules ?? []), m]
-                            updateUser(user.id, user.role, modules)
+                            updateUser(user.id, { modules })
                           }}
                         />
                         {m}
@@ -95,6 +136,37 @@ export default function UsersPage() {
                     )
                   })}
                 </div>
+              </td>
+              <td className="p-3 text-center">
+                <button
+                  onClick={() =>
+                    updateUser(user.id, { removed: !user.removed })
+                  }
+                  className={
+                    user.removed
+                      ? 'text-red-600 hover:text-red-800'
+                      : 'text-green-600 hover:text-green-800'
+                  }
+                  title={user.removed ? 'Activate user' : 'Deactivate user'}
+                >
+                  {user.removed ? (
+                    <XCircle className="w-5 h-5" />
+                  ) : (
+                    <CheckCircle className="w-5 h-5" />
+                  )}
+                </button>
+              </td>
+              <td className="p-3 text-center">
+                <button
+                  onClick={() => {
+                    const pwd = prompt('Enter new password')
+                    if (pwd) updateUser(user.id, { password: pwd })
+                  }}
+                  className="text-blue-600 hover:text-blue-800"
+                  title="Change password"
+                >
+                  <KeyRound className="w-5 h-5" />
+                </button>
               </td>
             </tr>
           ))}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -21,6 +21,7 @@ interface User {
 
 const allModules = [
   'dashboard',
+  'staff-roles',
   'staff',
   'customers',
   'branches',
@@ -28,7 +29,7 @@ const allModules = [
   'billing',
 ]
 
-export default function UsersPage() {
+export default function StaffRolesPage() {
   const [users, setUsers] = useState<User[]>([])
 
   useEffect(() => {
@@ -57,7 +58,7 @@ export default function UsersPage() {
   return (
     <div className="p-4 max-w-5xl mx-auto">
       <h1 className="flex items-center text-3xl font-bold mb-6 text-green-800">
-        <Users className="w-8 h-8 mr-2" /> User Management
+        <Users className="w-8 h-8 mr-2" /> Staff Roles
       </h1>
 
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
@@ -119,6 +120,7 @@ export default function UsersPage() {
                 <div className="flex flex-wrap gap-2">
                   {allModules.map((m) => {
                     const active = user.modules?.includes(m)
+                    const label = m.replace('-', ' ')
                     return (
                       <label key={m} className="flex items-center gap-1 text-sm">
                         <input
@@ -131,7 +133,7 @@ export default function UsersPage() {
                             updateUser(user.id, { modules })
                           }}
                         />
-                        {m}
+                        {label}
                       </label>
                     )
                   })}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -18,7 +18,12 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const { id, role, modules, password, removed } = await req.json()
-  const data: any = {}
+  const data: Partial<{
+    role: string
+    modules: string[]
+    password: string
+    removed: boolean
+  }> = {}
   if (role !== undefined) data.role = role
   if (modules !== undefined) data.modules = modules
   if (password !== undefined) data.password = password

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -3,17 +3,29 @@ import { prisma } from '@/lib/prisma'
 
 export async function GET() {
   const users = await prisma.user.findMany({
-    where: { role: { in: ['admin', 'staff'] } },
-    select: { id: true, name: true, email: true, role: true, modules: true },
+    where: { role: { not: 'customer' } },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      modules: true,
+      removed: true,
+    },
   })
   return NextResponse.json({ users })
 }
 
 export async function POST(req: Request) {
-  const { id, role, modules } = await req.json()
+  const { id, role, modules, password, removed } = await req.json()
+  const data: any = {}
+  if (role !== undefined) data.role = role
+  if (modules !== undefined) data.modules = modules
+  if (password !== undefined) data.password = password
+  if (removed !== undefined) data.removed = removed
   await prisma.user.update({
     where: { id },
-    data: { role, modules }
+    data,
   })
   return NextResponse.json({ success: true })
 }

--- a/src/app/auth/signin/SignInClient.tsx
+++ b/src/app/auth/signin/SignInClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { signIn, getSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
+import { Mail, Lock } from 'lucide-react'
 
 export default function SignInClient() {
   const [email, setEmail] = useState('')
@@ -44,43 +45,59 @@ export default function SignInClient() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-900 to-gray-900 flex items-center justify-center p-4">
-      <div className="bg-black/70 backdrop-blur-sm p-8 rounded-2xl w-full max-w-md shadow-lg space-y-6">
-        <div className="text-center">
-          <h1 className="text-3xl font-bold text-primary mb-2">Hello!</h1>
-          <p className="text-primary">Sign in to continue</p>
+    <div className="min-h-screen grid md:grid-cols-2">
+      <div className="hidden md:flex flex-col items-center justify-center bg-gradient-to-br from-green-600 to-green-900 text-white p-10">
+        <h2 className="text-4xl font-bold mb-4">Welcome Back</h2>
+        <p className="text-center max-w-sm">
+          Manage your salon operations, staff, and customers all in one place.
+        </p>
+      </div>
+      <div className="flex items-center justify-center bg-gray-50 p-6">
+        <div className="w-full max-w-md space-y-6">
+          <div className="text-center">
+            <h1 className="text-3xl font-bold text-primary mb-2">Sign In</h1>
+            <p className="text-gray-500">Enter your credentials to access your account</p>
+          </div>
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-gray-700">Email</label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                <input
+                  type="email"
+                  className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+              </div>
+              <p className="text-xs text-gray-500">We&apos;ll never share your email.</p>
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-gray-700">Password</label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                <input
+                  type="password"
+                  className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                  placeholder="Your password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
+              <p className="text-xs text-gray-500">Use at least 8 characters.</p>
+            </div>
+            <button
+              type="submit"
+              className="w-full bg-primary text-black py-2 rounded-lg font-semibold hover:bg-green-400 transition-colors"
+            >
+              Sign In
+            </button>
+          </form>
+          {error && <p className="text-red-500 text-center">{error}</p>}
         </div>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="text-primary">Email</label>
-            <input
-              type="email"
-              className="w-full"
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
-          </div>
-          <div>
-            <label className="text-primary">Password</label>
-            <input
-              type="password"
-              className="w-full"
-              placeholder="Your password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </div>
-          <button
-            type="submit"
-            className="w-full bg-primary text-black py-2 rounded font-semibold"
-          >
-            Sign In
-          </button>
-        </form>
-        {error && <p className="text-red-400 text-center">{error}</p>}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- filter API user list to exclude customers and support password/active updates
- redesign admin user page with role cards, activation toggle, and password reset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interface declaring no members, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898220211588325aa66aeb94c544c78