### PR TITLE
feat: show staff details and improve auth redirects

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -16,6 +16,8 @@ interface User {
   email: string | null
   role: string
   modules: string[] | null
+  designation: string | null
+  imageUrl: string | null
   removed: boolean
 }
 
@@ -88,8 +90,10 @@ export default function StaffRolesPage() {
       <table className="w-full bg-white rounded-lg shadow overflow-hidden">
         <thead className="bg-green-100">
           <tr className="text-left">
+            <th className="p-3">Photo</th>
             <th className="p-3">Name</th>
             <th className="p-3">Email</th>
+            <th className="p-3">Designation</th>
             <th className="p-3">Role</th>
             <th className="p-3">Modules</th>
             <th className="p-3 text-center">Active</th>
@@ -102,8 +106,20 @@ export default function StaffRolesPage() {
               key={user.id}
               className="border-t odd:bg-green-50 last:border-b-0 hover:bg-green-100"
             >
+              <td className="p-3">
+                {user.imageUrl ? (
+                  <img
+                    src={user.imageUrl}
+                    alt={user.name ?? ''}
+                    className="w-10 h-10 rounded-full object-cover"
+                  />
+                ) : (
+                  '—'
+                )}
+              </td>
               <td className="p-3">{user.name ?? '—'}</td>
               <td className="p-3">{user.email ?? '—'}</td>
+              <td className="p-3">{user.designation ?? '—'}</td>
               <td className="p-3">
                 <select
                   value={user.role}
@@ -119,14 +135,17 @@ export default function StaffRolesPage() {
               <td className="p-3">
                 <div className="flex flex-wrap gap-2">
                   {allModules.map((m) => {
-                    const active = user.modules?.includes(m)
+                    const active =
+                      user.role === 'admin' || user.modules?.includes(m)
                     const label = m.replace('-', ' ')
                     return (
                       <label key={m} className="flex items-center gap-1 text-sm">
                         <input
                           type="checkbox"
                           checked={active}
+                          disabled={user.role === 'admin'}
                           onChange={() => {
+                            if (user.role === 'admin') return
                             const modules = active
                               ? (user.modules ?? []).filter((x) => x !== m)
                               : [...(user.modules ?? []), m]

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -10,6 +10,8 @@ export async function GET() {
       email: true,
       role: true,
       modules: true,
+      designation: true,
+      imageUrl: true,
       removed: true,
     },
   })

--- a/src/app/auth/signin/SignInClient.tsx
+++ b/src/app/auth/signin/SignInClient.tsx
@@ -24,7 +24,8 @@ export default function SignInClient() {
     }
 
     const session = await getSession()
-    const modules = (session?.user as { modules?: string[] })?.modules || []
+    const user = session?.user as { role?: string; modules?: unknown }
+    const modules = Array.isArray(user?.modules) ? (user!.modules as string[]) : []
     const moduleRoutes: Record<string, string> = {
       dashboard: '/admin/dashboard',
       staff: '/admin/staff',
@@ -36,7 +37,7 @@ export default function SignInClient() {
     }
 
     let destination = '/admin/dashboard'
-    if (!modules.includes('dashboard') && modules.length > 0) {
+    if (user?.role !== 'admin' && modules.length > 0 && !modules.includes('dashboard')) {
       const first = modules[0]
       destination = moduleRoutes[first] || destination
     }


### PR DESCRIPTION
## Summary
- display staff designation and photo on admin users page
- ensure admins show all module checkboxes as selected
- improve sign-in redirect logic using user role and modules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68982aa1966883259687d37db3082f76