### PR TITLE
feat: enforce staff portal role restrictions

### DIFF
--- a/pages/api/billing-services.ts
+++ b/pages/api/billing-services.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!date) return res.status(400).json({ error: 'Missing date' })
   try {
     const bookings = await prisma.booking.findMany({
-      where: { date },
+      where: { date, status: { not: 'cancelled' } },
       include: { items: true },
       orderBy: { start: 'asc' },
     })

--- a/pages/api/booking-items.ts
+++ b/pages/api/booking-items.ts
@@ -1,8 +1,47 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { prisma } from '@/lib/prisma'
 import { startOfDay, endOfDay } from 'date-fns'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions)
+  if (!session) return res.status(401).json({ error: 'Unauthorized' })
+  const role = (session.user as { role?: string })?.role
+  const userId = (session.user as { id?: string })?.id
+  const allowed = ['beautician', 'receptionist', 'manager', 'owner']
+
+  if (req.method === 'POST') {
+    const { bookingId, serviceId, tierId, name, duration, price, start } = req.body
+    try {
+      const booking = await prisma.booking.findUnique({ where: { id: bookingId } })
+      if (!booking) return res.status(404).json({ error: 'Booking not found' })
+      if (!booking.phone) return res.status(403).json({ error: 'Cannot add service without customer phone' })
+      if (booking.status === 'cancelled') return res.status(400).json({ error: 'Cannot modify a cancelled booking' })
+      if (role !== 'admin') {
+        if (!userId || booking.staffId !== userId || !allowed.includes(role || '')) {
+          return res.status(403).json({ error: 'Forbidden' })
+        }
+      }
+      const item = await prisma.bookingItem.create({
+        data: {
+          bookingId,
+          serviceId,
+          tierId,
+          name,
+          duration,
+          price,
+          staffId: userId!,
+          start,
+        },
+      })
+      return res.status(200).json(item)
+    } catch (err) {
+      console.error('add booking item error', err)
+      return res.status(500).json({ error: 'Failed to add service' })
+    }
+  }
+
   if (req.method === 'PUT') {
     const { id, staffId, start, customer, phone, gender, age } = req.body
     try {
@@ -11,6 +50,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         include: { booking: true },
       })
       if (!existing) return res.status(404).json({ error: 'Booking item not found' })
+      if (existing.booking.status === 'cancelled') return res.status(400).json({ error: 'Cannot modify a cancelled booking' })
+      if (role !== 'admin') {
+        if (!userId || existing.booking.staffId !== userId || !allowed.includes(role || '')) {
+          return res.status(403).json({ error: 'Forbidden' })
+        }
+      }
 
       const scheduledAt = new Date(`${existing.booking.date}T${existing.start}:00`)
       const billed = await prisma.billing.findFirst({ where: { scheduledAt } })
@@ -66,6 +111,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         include: { booking: true },
       })
       if (!item) return res.status(404).json({ error: 'Booking item not found' })
+      if (item.booking.status === 'cancelled') return res.status(400).json({ error: 'Cannot modify a cancelled booking' })
+      if (role !== 'admin') {
+        if (!userId || item.booking.staffId !== userId || !allowed.includes(role || '')) {
+          return res.status(403).json({ error: 'Forbidden' })
+        }
+      }
       const scheduledAt = new Date(`${item.booking.date}T${item.start}:00`)
       const billed = await prisma.billing.findFirst({ where: { scheduledAt } })
       if (billed) {
@@ -90,6 +141,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   }
 
-  res.setHeader('Allow', ['PUT', 'DELETE'])
+  res.setHeader('Allow', ['POST', 'PUT', 'DELETE'])
   return res.status(405).end(`Method ${req.method} Not Allowed`)
 }

--- a/pages/api/bookings.ts
+++ b/pages/api/bookings.ts
@@ -1,12 +1,27 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { prisma } from '@/lib/prisma'
+import type { Prisma } from '@prisma/client'
 import { startOfDay, endOfDay } from 'date-fns'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions)
