### PR TITLE
Use phone number for sign in and add customer APIs

### DIFF
--- a/src/app/api/customer/bills/[id]/route.ts
+++ b/src/app/api/customer/bills/[id]/route.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from '@prisma/client'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+const prisma = new PrismaClient()
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession(authOptions)
+    const phone = (session?.user as { phone?: string | null })?.phone
+    if (!phone) return Response.json({ bill: null }, { status: 401 })
+
+    const bill = await prisma.billing.findFirst({
+      where: { id: params.id, phone },
+    })
+    if (!bill) return Response.json({ bill: null }, { status: 404 })
+
+    return Response.json({ bill })
+  } catch (err) {
+    console.error('Error in /api/customer/bills/[id]:', err)
+    return Response.json({ bill: null }, { status: 500 })
+  }
+}

--- a/src/app/api/customer/bills/route.ts
+++ b/src/app/api/customer/bills/route.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+const prisma = new PrismaClient()
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions)
+    const phone = (session?.user as { phone?: string | null })?.phone
+    if (!phone) return Response.json({ bills: [] })
+
+    const billsDb = await prisma.billing.findMany({
+      where: { phone },
+      orderBy: { createdAt: 'desc' },
+    })
+    const bills = billsDb.map((b) => ({
+      id: b.id,
+      date: b.createdAt.toISOString().split('T')[0],
+      amount: b.amountAfter,
+    }))
+    return Response.json({ bills })
+  } catch (err) {
+    console.error('Error in /api/customer/bills:', err)
+    return Response.json({ bills: [] }, { status: 500 })
+  }
+}

--- a/src/app/api/customer/schedules/route.ts
+++ b/src/app/api/customer/schedules/route.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from '@prisma/client'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+const prisma = new PrismaClient()
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions)
+    const phone = (session?.user as { phone?: string | null })?.phone
+    if (!phone) return Response.json({ schedules: [] })
+
+    const bookings = await prisma.booking.findMany({
+      where: { phone },
+      include: { items: { select: { name: true } } },
+      orderBy: { date: 'desc' },
+    })
+    const schedules = bookings.map((b) => ({
+      id: b.id,
+      date: b.date,
+      service: b.items[0]?.name || '',
+    }))
+    return Response.json({ schedules })
+  } catch (err) {
+    console.error('Error in /api/customer/schedules:', err)
+    return Response.json({ schedules: [] }, { status: 500 })
+  }
+}

--- a/src/app/auth/signin/SignInClient.tsx
+++ b/src/app/auth/signin/SignInClient.tsx
@@ -3,14 +3,14 @@
 import { useState } from 'react'
 import { signIn } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
-import { Mail, Lock } from 'lucide-react'
+import { Phone, Lock } from 'lucide-react'
 
 interface Props {
   type?: string
 }
 
 export default function SignInClient({ type }: Props) {
-  const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const router = useRouter()
@@ -19,11 +19,11 @@ export default function SignInClient({ type }: Props) {
     e.preventDefault()
     const res = await signIn('credentials', {
       redirect: false,
-      email,
+      phone,
       password,
     })
     if (res?.error) {
-      setError('Invalid email or password')
+      setError('Invalid mobile number or password')
       return
     }
 
@@ -70,19 +70,19 @@ export default function SignInClient({ type }: Props) {
           </div>
           <form onSubmit={handleSubmit} className="space-y-5">
             <div className="space-y-1">
-              <label className="text-sm font-medium text-gray-700">Email</label>
+              <label className="text-sm font-medium text-gray-700">Mobile Number</label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                <Phone className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
                 <input
-                  type="email"
+                  type="tel"
                   className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
-                  placeholder="you@example.com"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="9999999999"
+                  value={phone}
+                  onChange={(e) => setPhone(e.target.value)}
                   required
                 />
               </div>
-              <p className="text-xs text-gray-500">We&apos;ll never share your email.</p>
+              <p className="text-xs text-gray-500">We&apos;ll never share your mobile number.</p>
             </div>
             <div className="space-y-1">
               <label className="text-sm font-medium text-gray-700">Password</label>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -14,19 +14,19 @@ export const authOptions: NextAuthOptions = {
     CredentialsProvider({
       name: 'Credentials',
       credentials: {
-        email: { label: 'Email', type: 'email', placeholder: 'you@example.com' },
+        phone: { label: 'Phone', type: 'text', placeholder: '9999999999' },
         password: { label: 'Password', type: 'password' },
       },
       async authorize(credentials) {
-        if (!credentials?.email || !credentials.password) return null
+        if (!credentials?.phone || !credentials.password) return null
         const user = await prisma.user.findUnique({
-          where: { email: credentials.email },
+          where: { phone: credentials.phone },
         })
         if (!user || user.password !== credentials.password) return null
         return {
           id: user.id,
           name: user.name ?? undefined,
-          email: user.email ?? undefined,
+          phone: user.phone ?? undefined,
           role: user.role,
         }
       },


### PR DESCRIPTION
## Summary
- switch NextAuth credentials to phone-based login
- update sign in UI to accept mobile number
- expose customer schedules and bills APIs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: various lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68983855787483258f478e5146318026