### PR TITLE
feat: add dynamic limited-time offers

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -260,3 +260,14 @@ model Enquiry {
   createdAt  DateTime @default(now()) @db.Timestamp(3)
   updatedAt  DateTime @default(now()) @updatedAt @db.Timestamp(3)
 }
+
+model Offer {
+  id          String   @id @default(uuid())
+  title       String
+  subTitle    String?  @db.VarChar(191)
+  category    String?  @db.VarChar(191)
+  description String?  @db.LongText
+  imageUrl    String?  @db.VarChar(191)
+  createdAt   DateTime @default(now()) @db.Timestamp(3)
+  updatedAt   DateTime @default(now()) @updatedAt @db.Timestamp(3)
+}

--- a/src/app/admin/AdminClientLayout.tsx
+++ b/src/app/admin/AdminClientLayout.tsx
@@ -22,6 +22,7 @@ import {
   MdMenu,
   MdViewCarousel,
   MdQuestionAnswer,
+  MdLocalOffer,
 } from 'react-icons/md'
 import type { IconType } from 'react-icons'
 
@@ -64,6 +65,7 @@ const sections: {
       { href: '/admin/service-categories', label: 'Categories', icon: MdCategory },
       { href: '/admin/services', label: 'Services', icon: MdDesignServices },
       { href: '/admin/featured-services', label: 'Featured Services', icon: MdStar },
+      { href: '/admin/limited-time-offers', label: 'Offers', icon: MdLocalOffer },
       { href: '/admin/variant-price-history', label: 'Price History', icon: MdHistory },
     ],
   },

--- a/src/app/admin/limited-time-offers/page.tsx
+++ b/src/app/admin/limited-time-offers/page.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import WysiwygEditor from '@/app/components/WysiwygEditor'
+import { Pencil, Trash2 } from 'lucide-react'
+
+interface Offer {
+  id: string
+  title: string
+  subTitle?: string
+  category?: string
+  imageUrl?: string
+  description?: string
+}
+
+export default function OffersAdminPage() {
+  const empty: Offer = { id: '', title: '', subTitle: '', category: '', imageUrl: '', description: '' }
+  const [offers, setOffers] = useState<Offer[]>([])
+  const [form, setForm] = useState<Offer>(empty)
+  const [editing, setEditing] = useState(false)
+
+  const load = async () => {
+    const res = await fetch('/api/admin/limited-time-offers')
+    const data = await res.json()
+    setOffers(data)
+  }
+
+  useEffect(() => { load() }, [])
+
+  const handleImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const fd = new FormData()
+    fd.append('file', file)
+    const res = await fetch('/api/upload', { method: 'POST', body: fd })
+    const data = await res.json()
+    setForm({ ...form, imageUrl: data.url })
+  }
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const method = editing ? 'PUT' : 'POST'
+    await fetch('/api/admin/limited-time-offers', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+    setForm(empty)
+    setEditing(false)
+    load()
+  }
+
+  const edit = (o: Offer) => {
+    setForm(o)
+    setEditing(true)
+  }
+
+  const del = async (id: string) => {
+    if (!confirm('Delete this offer?')) return
+    await fetch('/api/admin/limited-time-offers', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    })
+    load()
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Limited-Time Offers</h1>
+      <form onSubmit={save} className="space-y-4 bg-white p-6 rounded shadow border mb-6">
+        <div>
+          <label className="block font-medium mb-1">Title</label>
+          <input className="w-full p-2 rounded border" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Sub Title</label>
+          <input className="w-full p-2 rounded border" value={form.subTitle || ''} onChange={e => setForm({ ...form, subTitle: e.target.value })} />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Category</label>
+          <input className="w-full p-2 rounded border" value={form.category || ''} onChange={e => setForm({ ...form, category: e.target.value })} />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Image</label>
+          <input type="file" accept="image/*" onChange={handleImage} />
+          {form.imageUrl && <img src={form.imageUrl} className="h-16 mt-2" />}
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Description</label>
+          <WysiwygEditor value={form.description || ''} onChange={val => setForm({ ...form, description: val })} />
+        </div>
+        <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">{editing ? 'Update' : 'Add'} Offer</button>
+      </form>
+      <table className="w-full text-left text-sm bg-white rounded shadow border">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2">Title</th>
+            <th className="px-3 py-2">Category</th>
+            <th className="px-3 py-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {offers.map(o => (
+            <tr key={o.id} className="border-t">
+              <td className="px-3 py-2">{o.title}</td>
+              <td className="px-3 py-2">{o.category}</td>
+              <td className="flex gap-2 px-3 py-2">
+                <button className="flex items-center gap-1 px-2 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded" onClick={() => edit(o)}>
+                  <Pencil className="h-4 w-4" /> Edit
+                </button>
+                <button className="flex items-center gap-1 px-2 py-1 text-sm bg-red-600 hover:bg-red-700 text-white rounded" onClick={() => del(o.id)}>
+                  <Trash2 className="h-4 w-4" /> Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/api/admin/limited-time-offers/route.ts
+++ b/src/app/api/admin/limited-time-offers/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const offers = await prisma.offer.findMany({ orderBy: { createdAt: 'desc' } })
+  return NextResponse.json(offers)
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const offer = await prisma.offer.create({
+    data: {
+      title: data.title,
+      subTitle: data.subTitle || null,
+      category: data.category || null,
+      description: data.description || null,
+      imageUrl: data.imageUrl || null,
+    },
+  })
+  return NextResponse.json(offer)
+}
+
+export async function PUT(req: NextRequest) {
+  const data = await req.json()
+  if (!data.id) return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+  const offer = await prisma.offer.update({
+    where: { id: data.id },
+    data: {
+      title: data.title,
+      subTitle: data.subTitle || null,
+      category: data.category || null,
+      description: data.description || null,
+      imageUrl: data.imageUrl || null,
+    },
+  })
+  return NextResponse.json(offer)
+}
+
+export async function DELETE(req: NextRequest) {
+  const { id } = await req.json()
+  await prisma.offer.delete({ where: { id } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/limited-time-offers/[id]/route.ts
+++ b/src/app/api/limited-time-offers/[id]/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const offer = await prisma.offer.findUnique({ where: { id: params.id } })
+  if (!offer) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(offer)
+}

--- a/src/app/api/limited-time-offers/route.ts
+++ b/src/app/api/limited-time-offers/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const offers = await prisma.offer.findMany({ orderBy: { createdAt: 'desc' } })
+  return NextResponse.json(offers)
+}

--- a/src/app/offers/[id]/page.tsx
+++ b/src/app/offers/[id]/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link'
+import { headers } from 'next/headers'
+import Header from '@/components/Header'
+import { FiArrowLeft } from 'react-icons/fi'
+
+export default async function OfferDetailsPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const headersList = await headers()
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
+  const res = await fetch(`${baseUrl}/api/limited-time-offers/${id}`, { cache: 'no-store' })
+  if (!res.ok) {
+    return <div className="text-red-500 text-xl p-8">Unable to load offer</div>
+  }
+  const offer = await res.json()
+  if (!offer || !offer.id) {
+    return <div className="text-red-500 text-xl p-8">Offer not found</div>
+  }
+  return (
+    <main className="bg-white min-h-screen font-sans text-gray-800">
+      <Header />
+      <div className="container mx-auto px-6 pt-24 pb-12">
+        <Link href="/" className="inline-flex items-center gap-2 text-emerald-800 font-semibold mb-6">
+          <FiArrowLeft /> Back to Home
+        </Link>
+        <div className="grid md:grid-cols-2 gap-8">
+          {offer.imageUrl && (
+            <img src={offer.imageUrl} alt={offer.title} className="w-full h-64 object-cover rounded-2xl" />
+          )}
+          <div>
+            {offer.category && <div className="text-sm text-emerald-700 font-semibold mb-1">{offer.category}</div>}
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">{offer.title}</h1>
+            {offer.subTitle && <p className="text-gray-700 mb-4">{offer.subTitle}</p>}
+            <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: offer.description || '' }} />
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,6 +44,7 @@ export default function HomePage() {
     male: [],
     children: [],
   })
