### PR TITLE
feat: enhance hero layout and show service discounts

### DIFF
--- a/src/app/api/v2/service-categories/route.ts
+++ b/src/app/api/v2/service-categories/route.ts
@@ -41,7 +41,8 @@ export async function GET() {
           return {
             id: svc.id,
             name: svc.name,
-            slug: svc.slug,
+            // use slug when available, otherwise fall back to id so links remain valid
+            slug: svc.slug || svc.id,
             caption: svc.caption ?? '',
             imageUrl: svc.imageUrl ?? null,
             minOfferPrice: minOffer,

--- a/src/app/api/v2/service-categories/route.ts
+++ b/src/app/api/v2/service-categories/route.ts
@@ -19,9 +19,9 @@ export async function GET() {
     categories.map(async (cat) => {
       const services = await Promise.all(
         cat.servicesNew.map(async (svc) => {
-          const prices = await Promise.all(
+          const records = await Promise.all(
             svc.tiers.map(async (t) => {
-              const current = await prisma.serviceTierPriceHistory.findFirst({
+              return prisma.serviceTierPriceHistory.findFirst({
                 where: {
                   tierId: t.id,
                   startDate: { lte: now },
@@ -29,18 +29,24 @@ export async function GET() {
                 },
                 orderBy: { startDate: 'desc' },
               })
-              return current ? current.offerPrice ?? current.actualPrice : null
             })
           )
-          const valid = prices.filter((p) => p !== null) as number[]
-          const min = valid.length ? Math.min(...valid) : null
+          const offerPrices = records.map((r) => r?.offerPrice ?? null)
+          const actualPrices = records.map((r) => r?.actualPrice ?? null)
+          const validOffer = offerPrices.filter((p) => p !== null) as number[]
+          const validActual = actualPrices.filter((p) => p !== null) as number[]
+          const minOffer = validOffer.length ? Math.min(...validOffer) : null
+          const minActual = validActual.length ? Math.min(...validActual) : null
+          const minPrice = minOffer ?? minActual
           return {
             id: svc.id,
             name: svc.name,
             slug: svc.slug,
             caption: svc.caption ?? '',
             imageUrl: svc.imageUrl ?? null,
-            minPrice: min,
+            minOfferPrice: minOffer,
+            minActualPrice: minActual,
+            minPrice,
           }
         })
       )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -191,11 +191,12 @@ export default function HomePage() {
 
   return (
     <main className="bg-white min-h-screen font-sans text-gray-800">
-      <Header />
-     
 
       {/* HERO SECTION (DARK) */}
-      <section className="relative flex flex-col overflow-hidden min-h-[60vh] md:min-h-[60vh] bg-gray-800">
+      <section className="relative flex flex-col overflow-hidden min-h-[80vh] md:min-h-[80vh] bg-gray-800 pt-20">
+        <div className="absolute inset-x-0 top-0 z-20">
+          <Header />
+        </div>
         {heroLoading ? (
           <div className="w-full h-full flex flex-col">
             <div className="flex-1 bg-gray-200 animate-pulse flex items-center justify-center">
@@ -387,7 +388,7 @@ export default function HomePage() {
       {/* ALL SERVICES SECTION (DARK) */}
       <section id="services" className="py-12 sm:py-16 bg-emerald-950 text-white relative">
         <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-transparent via-amber-300 to-transparent" />
-        <div className="px-4 sm:px-6 relative z-10">
+        <div className="px-6 sm:px-10 relative z-10">
           <motion.div
             className="text-center mb-8"
             initial={{ opacity: 0, y: 30 }}
@@ -489,8 +490,22 @@ export default function HomePage() {
                                     }}
                                     className="flex justify-between items-center p-3 rounded-md bg-emerald-900 hover:bg-emerald-800 transition-colors"
                                   >
-                                    <span className="font-semibold text-white text-sm">{svc.name}</span>
-                                    <FiArrowRight className="text-emerald-400" />
+                                    <div className="flex flex-col text-left">
+                                      <span className="font-semibold text-white text-sm">{svc.name}</span>
+                                      {(svc.minActualPrice || svc.minOfferPrice) && (
+                                        <span className="text-xs">
+                                          {svc.minOfferPrice && svc.minActualPrice && svc.minActualPrice > svc.minOfferPrice ? (
+                                            <>
+                                              <span className="line-through text-gray-400 mr-1">₹{svc.minActualPrice} onwards</span>
+                                              <span className="text-emerald-400">₹{svc.minOfferPrice} onwards</span>
+                                            </>
+                                          ) : (
+                                            <span className="text-emerald-400">₹{(svc.minOfferPrice ?? svc.minActualPrice)} onwards</span>
+                                          )}
+                                        </span>
+                                      )}
+                                    </div>
+                                    <FiArrowRight className="text-emerald-400 ml-2" />
                                   </Link>
                                 </li>
                               ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -332,7 +332,7 @@ export default function HomePage() {
                       <h3 className="text-xl font-bold mb-2">{service.name}</h3>
                       <p className="text-sm opacity-80 mb-4 line-clamp-2">{service.caption}</p>
                       <Link
-                        href={`/services/${service.slug}`}
+                        href={`/services/${service.slug || service.id}`}
                         className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-300 opacity-0 group-hover:opacity-100 translate-y-4 group-hover:translate-y-0 transition-all duration-300 hover:text-emerald-200"
                       >
                         Explore Service <FiArrowRight />
@@ -481,7 +481,7 @@ export default function HomePage() {
                               {subServices.map((svc) => (
                                 <li key={svc.id}>
                                   <Link
-                                    href={`/services/${svc.slug}`}
+                                    href={`/services/${svc.slug || svc.id}`}
                                     onClick={() => {
                                       if (expandedCat) {
                                         sessionStorage.setItem('expandedCat', expandedCat)


### PR DESCRIPTION
## Summary
- overlay transparent topbar above taller hero section
- show original and offer pricing in Explore All Services with added horizontal padding
- expose offer and actual prices in service categories API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898609926a08325a5e66d62c0ff6c24