### PR TITLE
Enhance staff assignments with search-ready service selector

### DIFF
--- a/pages/api/booking-items.ts
+++ b/pages/api/booking-items.ts
@@ -33,6 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           price,
           staffId: userId!,
           start,
+          status: 'pending',
         },
       })
       return res.status(200).json(item)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -218,6 +218,7 @@ model BookingItem {
   price     Float
   staffId   String  @db.VarChar(191)
   start     String  @db.VarChar(5)
+  status    String  @default("pending") @db.VarChar(191)
 }
 
 model Billing {

--- a/src/app/admin/staff/assignments/page.tsx
+++ b/src/app/admin/staff/assignments/page.tsx
@@ -5,11 +5,14 @@ import ReactSelect from 'react-select'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Input } from '@/components/ui/input'
+import { Search, CheckCircle, Clock, XCircle, ClipboardList } from 'lucide-react'
 
 interface BookingItem {
   id: string
   name: string
   price: number
+  status: string
 }
 
 interface Booking {
@@ -54,22 +57,27 @@ export default function AssignmentsPage() {
   const [selectedService, setSelectedService] = useState<Record<string, string>>({})
   const [selectedVariant, setSelectedVariant] = useState<Record<string, string>>({})
   const [stats, setStats] = useState({ total: 0, pending: 0, completed: 0, cancelled: 0 })
+  const [search, setSearch] = useState('')
 
   const load = async () => {
     const res = await fetch(`/api/staff/assignments?date=${date}`)
     const data = await res.json()
     if (data.success) {
       setGroups(data.groups)
-      const all = data.groups.flatMap((g: Group) => g.bookings)
+      const allItems = data.groups.flatMap((g: Group) =>
+        g.bookings.flatMap((b: Booking) => b.items),
+      )
       setStats({
-        total: all.length,
-        pending: all.filter((b: Booking) => b.status === 'pending').length,
-        completed: all.filter((b: Booking) => b.status === 'completed').length,
-        cancelled: all.filter((b: Booking) => b.status === 'cancelled').length,
+        total: allItems.length,
+        pending: allItems.filter((it: BookingItem) => it.status === 'pending').length,
+        completed: allItems.filter((it: BookingItem) => it.status === 'completed').length,
+        cancelled: allItems.filter((it: BookingItem) => it.status === 'cancelled').length,
       })
     }
   }
-  useEffect(() => { load() }, [date])
+  useEffect(() => {
+    load()
+  }, [date])
 
   useEffect(() => {
     fetch('/api/admin/services-walkin')
@@ -79,8 +87,8 @@ export default function AssignmentsPage() {
       })
   }, [])
 
-  const updateStatus = async (id: string, status: string) => {
-    await fetch(`/api/staff/assignments/${id}/status`, {
+  const updateItemStatus = async (id: string, status: string) => {
+    await fetch(`/api/staff/assignments/items/${id}/status`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ status }),
@@ -104,8 +112,8 @@ export default function AssignmentsPage() {
         duration: variant.duration || 0,
       }),
     })
-    setSelectedService((p) => ({ ...p, [bookingId]: '' }))
-    setSelectedVariant((p) => ({ ...p, [bookingId]: '' }))
+    setSelectedService(p => ({ ...p, [bookingId]: '' }))
+    setSelectedVariant(p => ({ ...p, [bookingId]: '' }))
     load()
   }
 
@@ -118,81 +126,149 @@ export default function AssignmentsPage() {
     load()
   }
 