+  if (!session) return res.status(401).json({ error: 'Unauthorized' })
+  const role = (session.user as { role?: string })?.role
+  const userId = (session.user as { id?: string })?.id
+
   if (req.method === 'GET') {
     const date = req.query.date as string | undefined
-    const where: { date?: string } = {}
+    const where: { date?: string; staffId?: string } = {}
     if (date) where.date = date
+    if (role !== 'admin') {
+      const allowed = ['beautician', 'receptionist', 'manager', 'owner']
+      if (!role || !allowed.includes(role) || !userId) {
+        return res.status(403).json({ error: 'Forbidden' })
+      }
+      where.staffId = userId
+    }
     const bookings = await prisma.booking.findMany({
       where,
       include: { items: true },
@@ -37,6 +52,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === 'POST') {
     const data = req.body
     const firstItem = data.items?.[0]
+    const bookingStaffId = firstItem?.staffId || data.staffId
+    const allowed = ['beautician', 'receptionist', 'manager', 'owner']
+
+    if (role !== 'admin') {
+      if (!userId || bookingStaffId !== userId || !allowed.includes(role || '')) {
+        return res.status(403).json({ error: 'Forbidden' })
+      }
+    }
 
     if (data.phone && data.customer) {
       try {
@@ -55,10 +78,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         phone: data.phone,
         gender: data.gender,
         age: data.age !== null && data.age !== undefined ? Number(data.age) : null,
-        staffId: firstItem?.staffId || data.staffId,
+        staffId: bookingStaffId,
         date: data.date,
         start: firstItem?.start || data.start,
         color: data.color,
+        status: data.status || undefined,
         items: {
           create:
             (data.items as {
@@ -85,23 +109,41 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(200).json(booking)
   }
   if (req.method === 'PUT') {
-    const { id, staffId, start, customer, phone, gender, age } = req.body
+    const { id, staffId, start, customer, phone, gender, age, status } = req.body
+    const existing = await prisma.booking.findUnique({ where: { id } })
+    if (!existing) return res.status(404).json({ error: 'Booking not found' })
+    if (role !== 'admin') {
+      const allowed = ['beautician', 'receptionist', 'manager', 'owner']
+      if (!userId || existing.staffId !== userId || !allowed.includes(role || '')) {
+        return res.status(403).json({ error: 'Forbidden' })
+      }
+    }
+    const updateData: Prisma.BookingUpdateInput = {
+      staffId,
+      start,
+      customer,
+      phone,
+      gender,
+      age: age !== null && age !== undefined ? Number(age) : null,
+    }
+    if (status) updateData.status = status
     const booking = await prisma.booking.update({
       where: { id },
-      data: {
-        staffId,
-        start,
-        customer,
-        phone,
-        gender,
-        age: age !== null && age !== undefined ? Number(age) : null,
-      },
+      data: updateData,
       include: { items: true },
     })
     return res.status(200).json(booking)
   }
   if (req.method === 'DELETE') {
     const id = (req.query.id as string) || req.body.id
+    const existing = await prisma.booking.findUnique({ where: { id } })
+    if (!existing) return res.status(404).json({ error: 'Booking not found' })
+    if (role !== 'admin') {
+      const allowed = ['beautician', 'receptionist', 'manager', 'owner']
+      if (!userId || existing.staffId !== userId || !allowed.includes(role || '')) {
+        return res.status(403).json({ error: 'Forbidden' })
+      }
+    }
     await prisma.bookingItem.deleteMany({ where: { bookingId: id } })
     await prisma.booking.delete({ where: { id } })
     return res.status(204).end()

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,6 +202,7 @@ model Booking {
   date      String        @db.VarChar(10)
   start     String        @db.VarChar(5)
   color     String        @db.VarChar(191)
+  status    String        @default("pending") @db.VarChar(191)
   createdAt DateTime      @default(now()) @db.Timestamp(3)
   items     BookingItem[]
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,7 +14,17 @@ export async function middleware(req: NextRequest) {
   }
 
   if (pathname.startsWith('/staff')) {
-    if (!token || (token as { role?: string }).role === 'customer' || roleCookie !== 'staff') {
+    const role = (token as { role?: string | null })?.role
+    const allowed = ['beautician', 'receptionist', 'manager', 'owner']
+    if (!token) {
+      return NextResponse.redirect(new URL('/login', req.url))
+    }
+
+    if (role === 'admin') {
+      return NextResponse.redirect(new URL('/admin', req.url))
+    }
+
+    if (!role || !allowed.includes(role)) {
       return NextResponse.redirect(new URL('/login', req.url))
     }
   }


### PR DESCRIPTION
## Summary
- restrict /staff routes to specific staff roles and redirect admins appropriately
- scope booking APIs to logged-in staff and add ownership checks on mutations
- add booking-item API endpoint to add services with phone/ownership guards
- allow marking bookings completed or cancelled and block billing of cancelled tasks

## Testing
- `npm run lint` *(fails: Unexpected any and other existing errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_689f329289dc83258303cc56ac8f6aa6