### PR TITLE
feat: add premium services section

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -171,6 +171,26 @@ model FeaturedService {
   updatedAt    DateTime   @default(now()) @updatedAt @db.Timestamp(3)
 }
 
+model PremiumService {
+  id        String   @id @default(uuid())
+  title     String
+  imageUrl  String?
+  order     Int      @default(0)
+  items     PremiumServiceItem[]
+  createdAt DateTime @default(now()) @db.Timestamp(3)
+  updatedAt DateTime @default(now()) @updatedAt @db.Timestamp(3)
+}
+
+model PremiumServiceItem {
+  id               String         @id @default(uuid())
+  premiumService   PremiumService @relation(fields: [premiumServiceId], references: [id], onDelete: Cascade)
+  premiumServiceId String
+  name             String
+  currentPrice     Float
+  offerPrice       Float?
+  order            Int            @default(0)
+}
+
 model Booking {
   id        String        @id @default(uuid())
   customer  String?       @db.VarChar(191)

--- a/src/app/admin/AdminClientLayout.tsx
+++ b/src/app/admin/AdminClientLayout.tsx
@@ -23,6 +23,7 @@ import {
   MdViewCarousel,
   MdQuestionAnswer,
   MdLocalOffer,
+  MdWorkspacePremium,
 } from 'react-icons/md'
 import type { IconType } from 'react-icons'
 
@@ -66,6 +67,7 @@ const sections: {
       { href: '/admin/services', label: 'Services', icon: MdDesignServices },
       { href: '/admin/featured-services', label: 'Featured Services', icon: MdStar },
       { href: '/admin/limited-time-offers', label: 'Offers', icon: MdLocalOffer },
+      { href: '/admin/premium-services', label: 'Premium Services', icon: MdWorkspacePremium },
       { href: '/admin/variant-price-history', label: 'Price History', icon: MdHistory },
     ],
   },

