### PR TITLE
Link premium services to existing service tiers

### DIFF
--- a/prisma/migrations/20250808000000_link_premium_items_to_service_tiers/migration.sql
+++ b/prisma/migrations/20250808000000_link_premium_items_to_service_tiers/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `PremiumServiceItem`
+  ADD COLUMN `serviceTierId` VARCHAR(191) NOT NULL,
+  ADD CONSTRAINT `PremiumServiceItem_serviceTierId_fkey` FOREIGN KEY (`serviceTierId`) REFERENCES `ServiceTier`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE `PremiumServiceItem`
+  DROP COLUMN `name`,
+  DROP COLUMN `currentPrice`,
+  DROP COLUMN `offerPrice`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,7 +17,7 @@ model User {
   email       String?   @unique @db.VarChar(191)
   role        String    @default("customer") @db.VarChar(191)
   password    String?   @db.VarChar(191)
-  modules     Json?    @default("[]")
+  modules     Json?     @default("[]")
   branchId    String?   @db.VarChar(191)
   branch      Branch?   @relation(fields: [branchId], references: [id])
   phone       String?   @unique @db.VarChar(191)
@@ -146,6 +146,7 @@ model ServiceTier {
   duration     Int?
   priceHistory ServiceTierPriceHistory[]
   heroTabs     HeroTabVariant[]
+  premiumItems PremiumServiceItem[]
 }
 
 model ServiceTierPriceHistory {
@@ -172,22 +173,21 @@ model FeaturedService {
 }
 
 model PremiumService {
-  id        String   @id @default(uuid())
+  id        String               @id @default(uuid())
   title     String
   imageUrl  String?
-  order     Int      @default(0)
+  order     Int                  @default(0)
   items     PremiumServiceItem[]
-  createdAt DateTime @default(now()) @db.Timestamp(3)
-  updatedAt DateTime @default(now()) @updatedAt @db.Timestamp(3)
+  createdAt DateTime             @default(now()) @db.Timestamp(3)
+  updatedAt DateTime             @default(now()) @updatedAt @db.Timestamp(3)
 }
 
 model PremiumServiceItem {
   id               String         @id @default(uuid())
   premiumService   PremiumService @relation(fields: [premiumServiceId], references: [id], onDelete: Cascade)
   premiumServiceId String
-  name             String
-  currentPrice     Float
-  offerPrice       Float?
+  serviceTier      ServiceTier    @relation(fields: [serviceTierId], references: [id])
+  serviceTierId    String
   order            Int            @default(0)
 }
 
@@ -263,22 +263,22 @@ model HeroTabVariant {
 }
 
 model Enquiry {
-  id         String   @id @default(uuid()) @db.VarChar(191)
-  customerId String?  @db.VarChar(191)
-  customer   User?    @relation(fields: [customerId], references: [id])
-  name       String?  @db.VarChar(191)
-  phone      String?  @db.VarChar(191)
-  gender     String?  @db.VarChar(191)
-  enquiry    String?  @db.LongText
-  variantIds String?  @db.Text
-  status     String   @default("new") @db.VarChar(191)
-  remark     String?  @db.Text
-  source     String   @default("admin") @db.VarChar(191)
+  id            String    @id @default(uuid()) @db.VarChar(191)
+  customerId    String?   @db.VarChar(191)
+  customer      User?     @relation(fields: [customerId], references: [id])
+  name          String?   @db.VarChar(191)
+  phone         String?   @db.VarChar(191)
+  gender        String?   @db.VarChar(191)
+  enquiry       String?   @db.LongText
+  variantIds    String?   @db.Text
+  status        String    @default("new") @db.VarChar(191)
+  remark        String?   @db.Text
+  source        String    @default("admin") @db.VarChar(191)
   preferredDate DateTime? @db.Date
-  preferredTime String?  @db.VarChar(191)
+  preferredTime String?   @db.VarChar(191)
 
-  createdAt  DateTime @default(now()) @db.Timestamp(3)
-  updatedAt  DateTime @default(now()) @updatedAt @db.Timestamp(3)
+  createdAt DateTime @default(now()) @db.Timestamp(3)
+  updatedAt DateTime @default(now()) @updatedAt @db.Timestamp(3)
 }
 
 model Offer {

--- a/src/app/api/admin/premium-services/route.ts
+++ b/src/app/api/admin/premium-services/route.ts
@@ -1,16 +1,58 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+function serialize(plan: any) {
+  return {
+    id: plan.id,
+    title: plan.title,
+    imageUrl: plan.imageUrl,
+    order: plan.order,
+    items: plan.items.map((item: any) => {
+      const tier = item.serviceTier
+      const price = tier.priceHistory[0]
+      return {
+        id: item.id,
+        serviceTierId: item.serviceTierId,
+        name: `${tier.service.name} - ${tier.name}`,
+        currentPrice: price?.actualPrice ?? 0,
+        offerPrice: price?.offerPrice ?? null,
+      }
+    }),
+  }
+}
+
 export async function GET() {
+  const now = new Date()
   const plans = await prisma.premiumService.findMany({
-    include: { items: { orderBy: { order: 'asc' } } },
+    include: {
+      items: {
+        orderBy: { order: 'asc' },
+        include: {
+          serviceTier: {
+            include: {
+              service: true,
+              priceHistory: {
+                where: {
+                  startDate: { lte: now },
+                  OR: [{ endDate: null }, { endDate: { gt: now } }],
+                },
+                orderBy: { startDate: 'desc' },
+                take: 1,
+              },
+            },
+          },
+        },
+      },
+    },
     orderBy: { order: 'asc' },
   })
-  return NextResponse.json(plans)
+  return NextResponse.json(plans.map(serialize))
 }
 
 export async function POST(req: Request) {
   const data = await req.json()
+  const now = new Date()
   const created = await prisma.premiumService.create({
     data: {
       title: data.title,
@@ -18,25 +60,40 @@ export async function POST(req: Request) {
       order: data.order ?? 0,
       items: {
         create: (data.items || []).map(
-          (
-            item: { name: string; currentPrice: number; offerPrice?: number },
-            idx: number,
-          ) => ({
-            name: item.name,
-            currentPrice: item.currentPrice,
-            offerPrice: item.offerPrice,
+          (item: { serviceTierId: string }, idx: number) => ({
+            serviceTierId: item.serviceTierId,
             order: idx,
           }),
         ),
       },
     },
-    include: { items: { orderBy: { order: 'asc' } } },
+    include: {
+      items: {
+        orderBy: { order: 'asc' },
+        include: {
+          serviceTier: {
+            include: {
+              service: true,
+              priceHistory: {
+                where: {
+                  startDate: { lte: now },
+                  OR: [{ endDate: null }, { endDate: { gt: now } }],
+                },
+                orderBy: { startDate: 'desc' },
+                take: 1,
+              },
+            },
+          },
+        },
+      },
+    },
   })
-  return NextResponse.json(created)
+  return NextResponse.json(serialize(created))
 }
 
 export async function PUT(req: Request) {
   const data = await req.json()
+  const now = new Date()
   const updated = await prisma.premiumService.update({
     where: { id: data.id },
     data: {
@@ -46,21 +103,35 @@ export async function PUT(req: Request) {
       items: {
         deleteMany: {},
         create: (data.items || []).map(
-          (
-            item: { name: string; currentPrice: number; offerPrice?: number },
-            idx: number,
-          ) => ({
-            name: item.name,
-            currentPrice: item.currentPrice,
-            offerPrice: item.offerPrice,
+          (item: { serviceTierId: string }, idx: number) => ({
+            serviceTierId: item.serviceTierId,
             order: idx,
           }),
         ),
       },
     },
-    include: { items: { orderBy: { order: 'asc' } } },
+    include: {
+      items: {
+        orderBy: { order: 'asc' },
+        include: {
+          serviceTier: {
+            include: {
+              service: true,
+              priceHistory: {
+                where: {
+                  startDate: { lte: now },
+                  OR: [{ endDate: null }, { endDate: { gt: now } }],
+                },
+                orderBy: { startDate: 'desc' },
+                take: 1,
+              },
+            },
+          },
+        },
+      },
+    },
   })
-  return NextResponse.json(updated)
+  return NextResponse.json(serialize(updated))
 }
 
 export async function DELETE(req: Request) {

--- a/src/app/api/premium-services/route.ts
+++ b/src/app/api/premium-services/route.ts
@@ -1,10 +1,50 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+function serialize(plan: any) {
+  return {
+    id: plan.id,
+    title: plan.title,
+    imageUrl: plan.imageUrl,
+    order: plan.order,
+    items: plan.items.map((item: any) => {
+      const tier = item.serviceTier
+      const price = tier.priceHistory[0]
+      return {
+        id: item.id,
+        name: `${tier.service.name} - ${tier.name}`,
+        currentPrice: price?.actualPrice ?? 0,
+        offerPrice: price?.offerPrice ?? null,
+      }
+    }),
+  }
+}
+
 export async function GET() {
+  const now = new Date()
   const plans = await prisma.premiumService.findMany({
-    include: { items: { orderBy: { order: 'asc' } } },
+    include: {
+      items: {
+        orderBy: { order: 'asc' },
+        include: {
+          serviceTier: {
+            include: {
+              service: true,
+              priceHistory: {
+                where: {
+                  startDate: { lte: now },
+                  OR: [{ endDate: null }, { endDate: { gt: now } }],
+                },
+                orderBy: { startDate: 'desc' },
+                take: 1,
+              },
+            },
+          },
+        },
+      },
+    },
     orderBy: { order: 'asc' },
   })
-  return NextResponse.json(plans)
+  return NextResponse.json(plans.map(serialize))
 }


### PR DESCRIPTION
## Summary
- Reference existing service tiers for premium service items
- Allow admins to pick service variants with current pricing
- Expose premium service plans with dynamic prices

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f134fa6e88325b173c8c322f33484