### PR TITLE
Include admin role in login role selection

### DIFF
--- a/src/app/api/auth/role-options/route.ts
+++ b/src/app/api/auth/role-options/route.ts
@@ -5,16 +5,18 @@ import { prisma } from '@/lib/prisma'
 export async function GET() {
   const session = await getServerSession(authOptions)
   const phone = (session?.user as { phone?: string | null })?.phone
-  if (!phone) return Response.json({ staff: false, customer: false })
+  if (!phone) return Response.json({ admin: false, staff: false, customer: false })
 
   const user = await prisma.user.findUnique({ where: { phone }, select: { role: true } })
-  const staff = user?.role !== 'customer'
+  const admin = user?.role === 'admin'
+  const staff = user?.role === 'staff' || user?.role === 'customer_staff'
 
   const [billing, booking] = await Promise.all([
     prisma.billing.findFirst({ where: { phone } }),
     prisma.booking.findFirst({ where: { phone } }),
   ])
-  const customer = user?.role === 'customer' || !!billing || !!booking
+  const customer =
+    user?.role === 'customer' || user?.role === 'customer_staff' || !!billing || !!booking
 
-  return Response.json({ staff, customer })
+  return Response.json({ admin, staff, customer })
 }

--- a/src/app/login/SignInClient.tsx
+++ b/src/app/login/SignInClient.tsx
@@ -3,15 +3,16 @@
 import { useState } from 'react'
 import { signIn } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
-import { Phone, Lock, Users, User, CheckCircle2, Sparkles, Loader2 } from 'lucide-react'
+import { Phone, Lock, Users, User, CheckCircle2, Sparkles, Loader2, Shield } from 'lucide-react'
 import { motion } from 'framer-motion'
 
 export default function SignInClient() {
   const [phone, setPhone] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
-  const [roles, setRoles] = useState<{ staff: boolean; customer: boolean } | null>(null)
+  const [roles, setRoles] = useState<{ admin: boolean; staff: boolean; customer: boolean } | null>(null)
   const [loading, setLoading] = useState(false)
+  const [roleLoading, setRoleLoading] = useState<'admin' | 'staff' | 'customer' | null>(null)
   const router = useRouter()
 
   // --- helpers: digits only + 10 max ---
@@ -40,9 +41,12 @@ export default function SignInClient() {
     try {
       const rolesRes = await fetch('/api/auth/role-options', { credentials: 'include' })
       const data = await rolesRes.json()
-      if (data.staff && data.customer) {
+      const count = (data.admin ? 1 : 0) + (data.staff ? 1 : 0) + (data.customer ? 1 : 0)
+      if (count > 1) {
         setRoles(data)
         setLoading(false)
+      } else if (data.admin) {
+        await selectRole('admin')
       } else if (data.staff) {
         await selectRole('staff')
       } else if (data.customer) {
@@ -57,7 +61,12 @@ export default function SignInClient() {
     }
   }
 
-  const selectRole = async (role: 'staff' | 'customer') => {
+  const handleRoleSelect = async (role: 'staff' | 'customer' | 'admin') => {
+    setRoleLoading(role)
+    await selectRole(role)
+  }
+
+  const selectRole = async (role: 'staff' | 'customer' | 'admin') => {
     await fetch('/api/auth/set-role', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -90,7 +99,7 @@ export default function SignInClient() {
   }
 
   // --- Role chooser (styled) ---
-  if (roles && roles.staff && roles.customer) {
+  if (roles) {
     return (
       <div className="min-h-screen relative overflow-hidden bg-gradient-to-br from-emerald-900 via-emerald-950 to-emerald-900 text-emerald-50">
         <div aria-hidden className="pointer-events-none absolute -top-24 -left-24 h-72 w-72 rounded-full bg-emerald-400/20 blur-3xl" />
@@ -105,18 +114,57 @@ export default function SignInClient() {
             <h1 className="text-3xl md:text-4xl font-extrabold text-emerald-100">Choose Role</h1>
             <p className="text-emerald-200/85">Select how you want to continue</p>
             <div className="flex flex-col sm:flex-row gap-4 md:gap-6 justify-center mt-2">
-              <button
-                onClick={() => selectRole('staff')}
-                className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 rounded-xl bg-emerald-600 text-white font-semibold shadow hover:bg-emerald-700 transition-colors"
-              >
-                <Users /> Staff
-              </button>
-              <button
-                onClick={() => selectRole('customer')}
-                className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 rounded-xl bg-emerald-50 text-emerald-900 font-semibold shadow hover:bg-emerald-100 transition-colors"
-              >
-                <User /> Customer
-              </button>
+              {roles.admin && (
+                <button
+                  onClick={() => handleRoleSelect('admin')}
+                  disabled={!!roleLoading}
+                  className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 rounded-xl bg-emerald-600 text-white font-semibold shadow hover:bg-emerald-700 transition-colors disabled:opacity-50"
+                >
+                  {roleLoading === 'admin' ? (
+                    <>
+                      <Loader2 className="animate-spin" /> Loading...
+                    </>
+                  ) : (
+                    <>
+                      <Shield /> Admin
+                    </>
+                  )}
+                </button>
+              )}
+              {roles.staff && (
+                <button
+                  onClick={() => handleRoleSelect('staff')}
+                  disabled={!!roleLoading}
+                  className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 rounded-xl bg-emerald-600 text-white font-semibold shadow hover:bg-emerald-700 transition-colors disabled:opacity-50"
+                >
+                  {roleLoading === 'staff' ? (
+                    <>
+                      <Loader2 className="animate-spin" /> Loading...
+                    </>
+                  ) : (
+                    <>
+                      <Users /> Staff
+                    </>
+                  )}
+                </button>
+              )}
+              {roles.customer && (
+                <button
+                  onClick={() => handleRoleSelect('customer')}
+                  disabled={!!roleLoading}
+                  className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 rounded-xl bg-emerald-50 text-emerald-900 font-semibold shadow hover:bg-emerald-100 transition-colors disabled:opacity-50"
+                >
+                  {roleLoading === 'customer' ? (
+                    <>
+                      <Loader2 className="animate-spin" /> Loading...
+                    </>
+                  ) : (
+                    <>
+                      <User /> Customer
+                    </>
+                  )}
+                </button>
+              )}
             </div>
           </motion.div>
         </div>


### PR DESCRIPTION
## Summary
- add admin detection to role options API
- show admin option on login role prompt and support admin selection
- display loading indicator while setting the chosen role

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689f27c870c88325a0266be37510e222