+  const searchLower = search.toLowerCase()
+  const filteredGroups = groups
+    .map(g => {
+      const filteredBookings = g.bookings
+        .map(b => ({
+          ...b,
+          items: b.items.filter(it => it.name.toLowerCase().includes(searchLower)),
+        }))
+        .filter(b => b.items.length > 0)
+      const matchGroup =
+        (g.customer || '').toLowerCase().includes(searchLower) ||
+        (g.phone || '').includes(search)
+      if (matchGroup) return g
+      if (filteredBookings.length === 0) return null
+      return { ...g, bookings: filteredBookings }
+    })
+    .filter(Boolean) as Group[]
+
   return (
-    <div className="space-y-6">
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6 space-y-6">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-        <h1 className="text-2xl font-bold">Assignments</h1>
-        <input
-          type="date"
-          value={date}
-          onChange={(e) => setDate(e.target.value)}
-          className="border border-gray-300 rounded-md p-2 focus:ring-2 focus:ring-emerald-500"
-        />
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <ClipboardList className="h-6 w-6" /> Assignments
+        </h1>
+        <div className="flex items-center gap-3">
+          <div className="relative">
+            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+            <Input
+              placeholder="Search"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="pl-8 w-48"
+            />
+          </div>
+          <Input type="date" value={date} onChange={e => setDate(e.target.value)} className="w-40" />
+        </div>
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card className="bg-blue-50">
-          <CardContent className="p-4 text-blue-800">
-            <div className="text-2xl font-bold">{stats.total}</div>
-            <div className="text-sm">Total</div>
+          <CardContent className="p-4 text-blue-800 flex items-center gap-3">
+            <ClipboardList className="h-5 w-5" />
+            <div>
+              <div className="text-2xl font-bold">{stats.total}</div>
+              <div className="text-sm">Total</div>
+            </div>
           </CardContent>
         </Card>
         <Card className="bg-yellow-50">
-          <CardContent className="p-4 text-yellow-800">
-            <div className="text-2xl font-bold">{stats.pending}</div>
-            <div className="text-sm">Pending</div>
+          <CardContent className="p-4 text-yellow-800 flex items-center gap-3">
+            <Clock className="h-5 w-5" />
+            <div>
+              <div className="text-2xl font-bold">{stats.pending}</div>
+              <div className="text-sm">Pending</div>
+            </div>
           </CardContent>
         </Card>
         <Card className="bg-green-50">
-          <CardContent className="p-4 text-green-800">
-            <div className="text-2xl font-bold">{stats.completed}</div>
-            <div className="text-sm">Completed</div>
+          <CardContent className="p-4 text-green-800 flex items-center gap-3">
+            <CheckCircle className="h-5 w-5" />
+            <div>
+              <div className="text-2xl font-bold">{stats.completed}</div>
+              <div className="text-sm">Completed</div>
+            </div>
           </CardContent>
         </Card>
         <Card className="bg-red-50">
-          <CardContent className="p-4 text-red-800">
-            <div className="text-2xl font-bold">{stats.cancelled}</div>
-            <div className="text-sm">Cancelled</div>
+          <CardContent className="p-4 text-red-800 flex items-center gap-3">
+            <XCircle className="h-5 w-5" />
+            <div>
+              <div className="text-2xl font-bold">{stats.cancelled}</div>
+              <div className="text-sm">Cancelled</div>
+            </div>
           </CardContent>
         </Card>
       </div>
 
-      {groups.map((g, idx) => (
+      {filteredGroups.map((g, idx) => (
         <Card key={idx} className="shadow">
           <CardHeader>
-            <CardTitle className="text-lg">{g.customer || 'No Name'} - {g.phone || 'No Phone'}</CardTitle>
+            <CardTitle className="text-lg">
+              {g.customer || 'No Name'} - {g.phone || 'No Phone'}
+            </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             {g.bookings.map(b => (
-              <div key={b.id} className="p-4 border rounded bg-gray-50">
-                <div className="flex items-center gap-2">
-                  <div className="flex-1 font-medium">{b.start} - {b.status}</div>
-                  {b.status === 'pending' && (
-                    <>
-                      <Button
-                        onClick={() => updateStatus(b.id, 'completed')}
-                        className="bg-green-600 hover:bg-green-700 text-white"
-                      >
-                        Complete
-                      </Button>
-                      <Button
-                        onClick={() => updateStatus(b.id, 'cancelled')}
-                        className="bg-red-600 hover:bg-red-700 text-white"
-                      >
-                        Cancel
-                      </Button>
-                    </>
-                  )}
-                </div>
-                <ul className="list-disc ml-5 mt-2 text-sm text-gray-700">
-                  {b.items.map(it => (<li key={it.id}>{it.name}</li>))}
+              <div key={b.id} className="p-4 border rounded bg-gray-50 space-y-4">
+                <div className="font-medium">{b.start}</div>
+                <ul className="space-y-2">
+                  {b.items.map(it => (
+                    <li
+                      key={it.id}
+                      className="flex items-center justify-between bg-white p-2 rounded shadow-sm"
+                    >
+                      <div className="flex items-center gap-2">
+                        {it.status === 'completed' && (
+                          <CheckCircle className="h-4 w-4 text-green-600" />
+                        )}
+                        {it.status === 'cancelled' && (
+                          <XCircle className="h-4 w-4 text-red-600" />
+                        )}
+                        {it.status === 'pending' && (
+                          <Clock className="h-4 w-4 text-yellow-600" />
+                        )}
+                        <span className="text-sm">{it.name}</span>
+                      </div>
+                      {it.status === 'pending' && (
+                        <div className="space-x-2">
+                          <Button
+                            size="sm"
+                            onClick={() => updateItemStatus(it.id, 'completed')}
+                            className="bg-green-600 hover:bg-green-700 text-white"
+                          >
+                            Complete
+                          </Button>
+                          <Button
+                            size="sm"
+                            onClick={() => updateItemStatus(it.id, 'cancelled')}
+                            className="bg-red-600 hover:bg-red-700 text-white"
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      )}
+                    </li>
+                  ))}
                 </ul>
                 <div className="mt-4 space-y-2">
+                  <p className="text-xs text-gray-500">Add extra service</p>
                   <ReactSelect<ServiceSelectOption>
                     className="text-sm"
                     options={services.map(s => ({ value: s.id, label: `${s.categoryName} - ${s.name}` }))}
-                    value={selectedService[b.id] ? { value: selectedService[b.id], label: `${services.find(s => s.id === selectedService[b.id])?.categoryName} - ${services.find(s => s.id === selectedService[b.id])?.name}` } : null}
-                    onChange={(opt) => {
+                    value={
+                      selectedService[b.id]
+                        ? {
+                            value: selectedService[b.id],
+                            label: `${services.find(s => s.id === selectedService[b.id])?.categoryName} - ${
+                              services.find(s => s.id === selectedService[b.id])?.name
+                            }`,
+                          }
+                        : null
+                    }
+                    onChange={opt => {
                       const val = opt?.value || ''
                       setSelectedService(prev => ({ ...prev, [b.id]: val }))
                       setSelectedVariant(prev => ({ ...prev, [b.id]: '' }))
@@ -204,7 +280,7 @@ export default function AssignmentsPage() {
                     <div className="flex gap-2">
                       <Select
                         value={selectedVariant[b.id] || ''}
-                        onValueChange={(val) => setSelectedVariant(prev => ({ ...prev, [b.id]: val }))}
+                        onValueChange={val => setSelectedVariant(prev => ({ ...prev, [b.id]: val }))}
                         className="flex-1"
                       >
                         <SelectTrigger className="h-9">
@@ -212,10 +288,11 @@ export default function AssignmentsPage() {
                         </SelectTrigger>
                         <SelectContent>
                           {services
-                            .find((s) => s.id === selectedService[b.id])
-                            ?.variants.map((v) => (
+                            .find(s => s.id === selectedService[b.id])
+                            ?.variants.map(v => (
                               <SelectItem key={v.id} value={v.id}>
-                                {v.name} ({v.duration}m) - ₹{v.currentPrice?.offerPrice ?? v.currentPrice?.actualPrice}
+                                {v.name} ({v.duration}m) - ₹
+                                {v.currentPrice?.offerPrice ?? v.currentPrice?.actualPrice}
                               </SelectItem>
                             ))}
                         </SelectContent>
@@ -232,17 +309,15 @@ export default function AssignmentsPage() {
                 </div>
                 {(!b.customer || !b.phone) && (
                   <div className="mt-4 flex flex-col sm:flex-row gap-2">
-                    <input
+                    <Input
                       placeholder="Name"
                       defaultValue={b.customer || ''}
                       id={`name-${b.id}`}
-                      className="border p-2 flex-1 rounded"
                     />
-                    <input
+                    <Input
                       placeholder="Phone"
                       defaultValue={b.phone || ''}
                       id={`phone-${b.id}`}
-                      className="border p-2 flex-1 rounded"
                     />
                     <Button
                       onClick={() => {

--- a/src/app/admin/staff/assignments/page.tsx
+++ b/src/app/admin/staff/assignments/page.tsx
@@ -1,6 +1,10 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import ReactSelect from 'react-select'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
 interface BookingItem {
   id: string
@@ -23,17 +27,32 @@ interface Group {
   bookings: Booking[]
 }
 
-interface Service {
+interface Variant {
   id: string
   name: string
-  offerPrice: number
-  duration: number
+  duration?: number | null
+  currentPrice?: { actualPrice: number; offerPrice?: number | null } | null
+}
+
+interface ServiceOption {
+  id: string
+  name: string
+  categoryId: string
+  categoryName: string
+  variants: Variant[]
+}
+
+interface ServiceSelectOption {
+  value: string
+  label: string
 }
 
 export default function AssignmentsPage() {
   const [date, setDate] = useState(() => new Date().toISOString().split('T')[0])
   const [groups, setGroups] = useState<Group[]>([])
-  const [services, setServices] = useState<Service[]>([])
+  const [services, setServices] = useState<ServiceOption[]>([])
+  const [selectedService, setSelectedService] = useState<Record<string, string>>({})
+  const [selectedVariant, setSelectedVariant] = useState<Record<string, string>>({})
   const [stats, setStats] = useState({ total: 0, pending: 0, completed: 0, cancelled: 0 })
 
   const load = async () => {
@@ -53,18 +72,10 @@ export default function AssignmentsPage() {
   useEffect(() => { load() }, [date])
 
   useEffect(() => {
-    fetch('/api/admin/services/all')
+    fetch('/api/admin/service-variants/all')
       .then(res => res.json())
-      .then(d => {
-        const list = Array.isArray(d)
-          ? d.map((s: any) => ({
-            id: s.id,
-            name: s.main_service_name || s.name,
-            offerPrice: s.minPrice || 0,
-            duration: s.duration || 0,
-          }))
-          : []
-        setServices(list)
+      .then((d: ServiceOption[]) => {
+        if (Array.isArray(d)) setServices(d)
       })
   }, [])
 
@@ -77,14 +88,24 @@ export default function AssignmentsPage() {
     load()
   }
 
-  const addService = async (bookingId: string, serviceId: string) => {
-    const service = services.find(s => s.id === serviceId)
-    if (!service) return
+  const addService = async (bookingId: string) => {
+    const svcId = selectedService[bookingId]
+    const variantId = selectedVariant[bookingId]
+    const svc = services.find(s => s.id === svcId)
+    const variant = svc?.variants.find(v => v.id === variantId)
+    if (!svc || !variant) return
     await fetch(`/api/staff/assignments/${bookingId}/items`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ serviceId, name: service.name, price: service.offerPrice || 0, duration: service.duration }),
+      body: JSON.stringify({
+        serviceId: variant.id,
+        name: `${svc.name} - ${variant.name}`,
+        price: variant.currentPrice?.offerPrice ?? variant.currentPrice?.actualPrice ?? 0,
+        duration: variant.duration || 0,
+      }),
     })
+    setSelectedService((p) => ({ ...p, [bookingId]: '' }))
+    setSelectedVariant((p) => ({ ...p, [bookingId]: '' }))
     load()
   }
 
@@ -105,97 +126,140 @@ export default function AssignmentsPage() {
           type="date"
           value={date}
           onChange={(e) => setDate(e.target.value)}
-          className="border rounded p-2"
+          className="border border-gray-300 rounded-md p-2 focus:ring-2 focus:ring-emerald-500"
         />
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="p-4 rounded shadow bg-blue-100 text-blue-800">
-          <div className="text-2xl font-bold">{stats.total}</div>
-          <div className="text-sm">Total</div>
-        </div>
-        <div className="p-4 rounded shadow bg-yellow-100 text-yellow-800">
-          <div className="text-2xl font-bold">{stats.pending}</div>
-          <div className="text-sm">Pending</div>
-        </div>
-        <div className="p-4 rounded shadow bg-green-100 text-green-800">
-          <div className="text-2xl font-bold">{stats.completed}</div>
-          <div className="text-sm">Completed</div>
-        </div>
-        <div className="p-4 rounded shadow bg-red-100 text-red-800">
-          <div className="text-2xl font-bold">{stats.cancelled}</div>
-          <div className="text-sm">Cancelled</div>
-        </div>
+        <Card className="bg-blue-50">
+          <CardContent className="p-4 text-blue-800">
+            <div className="text-2xl font-bold">{stats.total}</div>
+            <div className="text-sm">Total</div>
+          </CardContent>
+        </Card>
+        <Card className="bg-yellow-50">
+          <CardContent className="p-4 text-yellow-800">
+            <div className="text-2xl font-bold">{stats.pending}</div>
+            <div className="text-sm">Pending</div>
+          </CardContent>
+        </Card>
+        <Card className="bg-green-50">
+          <CardContent className="p-4 text-green-800">
+            <div className="text-2xl font-bold">{stats.completed}</div>
+            <div className="text-sm">Completed</div>
+          </CardContent>
+        </Card>
+        <Card className="bg-red-50">
+          <CardContent className="p-4 text-red-800">
+            <div className="text-2xl font-bold">{stats.cancelled}</div>
+            <div className="text-sm">Cancelled</div>
+          </CardContent>
+        </Card>
       </div>
 
       {groups.map((g, idx) => (
-        <div key={idx} className="border rounded p-4 shadow">
-          <h2 className="font-semibold text-lg mb-2">{g.customer || 'No Name'} - {g.phone || 'No Phone'}</h2>
-          {g.bookings.map(b => (
-            <div key={b.id} className="mt-4 p-4 border rounded bg-gray-50">
-              <div className="flex items-center gap-2">
-                <div className="flex-1 font-medium">{b.start} - {b.status}</div>
-                {b.status === 'pending' && (
-                  <>
-                    <button
-                      onClick={() => updateStatus(b.id, 'completed')}
-                      className="px-3 py-1 bg-green-600 text-white rounded"
+        <Card key={idx} className="shadow">
+          <CardHeader>
+            <CardTitle className="text-lg">{g.customer || 'No Name'} - {g.phone || 'No Phone'}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {g.bookings.map(b => (
+              <div key={b.id} className="p-4 border rounded bg-gray-50">
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 font-medium">{b.start} - {b.status}</div>
+                  {b.status === 'pending' && (
+                    <>
+                      <Button
+                        onClick={() => updateStatus(b.id, 'completed')}
+                        className="bg-green-600 hover:bg-green-700 text-white"
+                      >
+                        Complete
+                      </Button>
+                      <Button
+                        onClick={() => updateStatus(b.id, 'cancelled')}
+                        className="bg-red-600 hover:bg-red-700 text-white"
+                      >
+                        Cancel
+                      </Button>
+                    </>
+                  )}
+                </div>
+                <ul className="list-disc ml-5 mt-2 text-sm text-gray-700">
+                  {b.items.map(it => (<li key={it.id}>{it.name}</li>))}
+                </ul>
+                <div className="mt-4 space-y-2">
+                  <ReactSelect<ServiceSelectOption>
+                    className="text-sm"
+                    options={services.map(s => ({ value: s.id, label: `${s.categoryName} - ${s.name}` }))}
+                    value={selectedService[b.id] ? { value: selectedService[b.id], label: `${services.find(s => s.id === selectedService[b.id])?.categoryName} - ${services.find(s => s.id === selectedService[b.id])?.name}` } : null}
+                    onChange={(opt) => {
+                      const val = opt?.value || ''
+                      setSelectedService(prev => ({ ...prev, [b.id]: val }))
+                      setSelectedVariant(prev => ({ ...prev, [b.id]: '' }))
+                    }}
+                    placeholder="Select service"
+                    isSearchable
+                  />
+                  {selectedService[b.id] && (
+                    <div className="flex gap-2">
+                      <Select
+                        value={selectedVariant[b.id] || ''}
+                        onValueChange={(val) => setSelectedVariant(prev => ({ ...prev, [b.id]: val }))}
+                        className="flex-1"
+                      >
+                        <SelectTrigger className="h-9">
+                          <SelectValue placeholder="Select variant" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {services
+                            .find((s) => s.id === selectedService[b.id])
+                            ?.variants.map((v) => (
+                              <SelectItem key={v.id} value={v.id}>
+                                {v.name} ({v.duration}m) - ₹{v.currentPrice?.offerPrice ?? v.currentPrice?.actualPrice}
+                              </SelectItem>
+                            ))}
+                        </SelectContent>
+                      </Select>
+                      <Button
+                        onClick={() => addService(b.id)}
+                        className="bg-green-600 hover:bg-green-700"
+                        disabled={!selectedVariant[b.id]}
+                      >
+                        Add
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                {(!b.customer || !b.phone) && (
+                  <div className="mt-4 flex flex-col sm:flex-row gap-2">
+                    <input
+                      placeholder="Name"
+                      defaultValue={b.customer || ''}
+                      id={`name-${b.id}`}
+                      className="border p-2 flex-1 rounded"
+                    />
+                    <input
+                      placeholder="Phone"
+                      defaultValue={b.phone || ''}
+                      id={`phone-${b.id}`}
+                      className="border p-2 flex-1 rounded"
+                    />
+                    <Button
+                      onClick={() => {
+                        const customer = (document.getElementById(`name-${b.id}`) as HTMLInputElement).value
+                        const phone = (document.getElementById(`phone-${b.id}`) as HTMLInputElement).value
+                        updateCustomer(b.id, customer, phone)
+                      }}
+                      className="bg-blue-600 hover:bg-blue-700 text-white"
                     >
-                      Complete
-                    </button>
-                    <button
-                      onClick={() => updateStatus(b.id, 'cancelled')}
-                      className="px-3 py-1 bg-red-600 text-white rounded"
-                    >
-                      Cancel
-                    </button>
-                  </>
+                      Save
+                    </Button>
+                  </div>
                 )}
               </div>
-              <ul className="list-disc ml-5 mt-2 text-sm text-gray-700">
-                {b.items.map(it => (<li key={it.id}>{it.name}</li>))}
-              </ul>
-              <div className="mt-4 flex items-center gap-2">
-                <select
-                  onChange={(e) => addService(b.id, e.target.value)}
-                  defaultValue=""
-                  className="border rounded p-2"
-                >
-                  <option value="" disabled>Add Service</option>
-                  {services.map(s => (
-                    <option key={s.id} value={s.id}>{s.name}</option>
-                  ))}
-                </select>
-              </div>
-              {(!b.customer || !b.phone) && (
-                <div className="mt-4 flex flex-col sm:flex-row gap-2">
-                  <input
-                    placeholder="Name"
-                    defaultValue={b.customer || ''}
-                    id={`name-${b.id}`}
-                    className="border p-2 flex-1 rounded"
-                  />
-                  <input
-                    placeholder="Phone"
-                    defaultValue={b.phone || ''}
-                    id={`phone-${b.id}`}
-                    className="border p-2 flex-1 rounded"
-                  />
-                  <button
-                    onClick={() => {
-                      const customer = (document.getElementById(`name-${b.id}`) as HTMLInputElement).value
-                      const phone = (document.getElementById(`phone-${b.id}`) as HTMLInputElement).value
-                      updateCustomer(b.id, customer, phone)
-                    }}
-                    className="px-3 py-1 bg-blue-600 text-white rounded"
-                  >
-                    Save
-                  </button>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+            ))}
+          </CardContent>
+        </Card>
       ))}
     </div>
   )

--- a/src/app/admin/staff/assignments/page.tsx
+++ b/src/app/admin/staff/assignments/page.tsx
@@ -72,7 +72,7 @@ export default function AssignmentsPage() {
   useEffect(() => { load() }, [date])
 
   useEffect(() => {
-    fetch('/api/admin/service-variants/all')
+    fetch('/api/admin/services-walkin')
       .then(res => res.json())
       .then((d: ServiceOption[]) => {
         if (Array.isArray(d)) setServices(d)

--- a/src/app/api/staff/assignments/[id]/items/route.ts
+++ b/src/app/api/staff/assignments/[id]/items/route.ts
@@ -26,7 +26,7 @@ export async function POST(
   const time = start.toTimeString().slice(0, 5)
 
   await prisma.bookingItem.create({
-    data: { bookingId: params.id, serviceId, name, price, duration, staffId, start: time },
+    data: { bookingId: params.id, serviceId, name, price, duration, staffId, start: time, status: 'pending' },
   })
 
   return Response.json({ success: true })

--- a/src/app/api/staff/assignments/items/[id]/status/route.ts
+++ b/src/app/api/staff/assignments/items/[id]/status/route.ts
@@ -1,0 +1,30 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions)
+  const staffId = session?.user?.id
+  if (!staffId) {
+    return Response.json({ success: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const item = await prisma.bookingItem.findUnique({
+    where: { id: params.id },
+    include: { booking: true },
+  })
+  if (!item || item.booking.staffId !== staffId) {
+    return Response.json({ success: false, error: 'Not found' }, { status: 404 })
+  }
+
+  const { status } = await req.json()
+  if (!['pending', 'completed', 'cancelled'].includes(status)) {
+    return Response.json({ success: false, error: 'Invalid status' }, { status: 400 })
+  }
+
+  await prisma.bookingItem.update({ where: { id: params.id }, data: { status } })
+  return Response.json({ success: true })
+}


### PR DESCRIPTION
## Summary
- Replace simple select with ReactSelect service and variant selectors for staff assignments
- Style staff assignments page using Tailwind cards and inputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f6e2437b88325939e22e9c592b10d