### PR TITLE
Restrict staff navigation and simplify role management

### DIFF
--- a/src/app/admin/AdminClientLayout.tsx
+++ b/src/app/admin/AdminClientLayout.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import React, { useState } from 'react'
-import { signOut } from 'next-auth/react'
+import { signOut, useSession } from 'next-auth/react'
 import { LoadingProvider } from '@/contexts/LoadingContext'
 import Loader from '@/components/Loader'
 
@@ -27,7 +27,7 @@ import {
 } from 'react-icons/md'
 import type { IconType } from 'react-icons'
 
-const sections: {
+const adminSections: {
   heading: string
   items: { href: string; label: string; icon: IconType }[]
 }[] = [
@@ -38,7 +38,7 @@ const sections: {
   {
     heading: 'Appointments & Billing',
     items: [
-         { href: '/admin/enquiries', label: 'Enquiries', icon: MdQuestionAnswer },
+      { href: '/admin/enquiries', label: 'Enquiries', icon: MdQuestionAnswer },
       { href: '/admin/walk-in', label: 'Walk-In Booking', icon: MdEvent },
       { href: '/admin/billing', label: 'New Billing', icon: MdReceipt },
       { href: '/admin/billing-history', label: 'Billing History', icon: MdHistory },
@@ -50,7 +50,6 @@ const sections: {
     items: [
       { href: '/admin/staff', label: 'Staff', icon: MdPeople },
       { href: '/admin/customers', label: 'Customers', icon: MdPeople },
-
     ],
   },
   {
@@ -77,10 +76,37 @@ const sections: {
   },
 ]
 
+const staffSections: {
+  heading: string
+  items: { href: string; label: string; icon: IconType }[]
+}[] = [
+  {
+    heading: 'Dashboard',
+    items: [{ href: '/admin/staff', label: 'Dashboard', icon: MdDashboard }],
+  },
+  {
+    heading: 'Appointments & Billing',
+    items: [
+      { href: '/admin/enquiries', label: 'Enquiries', icon: MdQuestionAnswer },
+      { href: '/admin/walk-in', label: 'Walk-In Booking', icon: MdEvent },
+      { href: '/admin/billing', label: 'New Billing', icon: MdReceipt },
+      { href: '/admin/billing-history', label: 'Billing History', icon: MdHistory },
+      { href: '/admin/paylater-bills', label: 'Pay Later', icon: MdPayment },
+    ],
+  },
+  {
+    heading: 'Customers',
+    items: [{ href: '/admin/customers', label: 'Customers', icon: MdPeople }],
+  },
+]
+
 export default function AdminClientLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const router = useRouter()
   const [open, setOpen] = useState(false)
+  const { data: session } = useSession()
+  const role = session?.user?.role
+  const sections = role === 'admin' ? adminSections : staffSections
 
   const handleLogout = async () => {
     await fetch('/api/auth/set-role', {
@@ -106,9 +132,9 @@ export default function AdminClientLayout({ children }: { children: React.ReactN
             >
               <MdMenu className="text-2xl" />
             </button>
-            <Link href="/admin/dashboard" className="flex items-center gap-2">
+            <Link href={role === 'admin' ? '/admin/dashboard' : '/admin/staff'} className="flex items-center gap-2">
               <img src="/logo.png" alt="Greens" className="h-8 w-auto" />
-              <span className="font-bold">Admin</span>
+              <span className="font-bold">{role === 'admin' ? 'Admin' : 'Staff'}</span>
             </Link>
           </div>
           <button

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -16,21 +16,10 @@ interface User {
   email: string | null
   phone: string | null
   role: string
-  modules: string[] | null
   designation: string | null
   imageUrl: string | null
   removed: boolean
 }
-
-const allModules = [
-  'dashboard',
-  'staff-roles',
-  'staff',
-  'customers',
-  'branches',
-  'services',
-  'billing',
-]
 
 export default function UsersPage() {
   const [users, setUsers] = useState<User[]>([])
@@ -43,7 +32,7 @@ export default function UsersPage() {
 
   const updateUser = async (
     id: string,
-    updates: Partial<Pick<User, 'role' | 'modules' | 'removed'>> & {
+    updates: Partial<Pick<User, 'role' | 'removed'>> & {
       password?: string
     },
   ) => {
@@ -103,7 +92,6 @@ export default function UsersPage() {
             <th className="p-3">Mobile</th>
             <th className="p-3">Designation</th>
             <th className="p-3">Role</th>
-            <th className="p-3">Modules</th>
             <th className="p-3 text-center">Active</th>
             <th className="p-3 text-center">Actions</th>
           </tr>
@@ -138,31 +126,6 @@ export default function UsersPage() {
                   <option value="admin">admin</option>
                   <option value="staff">staff</option>
                 </select>
-              </td>
-              <td className="p-3">
-                <div className="flex flex-wrap gap-2">
-                  {allModules.map((m) => {
-                    const active = user.role === 'admin' || user.modules?.includes(m)
-                    const label = m.replace('-', ' ')
-                    return (
-                      <label key={m} className="flex items-center gap-1 text-sm">
-                        <input
-                          type="checkbox"
-                          checked={active}
-                          disabled={user.role === 'admin'}
-                          onChange={() => {
-                            if (user.role === 'admin') return
-                            const modules = active
-                              ? (user.modules ?? []).filter((x) => x !== m)
-                              : [...(user.modules ?? []), m]
-                            updateUser(user.id, { modules })
-                          }}
-                        />
-                        {label}
-                      </label>
-                    )
-                  })}
-                </div>
               </td>
               <td className="p-3 text-center">
                 <button

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -10,7 +10,6 @@ export async function GET() {
       email: true,
       phone: true,
       role: true,
-      modules: true,
       designation: true,
       imageUrl: true,
       removed: true,
@@ -20,15 +19,13 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
-  const { id, role, modules, password, removed } = await req.json()
+  const { id, role, password, removed } = await req.json()
   const data: Partial<{
     role: string
-    modules: string[]
     password: string
     removed: boolean
   }> = {}
   if (role !== undefined) data.role = role
-  if (modules !== undefined) data.modules = modules
   if (password !== undefined) data.password = password
   if (removed !== undefined) data.removed = removed
   await prisma.user.update({

--- a/src/app/login/SignInClient.tsx
+++ b/src/app/login/SignInClient.tsx
@@ -71,25 +71,11 @@ export default function SignInClient() {
       router.push('/customer')
       return
     }
-    const sessionRes = await fetch('/api/auth/session', { credentials: 'include' })
-    const session = await sessionRes.json()
-    const user = session?.user as { role?: string; modules?: string[] }
-    const modules = user?.modules ?? []
-    const moduleRoutes: Record<string, string> = {
-      dashboard: '/admin/dashboard',
-      staff: '/admin/staff',
-      customers: '/admin/customers',
-      branches: '/admin/branches',
-      services: '/admin/services',
-      billing: '/admin/billing',
-      'staff-roles': '/admin/users',
+    if (role === 'staff') {
+      router.push('/admin/staff')
+      return
     }
-    let destination = '/admin/dashboard'
-    if (user?.role !== 'admin' && modules.length > 0 && !modules.includes('dashboard')) {
-      const first = modules[0]
-      destination = moduleRoutes[first] || destination
-    }
-    router.push(destination)
+    router.push('/admin/dashboard')
   }
 
   // --- Role chooser (styled) ---


### PR DESCRIPTION
## Summary
- Redirect staff to their dashboard after role selection
- Remove module-based permissions and streamline user role management
- Hide admin-only sections in the sidebar for staff members

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: various lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689f4e1514348325b6c531e5d34f9429