### PR TITLE
Redesign admin users page with mobile numbers

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -14,6 +14,7 @@ interface User {
   id: string
   name: string | null
   email: string | null
+  phone: string | null
   role: string
   modules: string[] | null
   designation: string | null
@@ -31,7 +32,7 @@ const allModules = [
   'billing',
 ]
 
-export default function StaffRolesPage() {
+export default function UsersPage() {
   const [users, setUsers] = useState<User[]>([])
 
   useEffect(() => {
@@ -58,41 +59,48 @@ export default function StaffRolesPage() {
   const staffCount = users.filter((u) => u.role === 'staff').length
 
   return (
-    <div className="p-4 max-w-5xl mx-auto">
-      <h1 className="flex items-center text-3xl font-bold mb-6 text-green-800">
-        <Users className="w-8 h-8 mr-2" /> Staff Roles
+    <div className="p-6 max-w-6xl mx-auto space-y-8">
+      <h1 className="flex items-center text-4xl font-extrabold bg-gradient-to-r from-green-600 to-emerald-500 bg-clip-text text-transparent">
+        <Users className="w-9 h-9 mr-3 text-green-700" /> Users
       </h1>
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-        <div className="flex items-center p-4 bg-green-50 rounded shadow-sm">
-          <Users className="text-green-600 mr-3" />
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+        <div className="flex items-center p-5 rounded-xl shadow bg-gradient-to-br from-green-200 to-green-400 text-green-900">
+          <div className="p-3 bg-white rounded-full mr-4">
+            <Users className="w-6 h-6 text-green-700" />
+          </div>
           <div>
-            <p className="text-sm text-gray-600">Total Users</p>
-            <p className="text-xl font-semibold">{users.length}</p>
+            <p className="text-sm">Total Users</p>
+            <p className="text-2xl font-bold">{users.length}</p>
           </div>
         </div>
-        <div className="flex items-center p-4 bg-green-50 rounded shadow-sm">
-          <Shield className="text-green-600 mr-3" />
+        <div className="flex items-center p-5 rounded-xl shadow bg-gradient-to-br from-yellow-200 to-yellow-400 text-yellow-900">
+          <div className="p-3 bg-white rounded-full mr-4">
+            <Shield className="w-6 h-6 text-yellow-700" />
+          </div>
           <div>
-            <p className="text-sm text-gray-600">Admins</p>
-            <p className="text-xl font-semibold">{adminCount}</p>
+            <p className="text-sm">Admins</p>
+            <p className="text-2xl font-bold">{adminCount}</p>
           </div>
         </div>
-        <div className="flex items-center p-4 bg-green-50 rounded shadow-sm">
-          <UserCog className="text-green-600 mr-3" />
+        <div className="flex items-center p-5 rounded-xl shadow bg-gradient-to-br from-blue-200 to-blue-400 text-blue-900">
+          <div className="p-3 bg-white rounded-full mr-4">
+            <UserCog className="w-6 h-6 text-blue-700" />
+          </div>
           <div>
-            <p className="text-sm text-gray-600">Staff</p>
-            <p className="text-xl font-semibold">{staffCount}</p>
+            <p className="text-sm">Staff</p>
+            <p className="text-2xl font-bold">{staffCount}</p>
           </div>
         </div>
       </div>
 
-      <table className="w-full bg-white rounded-lg shadow overflow-hidden">
-        <thead className="bg-green-100">
+      <table className="w-full bg-white rounded-xl shadow-lg overflow-hidden">
+        <thead className="bg-green-600 text-white">
           <tr className="text-left">
             <th className="p-3">Photo</th>
             <th className="p-3">Name</th>
             <th className="p-3">Email</th>
+            <th className="p-3">Mobile</th>
             <th className="p-3">Designation</th>
             <th className="p-3">Role</th>
             <th className="p-3">Modules</th>
@@ -104,7 +112,7 @@ export default function StaffRolesPage() {
           {users.map((user) => (
             <tr
               key={user.id}
-              className="border-t odd:bg-green-50 last:border-b-0 hover:bg-green-100"
+              className="border-t last:border-b-0 odd:bg-green-50 hover:bg-green-100 transition-colors"
             >
               <td className="p-3">
                 {user.imageUrl ? (
@@ -119,14 +127,13 @@ export default function StaffRolesPage() {
               </td>
               <td className="p-3">{user.name ?? '—'}</td>
               <td className="p-3">{user.email ?? '—'}</td>
+              <td className="p-3">{user.phone ?? '—'}</td>
               <td className="p-3">{user.designation ?? '—'}</td>
               <td className="p-3">
                 <select
                   value={user.role}
-                  onChange={(e) =>
-                    updateUser(user.id, { role: e.target.value })
-                  }
-                  className="border p-1 rounded"
+                  onChange={(e) => updateUser(user.id, { role: e.target.value })}
+                  className="border border-green-300 p-1 rounded bg-green-50"
                 >
                   <option value="admin">admin</option>
                   <option value="staff">staff</option>
@@ -135,8 +142,7 @@ export default function StaffRolesPage() {
               <td className="p-3">
                 <div className="flex flex-wrap gap-2">
                   {allModules.map((m) => {
-                    const active =
-                      user.role === 'admin' || user.modules?.includes(m)
+                    const active = user.role === 'admin' || user.modules?.includes(m)
                     const label = m.replace('-', ' ')
                     return (
                       <label key={m} className="flex items-center gap-1 text-sm">
@@ -160,9 +166,7 @@ export default function StaffRolesPage() {
               </td>
               <td className="p-3 text-center">
                 <button
-                  onClick={() =>
-                    updateUser(user.id, { removed: !user.removed })
-                  }
+                  onClick={() => updateUser(user.id, { removed: !user.removed })}
                   className={
                     user.removed
                       ? 'text-red-600 hover:text-red-800'

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -8,6 +8,7 @@ export async function GET() {
       id: true,
       name: true,
       email: true,
+      phone: true,
       role: true,
       modules: true,
       designation: true,


### PR DESCRIPTION
## Summary
- restyle admin users dashboard with colorful stats cards and improved table layout
- include each user's mobile number in the interface and table
- extend users API to return phone numbers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors across project)*
- `npm run build` *(fails: ReferenceError: useRef is not defined during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_689f205d7b388325a6678f7d4337da7f