### PR TITLE
Improve logout handling and add account dropdown

### DIFF
--- a/src/app/admin/AdminClientLayout.tsx
+++ b/src/app/admin/AdminClientLayout.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import React, { useState } from 'react'
 import { signOut } from 'next-auth/react'
 import { LoadingProvider } from '@/contexts/LoadingContext'
@@ -75,7 +75,13 @@ const sections: {
 
 export default function AdminClientLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+  const router = useRouter()
   const [open, setOpen] = useState(false)
+
+  const handleLogout = async () => {
+    await signOut({ redirect: false, callbackUrl: '/auth/signin' })
+    router.push('/auth/signin')
+  }
 
   return (
     <LoadingProvider>
@@ -97,7 +103,7 @@ export default function AdminClientLayout({ children }: { children: React.ReactN
             </Link>
           </div>
           <button
-            onClick={() => signOut({ callbackUrl: '/auth/signin' })}
+            onClick={handleLogout}
             className="flex items-center gap-1 bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
           >
             <MdLogout className="text-lg" /> Logout

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,37 +7,66 @@ import { motion, AnimatePresence } from "framer-motion"
 
 export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const [accountMenuOpen, setAccountMenuOpen] = useState(false)
+
+  const closeMenus = () => {
+    setIsMobileMenuOpen(false)
+    setAccountMenuOpen(false)
+  }
 
   const navLinks = (
     <>
-     <Link href="/" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+      <Link href="/" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         Home {/* Added Home link */}
       </Link>
-      <Link href="#" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+      <Link href="#" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         Explore Services
       </Link>
-      <Link href="#" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+      <Link href="#" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         Service Rates
       </Link>
-      <Link href="#" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+      <Link href="#" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         Current Offers
       </Link>
-      <Link href="#" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+      <Link href="#" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         Schedule Visit
       </Link>
-      <Link href="#" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+      <Link href="#" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         Academy & Training
       </Link>
-      <Link href="#" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+      <Link href="#" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         About Greens
       </Link>
-      <Link href="#" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+      <Link href="#" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         Contact Us
       </Link>
-      <Link href="#" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
-        My Account
-      </Link>
-      <Link href="/book-appointment" className="hover:text-green-400 transition-colors" onClick={() => setIsMobileMenuOpen(false)}>
+      <div className="relative" onMouseLeave={() => setAccountMenuOpen(false)}>
+        <button
+          onClick={() => setAccountMenuOpen(!accountMenuOpen)}
+          className="hover:text-green-400 transition-colors"
+        >
+          My Account
+        </button>
+        {accountMenuOpen && (
+          <div className="absolute right-0 mt-2 w-40 bg-white text-gray-800 rounded shadow-md z-50">
+            <Link
+              href="/auth/signin?type=staff"
+              className="block px-4 py-2 hover:bg-gray-100"
+              onClick={closeMenus}
+            >
+              Staff Login
+            </Link>
+            <Link
+              href="/auth/signin?type=customer"
+              className="block px-4 py-2 hover:bg-gray-100"
+              onClick={closeMenus}
+            >
+              Customer Login
+            </Link>
+          </div>
+        )}
+      </div>
+      <Link href="/book-appointment" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         Book Appointment
       </Link>
     </>


### PR DESCRIPTION
## Summary
- Ensure admin logout fully clears session and redirects to sign-in
- Add "My Account" dropdown with staff and customer login options in main header

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: existing lint errors)*
- `npx next lint --file src/components/Header.tsx --file src/app/admin/AdminClientLayout.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6898356776f48325b9752a49b7706f33