### PR TITLE
feat: improve login flow and add customer portal

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -3,10 +3,14 @@ export const dynamic = 'force-dynamic'
 import { Suspense } from 'react'
 import SignInClient from './SignInClient'
 
-export default function SignInPage() {
+export default function SignInPage({
+  searchParams,
+}: {
+  searchParams: { type?: string }
+}) {
   return (
     <Suspense>
-      <SignInClient />
+      <SignInClient type={searchParams.type} />
     </Suspense>
   )
 }

--- a/src/app/customer/page.tsx
+++ b/src/app/customer/page.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Calendar, Download, FileText, PlusCircle } from 'lucide-react'
+
+interface Schedule {
+  id: string
+  date: string
+  service: string
+}
+
+interface Bill {
+  id: string
+  date: string
+  amount: number
+}
+
+export default function CustomerDashboard() {
+  const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [bills, setBills] = useState<Bill[]>([])
+
+  useEffect(() => {
+    fetch('/api/customer/schedules')
+      .then((r) => r.json())
+      .then((d) => setSchedules(d.schedules ?? []))
+      .catch(() => setSchedules([]))
+    fetch('/api/customer/bills')
+      .then((r) => r.json())
+      .then((d) => setBills(d.bills ?? []))
+      .catch(() => setBills([]))
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-green-100 p-8">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <header className="text-center space-y-2">
+          <h1 className="text-4xl font-bold text-emerald-900">Your Dashboard</h1>
+          <p className="text-emerald-700">Track appointments and billing in style</p>
+        </header>
+        <section className="grid md:grid-cols-2 gap-8">
+          <div className="bg-white/70 backdrop-blur rounded-xl shadow-lg p-6">
+            <h2 className="flex items-center gap-2 text-2xl font-semibold text-emerald-900 mb-4">
+              <Calendar className="text-emerald-600" /> Upcoming Schedules
+            </h2>
+            <ul className="space-y-3">
+              {schedules.length ? (
+                schedules.map((s) => (
+                  <li key={s.id} className="flex justify-between items-center">
+                    <span>
+                      {s.date} - {s.service}
+                    </span>
+                    <Link
+                      href={`/customer/schedule/${s.id}`}
+                      className="text-emerald-600 hover:underline"
+                    >
+                      View
+                    </Link>
+                  </li>
+                ))
+              ) : (
+                <li className="text-emerald-700">No schedules yet.</li>
+              )}
+            </ul>
+          </div>
+          <div className="bg-white/70 backdrop-blur rounded-xl shadow-lg p-6">
+            <h2 className="flex items-center gap-2 text-2xl font-semibold text-emerald-900 mb-4">
+              <FileText className="text-emerald-600" /> Billing History
+            </h2>
+            <ul className="space-y-3">
+              {bills.length ? (
+                bills.map((b) => (
+                  <li key={b.id} className="flex justify-between items-center">
+                    <span>
+                      {b.date} - ₹{b.amount}
+                    </span>
+                    <div className="flex gap-2">
+                      <Link
+                        href={`/api/customer/bills/${b.id}`}
+                        className="text-emerald-600 hover:underline"
+                      >
+                        View
+                      </Link>
+                      <Link
+                        href={`/api/customer/bills/${b.id}?download=1`}
+                        className="text-emerald-600 hover:underline flex items-center"
+                      >
+                        <Download size={16} />
+                      </Link>
+                    </div>
+                  </li>
+                ))
+              ) : (
+                <li className="text-emerald-700">No bills yet.</li>
+              )}
+            </ul>
+          </div>
+        </section>
+        <div className="text-center">
+          <Link
+            href="/book-appointment"
+            className="inline-flex items-center gap-2 bg-emerald-600 text-white px-6 py-3 rounded-full text-lg font-semibold shadow hover:bg-emerald-700"
+          >
+            <PlusCircle /> New Booking
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,29 @@
-import { redirect } from 'next/navigation'
+'use client'
+
+import Link from 'next/link'
+import { User, Users } from 'lucide-react'
 
 export default function LoginPage() {
-  redirect('/auth/signin')
-  return null
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-emerald-50 to-green-100 p-6">
+      <div className="bg-white/70 backdrop-blur-xl shadow-xl rounded-2xl p-10 text-center space-y-6 max-w-lg w-full">
+        <h1 className="text-4xl font-extrabold text-emerald-900 mb-2">Login</h1>
+        <p className="text-emerald-700">Choose how you want to access Greens Salon</p>
+        <div className="flex flex-col sm:flex-row gap-6 justify-center mt-6">
+          <Link
+            href="/auth/signin?type=staff"
+            className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 rounded-xl bg-emerald-600 text-white font-semibold shadow hover:bg-emerald-700 transition-colors"
+          >
+            <Users /> Staff Login
+          </Link>
+          <Link
+            href="/auth/signin?type=customer"
+            className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 rounded-xl bg-green-100 text-emerald-800 font-semibold shadow hover:bg-green-200 transition-colors"
+          >
+            <User /> Customer Login
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- add dedicated login chooser with staff and customer options
- fix sign-in redirect to honor staff modules and route customers to their dashboard
- introduce a customer dashboard with schedules, billing history, and booking shortcut

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, no-unused-vars, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68982ec33328832599cfc9935367a555