### PR TITLE
Move topbar overlay above hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -193,7 +193,7 @@ export default function HomePage() {
     <main className="bg-white min-h-screen font-sans text-gray-800">
 
       {/* HERO SECTION (DARK) */}
-      <section className="relative flex flex-col overflow-hidden min-h-[80vh] md:min-h-[80vh] bg-gray-800 pt-20">
+      <section className="relative flex flex-col overflow-hidden min-h-[80vh] md:min-h-[80vh] bg-gray-800">
         <div className="absolute inset-x-0 top-0 z-20">
           <Header />
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -191,12 +191,10 @@ export default function HomePage() {
 
   return (
     <main className="bg-white min-h-screen font-sans text-gray-800">
+      <Header />
 
       {/* HERO SECTION (DARK) */}
       <section className="relative flex flex-col overflow-hidden min-h-[80vh] md:min-h-[80vh] bg-gray-800">
-        <div className="absolute inset-x-0 top-0 z-20">
-          <Header />
-        </div>
         {heroLoading ? (
           <div className="w-full h-full flex flex-col">
             <div className="flex-1 bg-gray-200 animate-pulse flex items-center justify-center">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
-import { Menu, X, LogOut } from "lucide-react"
+import { Menu, X, LogOut, Home } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
 import { useSession, signOut } from "next-auth/react"
 
@@ -79,7 +79,7 @@ export default function Header() {
 
   return (
     <header
-      className="text-white py-4 px-6 flex items-center justify-between w-full relative z-50 bg-transparent"
+      className="fixed top-0 left-0 w-full text-white py-4 px-6 flex items-center justify-between z-50 bg-transparent"
       style={{ textShadow: '0 2px 4px rgba(0,0,0,0.5)' }}
     >
       <div className="flex items-center gap-4">
@@ -89,10 +89,15 @@ export default function Header() {
       </div>
       <nav className="hidden md:flex items-center gap-6 text-sm font-medium">{navLinks}</nav>
 
-      {/* Mobile menu button */}
-      <button className="md:hidden text-white" onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}>
-        {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
-      </button>
+      {/* Mobile menu actions */}
+      <div className="md:hidden flex items-center gap-4">
+        <Link href="/" aria-label="Home" className="text-white">
+          <Home size={24} />
+        </Link>
+        <button className="text-white" onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}>
+          {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+        </button>
+      </div>
 
       {/* Mobile menu overlay */}
       <AnimatePresence>


### PR DESCRIPTION
## Summary
- remove top padding so hero section reaches the top
- overlay topbar above hero section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898654553a48325b9f0c4ae860ea678