--- a/src/app/admin/premium-services/page.tsx
+++ b/src/app/admin/premium-services/page.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Pencil, Trash2, Plus, X } from 'lucide-react'
+
+interface PlanItem {
+  id: string
+  name: string
+  currentPrice: number
+  offerPrice?: number
+}
+
+interface Plan {
+  id: string
+  title: string
+  imageUrl?: string
+  items: PlanItem[]
+}
+
+export default function PremiumServicesAdmin() {
+  const emptyPlan: Plan = { id: '', title: '', imageUrl: '', items: [] }
+  const [plans, setPlans] = useState<Plan[]>([])
+  const [form, setForm] = useState<Plan>(emptyPlan)
+  const [editing, setEditing] = useState(false)
+
+  const load = async () => {
+    const res = await fetch('/api/admin/premium-services')
+    const data = await res.json()
+    setPlans(data)
+  }
+
+  useEffect(() => { load() }, [])
+
+  const handleImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const fd = new FormData()
+    fd.append('file', file)
+    const res = await fetch('/api/upload', { method: 'POST', body: fd })
+    const data = await res.json()
+    setForm({ ...form, imageUrl: data.url })
+  }
+
+  const addItem = () => {
+    setForm({ ...form, items: [...form.items, { id: crypto.randomUUID(), name: '', currentPrice: 0, offerPrice: 0 }] })
+  }
+
+  const updateItem = (idx: number, field: keyof PlanItem, value: string | number) => {
+    const items = [...form.items]
+    items[idx] = { ...items[idx], [field]: value }
+    setForm({ ...form, items })
+  }
+
+  const removeItem = (idx: number) => {
+    const items = [...form.items]
+    items.splice(idx, 1)
+    setForm({ ...form, items })
+  }
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const method = editing ? 'PUT' : 'POST'
+    await fetch('/api/admin/premium-services', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+    setForm(emptyPlan)
+    setEditing(false)
+    load()
+  }
+
+  const edit = (p: Plan) => {
+    setForm(p)
+    setEditing(true)
+  }
+
+  const del = async (id: string) => {
+    if (!confirm('Delete this plan?')) return
+    await fetch('/api/admin/premium-services', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    })
+    load()
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Premium Services</h1>
+      <form onSubmit={save} className="space-y-4 bg-white p-6 rounded shadow border">
+        <div>
+          <label className="block font-medium mb-1">Title</label>
+          <input
+            className="w-full p-2 rounded border"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Image</label>
+          <input type="file" accept="image/*" onChange={handleImage} className="w-full p-2 rounded border" />
+          {form.imageUrl && <img src={form.imageUrl} alt="preview" className="h-32 object-cover mt-2" />}
+        </div>
+        <div>
+          <label className="block font-medium mb-2">Services</label>
+          <div className="space-y-2">
+            {form.items.map((item, idx) => (
+              <div key={item.id} className="flex gap-2 items-end">
+                <input
+                  className="flex-1 p-2 rounded border"
+                  placeholder="Service name"
+                  value={item.name}
+                  onChange={(e) => updateItem(idx, 'name', e.target.value)}
+                  required
+                />
+                <input
+                  type="number"
+                  className="w-24 p-2 rounded border"
+                  placeholder="Current"
+                  value={item.currentPrice}
+                  onChange={(e) => updateItem(idx, 'currentPrice', parseFloat(e.target.value))}
+                  required
+                />
+                <input
+                  type="number"
+                  className="w-24 p-2 rounded border"
+                  placeholder="Offer"
+                  value={item.offerPrice ?? ''}
+                  onChange={(e) => updateItem(idx, 'offerPrice', parseFloat(e.target.value))}
+                />
+                <button type="button" onClick={() => removeItem(idx)} className="p-2 text-red-600">
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+            <button type="button" onClick={addItem} className="flex items-center gap-1 text-sm text-green-700">
+              <Plus className="h-4 w-4" /> Add Service
+            </button>
+          </div>
+        </div>
+        <button type="submit" className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded">
+          {editing ? 'Update' : 'Add'} Plan
+        </button>
+      </form>
+
+      <table className="w-full text-left text-sm bg-white rounded shadow border">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2">Title</th>
+            <th className="px-3 py-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {plans.map((p) => (
+            <tr key={p.id} className="border-t">
+              <td className="px-3 py-2">{p.title}</td>
+              <td className="flex gap-2 px-3 py-2">
+                <button
+                  className="flex items-center gap-1 px-2 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded"
+                  onClick={() => edit(p)}
+                >
+                  <Pencil className="h-4 w-4" /> Edit
+                </button>
+                <button
+                  className="flex items-center gap-1 px-2 py-1 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                  onClick={() => del(p.id)}
+                >
+                  <Trash2 className="h-4 w-4" /> Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/api/admin/premium-services/route.ts
+++ b/src/app/api/admin/premium-services/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const plans = await prisma.premiumService.findMany({
+    include: { items: { orderBy: { order: 'asc' } } },
+    orderBy: { order: 'asc' },
+  })
+  return NextResponse.json(plans)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const created = await prisma.premiumService.create({
+    data: {
+      title: data.title,
+      imageUrl: data.imageUrl,
+      order: data.order ?? 0,
+      items: {
+        create: (data.items || []).map(
+          (
+            item: { name: string; currentPrice: number; offerPrice?: number },
+            idx: number,
+          ) => ({
+            name: item.name,
+            currentPrice: item.currentPrice,
+            offerPrice: item.offerPrice,
+            order: idx,
+          }),
+        ),
+      },
+    },
+    include: { items: { orderBy: { order: 'asc' } } },
+  })
+  return NextResponse.json(created)
+}
+
+export async function PUT(req: Request) {
+  const data = await req.json()
+  const updated = await prisma.premiumService.update({
+    where: { id: data.id },
+    data: {
+      title: data.title,
+      imageUrl: data.imageUrl,
+      order: data.order ?? 0,
+      items: {
+        deleteMany: {},
+        create: (data.items || []).map(
+          (
+            item: { name: string; currentPrice: number; offerPrice?: number },
+            idx: number,
+          ) => ({
+            name: item.name,
+            currentPrice: item.currentPrice,
+            offerPrice: item.offerPrice,
+            order: idx,
+          }),
+        ),
+      },
+    },
+    include: { items: { orderBy: { order: 'asc' } } },
+  })
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(req: Request) {
+  const { id } = await req.json()
+  await prisma.premiumService.delete({ where: { id } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/premium-services/route.ts
+++ b/src/app/api/premium-services/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const plans = await prisma.premiumService.findMany({
+    include: { items: { orderBy: { order: 'asc' } } },
+    orderBy: { order: 'asc' },
+  })
+  return NextResponse.json(plans)
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,6 +57,19 @@ export default function HomePage() {
     children: [],
   })
   const [offers, setOffers] = useState<any[]>([])
+  interface PremiumServiceItem {
+    id: string
+    name: string
+    currentPrice: number
+    offerPrice?: number | null
+  }
+  interface PremiumServicePlan {
+    id: string
+    title: string
+    imageUrl?: string | null
+    items: PremiumServiceItem[]
+  }
+  const [premiumPlans, setPremiumPlans] = useState<PremiumServicePlan[]>([])
 
   // Search functionality
   const [searchQuery, setSearchQuery] = useState("")
@@ -87,6 +100,21 @@ export default function HomePage() {
     fetch('/api/limited-time-offers')
       .then((res) => res.json())
       .then((data) => setOffers(Array.isArray(data) ? data : []))
+  }, [])
+
+  useEffect(() => {
+    const cached = getCache('premium-services')
+    if (cached) {
+      setPremiumPlans(Array.isArray(cached) ? cached : [])
+      return
+    }
+    fetch('/api/premium-services')
+      .then((res) => res.json())
+      .then((data: unknown) => {
+        const plans = Array.isArray(data) ? (data as PremiumServicePlan[]) : []
+        setPremiumPlans(plans)
+        setCache('premium-services', plans)
+      })
   }, [])
 
   useEffect(() => {
@@ -353,6 +381,45 @@ export default function HomePage() {
         ))
       )}
     </div>
+  </div>
+</section>
+<section id="premium-services" className="bg-white py-12 sm:py-16">
+  <div className="container mx-auto px-6">
+    <div className="text-center mb-8">
+      <h2 className="mt-3 text-2xl md:text-3xl font-bold text-amber-600">Our Premium Services</h2>
+      <div className="mx-auto mt-3 h-1 w-24 rounded-full bg-gradient-to-r from-amber-400 via-emerald-500 to-amber-400" />
+    </div>
+    {premiumPlans.length === 0 ? (
+      <p className="text-center text-gray-500">No premium services available</p>
+    ) : (
+      <div className="grid md:grid-cols-2 gap-8">
+        {premiumPlans.map((plan: PremiumServicePlan) => (
+          <div key={plan.id} className="border-2 border-amber-400 rounded-lg p-4 text-amber-700">
+            {plan.imageUrl && (
+              <img src={plan.imageUrl} alt={plan.title} className="w-full h-40 object-cover rounded mb-4" />
+            )}
+            <h3 className="text-xl font-bold mb-4 text-center">{plan.title}</h3>
+            <ul className="divide-y divide-amber-400 divide-dashed">
+              {plan.items.map((item: PremiumServiceItem) => (
+                <li key={item.id} className="py-2 flex justify-between">
+                  <span>{item.name}</span>
+                  <span className="font-semibold">
+                    {item.offerPrice && item.offerPrice < item.currentPrice ? (
+                      <>
+                        <span className="line-through mr-2">₹{item.currentPrice}</span>
+                        <span>₹{item.offerPrice}</span>
+                      </>
+                    ) : (
+                      <span>₹{item.currentPrice}</span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    )}
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- add PremiumService and PremiumServiceItem models
- create admin UI and APIs to manage premium service plans
- display new "Our Premium Services" section on home page

## Testing
- `npm run lint` (fails: Unexpected any and other existing lint errors)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689f0b7232448325b8b20fee225f245b