### PR TITLE
Allow staff access to admin dashboard

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,7 +6,9 @@ import AdminClientLayout from './AdminClientLayout'
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions)
-  if (!session || session.user?.role !== 'admin') {
+  const role = session?.user?.role
+  const allowed = ['admin', 'staff', 'customer_staff']
+  if (!session || !role || !allowed.includes(role)) {
     redirect('/login')
   }
   return <AdminClientLayout>{children}</AdminClientLayout>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,9 @@ export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl
 
   if (pathname.startsWith('/admin')) {
-    if (!token || (token as { role?: string }).role !== 'admin') {
+    const role = (token as { role?: string | null })?.role
+    const allowedAdminRoles = ['admin', 'staff', 'customer_staff']
+    if (!token || !role || !allowedAdminRoles.includes(role)) {
       return NextResponse.redirect(new URL('/login', req.url))
     }
   }


### PR DESCRIPTION
## Summary
- permit staff and customer_staff roles to access admin routes
- relax admin layout guard so staff roles aren't redirected to login

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f3e7e5a308325a747b330845509e4