### PR TITLE
Make preferred time optional and tweak layout

### DIFF
--- a/src/app/api/admin/enquiries/route.ts
+++ b/src/app/api/admin/enquiries/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: NextRequest) {
         status: 'new',
         source: 'admin',
         preferredDate: preferredDate ? new Date(preferredDate) : null,
-        preferredTime: preferredTime || null,
+        preferredTime: preferredTime && preferredTime !== '' ? preferredTime : null,
 
       },
     })

--- a/src/app/api/web-enquiries/route.ts
+++ b/src/app/api/web-enquiries/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest) {
         status: 'new',
         source: 'web',
         preferredDate: preferredDate ? new Date(preferredDate) : null,
-        preferredTime: preferredTime || null,
+        preferredTime: preferredTime && preferredTime !== '' ? preferredTime : null,
 
       },
     })

--- a/src/app/book-appointment/page.tsx
+++ b/src/app/book-appointment/page.tsx
@@ -103,7 +103,7 @@ export default function BookAppointmentPage() {
         : "",
       preferredTime: form.preferredTime
         ? format(form.preferredTime, "HH:mm")
-        : "",
+        : null,
     }
 
     const res = await fetch("/api/web-enquiries", {
@@ -226,7 +226,6 @@ export default function BookAppointmentPage() {
                   maxTime={maxTime}
                   placeholderText="Select time"
                   className="w-full mt-1 p-2 border rounded-md"
-                  required
                 />
               </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -173,7 +173,7 @@ export default function HomePage() {
 
                 </div>
                 <div className="relative z-20 text-white max-w-3xl space-y-4">
-                  <h1 className="text-3xl md:text-4xl font-bold tracking-wide text-white drop-shadow-lg">
+                  <h1 className="text-2xl md:text-3xl font-bold tracking-wide text-white drop-shadow-lg">
                     {currentHeroContent.heroTitle}
                   </h1>
                   {selectedHeroCategory === "home" ? (
@@ -235,7 +235,7 @@ export default function HomePage() {
             transition={{ duration: 0.8 }}
             viewport={{ once: true }}
           >
-            <p className="text-3xl md:text-4xl font-bold text-white">Our Signature Treatments</p>
+            <p className="text-2xl md:text-3xl font-bold text-white">Our Signature Treatments</p>
           </motion.div>
           <div className="relative">
             {signatureServices.length === 0 ? (
@@ -295,7 +295,7 @@ export default function HomePage() {
             transition={{ duration: 0.8 }}
             viewport={{ once: true }}
           >
-            <p className="text-3xl md:text-4xl font-bold text-gray-900">Tailored Experiences</p>
+            <p className="text-2xl md:text-3xl font-bold text-gray-900">Tailored Experiences</p>
           </motion.div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
             {Object.entries(TIER_LABELS).map(([key, { label, icon, description }], idx) => (
@@ -329,7 +329,7 @@ export default function HomePage() {
             transition={{ duration: 0.8 }}
             viewport={{ once: true }}
           >
-            <p className="text-3xl md:text-4xl font-bold text-white">Explore All Services</p>
+            <p className="text-2xl md:text-3xl font-bold text-white">Explore All Services</p>
           </motion.div>
           <motion.div
             className="max-w-2xl mx-auto mb-6"
@@ -454,7 +454,7 @@ export default function HomePage() {
             transition={{ duration: 0.8 }}
             viewport={{ once: true }}
           >
-            <h2 className="text-3xl md:text-5xl font-bold mb-4 text-white">Your Escape Awaits</h2>
+            <h2 className="text-2xl md:text-4xl font-bold mb-4 text-white">Your Escape Awaits</h2>
             <p className="text-lg text-white/90 mb-6">
               Ready to indulge in a moment of pure bliss? Book your appointment today and let our experts pamper you.
             </p>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -79,17 +79,12 @@ export default function Header() {
 
   return (
     <header
-      className="text-white py-4 px-6 flex items-center justify-between w-full relative z-50"
-      style={{
-        backgroundColor: '#052b1e',
-        backgroundImage: "url('/grass-texture.jpg')",
-        backgroundSize: 'cover',
-        backgroundRepeat: 'repeat',
-      }}
+      className="text-white py-4 px-6 flex items-center justify-between w-full relative z-50 bg-transparent"
+      style={{ textShadow: '0 2px 4px rgba(0,0,0,0.5)' }}
     >
       <div className="flex items-center gap-4">
         <Link href="/" className="flex items-center">
-          <Image src="/logo.png" alt="Greens Beauty Salon Logo" width={100} height={40} />
+          <Image src="/logo.png" alt="Greens Beauty Salon Logo" width={150} height={60} />
         </Link>
       </div>
       <nav className="hidden md:flex items-center gap-6 text-sm font-medium">{navLinks}</nav>
@@ -110,9 +105,6 @@ export default function Header() {
             className="fixed inset-0 z-40 flex flex-col items-center justify-center gap-8 text-lg md:hidden"
             style={{
               backgroundColor: '#052b1e',
-              backgroundImage: "url('/grass-texture.jpg')",
-              backgroundSize: 'cover',
-              backgroundRepeat: 'repeat',
             }}
           >
             <button className="absolute top-4 right-4 text-white" onClick={() => setIsMobileMenuOpen(false)}>


### PR DESCRIPTION
## Summary
- make preferred appointment time optional and support null backend
- simplify top bar with transparent background, text shadow, and larger logo
- shrink home page headings for a subtler style

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unused vars, and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689855d74e54832595538185515d02b7