+  const [offers, setOffers] = useState<any[]>([])
 
   // Search functionality
   const [searchQuery, setSearchQuery] = useState("")
@@ -68,6 +69,12 @@ export default function HomePage() {
         setLoading(false)
       })
       .catch(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    fetch('/api/limited-time-offers')
+      .then((res) => res.json())
+      .then((data) => setOffers(Array.isArray(data) ? data : []))
   }, [])
 
   useEffect(() => {
@@ -315,31 +322,40 @@ export default function HomePage() {
     </div>
 
     <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-      {[1, 2, 3].map((i) => (
-        <div key={i} className="offer-wrap group relative">
-          {/* vine gradient border (no rotation) */}
-          <div className="offer-vine rounded-2xl">
-            <div className="offer-card rounded-2xl">
-              {/* top vine accent */}
-              <div className="h-1 rounded-t-[16px] bg-gradient-to-r from-amber-400 via-emerald-500 to-amber-400" />
-              <div className="p-4">
-                <div className="text-xs text-emerald-700 font-semibold mb-1">Special {i}</div>
-                <h3 className="font-bold text-gray-900 mb-1.5">Flat 20% Off on Deluxe Facials</h3>
-                <p className="text-sm text-gray-700 mb-3">Weekdays 11am–4pm • By appointment only</p>
-                <Link
-                  href="/book-appointment"
-                  className="inline-flex items-center gap-2 text-emerald-800 font-semibold btn-shine"
-                >
-                  Book now <FiArrowRight />
-                </Link>
+      {offers.length === 0 ? (
+        <p className="col-span-full text-center text-gray-500">No offers available</p>
+      ) : (
+        offers.map((offer) => (
+          <div key={offer.id} className="offer-wrap group relative">
+            <div className="offer-vine rounded-2xl">
+              <div className="offer-card rounded-2xl">
+                <div className="h-1 rounded-t-[16px] bg-gradient-to-r from-amber-400 via-emerald-500 to-amber-400" />
+                {offer.imageUrl && (
+                  <img
+                    src={offer.imageUrl}
+                    alt={offer.title}
+                    className="w-full h-40 object-cover rounded-t-[16px]"
+                  />
+                )}
+                <div className="p-4">
+                  {offer.category && (
+                    <div className="text-xs text-emerald-700 font-semibold mb-1">{offer.category}</div>
+                  )}
+                  <h3 className="font-bold text-gray-900 mb-1.5">{offer.title}</h3>
+                  {offer.subTitle && <p className="text-sm text-gray-700 mb-3">{offer.subTitle}</p>}
+                  <Link
+                    href={`/offers/${offer.id}`}
+                    className="inline-flex items-center gap-2 text-emerald-800 font-semibold btn-shine"
+                  >
+                    View details <FiArrowRight />
+                  </Link>
+                </div>
               </div>
             </div>
+            <span aria-hidden className="burst" />
           </div>
-
-          {/* blossom burst behind on hover */}
-          <span aria-hidden className="burst" />
-        </div>
-      ))}
+        ))
+      )}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- add Offer model and CRUD APIs
- create admin interface for managing limited-time offers
- show dynamic offers on home page with detail pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68989d63edb883259ee20522a3142bf1