### PR TITLE
Include admin role in login role selection

### DIFF
--- a/src/app/api/auth/role-options/route.ts
+++ b/src/app/api/auth/role-options/route.ts
@@ -5,16 +5,18 @@ import { prisma } from '@/lib/prisma'
 export async function GET() {
   const session = await getServerSession(authOptions)
   const phone = (session?.user as { phone?: string | null })?.phone
-  if (!phone) return Response.json({ staff: false, customer: false })
+  if (!phone) return Response.json({ admin: false, staff: false, customer: false })
 
   const user = await prisma.user.findUnique({ where: { phone }, select: { role: true } })
-  const staff = user?.role !== 'customer'
+  const admin = user?.role === 'admin'
+  const staff = user?.role === 'staff' || user?.role === 'customer_staff'
 
   const [billing, booking] = await Promise.all([
     prisma.billing.findFirst({ where: { phone } }),
     prisma.booking.findFirst({ where: { phone } }),
   ])
-  const customer = user?.role === 'customer' || !!billing || !!booking
+  const customer =
+    user?.role === 'customer' || user?.role === 'customer_staff' || !!billing || !!booking
 
-  return Response.json({ staff, customer })
+  return Response.json({ admin, staff, customer })
 }


### PR DESCRIPTION
## Summary
- add admin detection to role options API
- show admin option on login role prompt and support admin selection

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689f27c870c88325a0266be37510e222