### PR TITLE
Fix staff assignment item creation

### DIFF
--- a/src/app/admin/staff/assignments/page.tsx
+++ b/src/app/admin/staff/assignments/page.tsx
@@ -106,7 +106,8 @@ export default function AssignmentsPage() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        serviceId: variant.id,
+        serviceId: svc.id,
+        tierId: variant.id,
         name: `${svc.name} - ${variant.name}`,
         price: variant.currentPrice?.offerPrice ?? variant.currentPrice?.actualPrice ?? 0,
         duration: variant.duration || 0,

--- a/src/app/api/staff/assignments/[id]/items/route.ts
+++ b/src/app/api/staff/assignments/[id]/items/route.ts
@@ -4,21 +4,28 @@ import { prisma } from '@/lib/prisma'
 
 export async function POST(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   const session = await getServerSession(authOptions)
   const staffId = session?.user?.id
   if (!staffId) {
     return Response.json({ success: false, error: 'Unauthorized' }, { status: 401 })
   }
 
-  const booking = await prisma.booking.findUnique({ where: { id: params.id } })
+  const booking = await prisma.booking.findUnique({ where: { id } })
   if (!booking || booking.staffId !== staffId) {
     return Response.json({ success: false, error: 'Not found' }, { status: 404 })
   }
 
-  const { serviceId, name, price, duration } = await req.json()
-  if (!serviceId || !name || typeof price !== 'number' || typeof duration !== 'number') {
+  const { serviceId, tierId, name, price, duration } = await req.json()
+  if (
+    !serviceId ||
+    !tierId ||
+    !name ||
+    typeof price !== 'number' ||
+    typeof duration !== 'number'
+  ) {
     return Response.json({ success: false, error: 'Missing fields' }, { status: 400 })
   }
 
@@ -26,7 +33,17 @@ export async function POST(
   const time = start.toTimeString().slice(0, 5)
 
   await prisma.bookingItem.create({
-    data: { bookingId: params.id, serviceId, name, price, duration, staffId, start: time, status: 'pending' },
+    data: {
+      bookingId: id,
+      serviceId,
+      tierId,
+      name,
+      price,
+      duration,
+      staffId,
+      start: time,
+      status: 'pending',
+    },
   })
 
   return Response.json({ success: true })


### PR DESCRIPTION
## Summary
- await Next.js route params and validate required service fields
- include tierId when creating staff assignment items and from client add-service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689fe9d52530832587b973ec58790bbe