### PR TITLE
Display offer price correctly in service listings

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -494,7 +494,7 @@ export default function HomePage() {
                                         <span className="text-xs">
                                           {svc.minOfferPrice && svc.minActualPrice && svc.minActualPrice > svc.minOfferPrice ? (
                                             <>
-                                              <span className="line-through text-gray-400 mr-1">₹{svc.minActualPrice} onwards</span>
+                                              <span className="line-through text-gray-400 mr-1">₹{svc.minActualPrice}</span>
                                               <span className="text-emerald-400">₹{svc.minOfferPrice} onwards</span>
                                             </>
                                           ) : (


### PR DESCRIPTION
## Summary
- Show discounted services with struck-through original price and separate offer price

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68986b8ea3d48325a51285f3b9c52735