### PR TITLE
Improve staff assignments page and item creation

### DIFF
--- a/src/app/admin/staff/assignments/page.tsx
+++ b/src/app/admin/staff/assignments/page.tsx
@@ -59,6 +59,11 @@ export default function AssignmentsPage() {
   const [stats, setStats] = useState({ total: 0, pending: 0, completed: 0, cancelled: 0 })
   const [search, setSearch] = useState('')
 
+  const maskPhone = (phone: string | null) => {
+    if (!phone) return 'No Phone'
+    return `XXXXXX${phone.slice(-4)}`
+  }
+
   const load = async () => {
     const res = await fetch(`/api/staff/assignments?date=${date}`)
     const data = await res.json()
@@ -106,7 +111,8 @@ export default function AssignmentsPage() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        serviceId: variant.id,
+        serviceId: svc.id,
+        tierId: variant.id,
         name: `${svc.name} - ${variant.name}`,
         price: variant.currentPrice?.offerPrice ?? variant.currentPrice?.actualPrice ?? 0,
         duration: variant.duration || 0,
@@ -203,139 +209,145 @@ export default function AssignmentsPage() {
         </Card>
       </div>
 
-      {filteredGroups.map((g, idx) => (
-        <Card key={idx} className="shadow">
-          <CardHeader>
-            <CardTitle className="text-lg">
-              {g.customer || 'No Name'} - {g.phone || 'No Phone'}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {g.bookings.map(b => (
-              <div key={b.id} className="p-4 border rounded bg-gray-50 space-y-4">
-                <div className="font-medium">{b.start}</div>
-                <ul className="space-y-2">
-                  {b.items.map(it => (
-                    <li
-                      key={it.id}
-                      className="flex items-center justify-between bg-white p-2 rounded shadow-sm"
-                    >
-                      <div className="flex items-center gap-2">
-                        {it.status === 'completed' && (
-                          <CheckCircle className="h-4 w-4 text-green-600" />
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {filteredGroups.map((g, idx) => (
+          <Card key={idx} className="shadow">
+            <CardHeader>
+              <CardTitle className="text-lg">
+                {g.customer || 'No Name'} - {maskPhone(g.phone)}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {g.bookings.map(b => (
+                <div key={b.id} className="p-4 border rounded bg-gray-50">
+                  <div className="grid grid-cols-[4rem,1fr] gap-4">
+                    <div className="font-medium">{b.start}</div>
+                    <div className="space-y-4">
+                      <ul className="space-y-2">
+                        {b.items.map(it => (
+                          <li
+                            key={it.id}
+                            className="flex items-center justify-between bg-white p-2 rounded shadow-sm"
+                          >
+                            <div className="flex items-center gap-2">
+                              {it.status === 'completed' && (
+                                <CheckCircle className="h-4 w-4 text-green-600" />
+                              )}
+                              {it.status === 'cancelled' && (
+                                <XCircle className="h-4 w-4 text-red-600" />
+                              )}
+                              {it.status === 'pending' && (
+                                <Clock className="h-4 w-4 text-yellow-600" />
+                              )}
+                              <span className="text-sm">{it.name}</span>
+                            </div>
+                            {it.status === 'pending' && (
+                              <div className="space-x-2">
+                                <Button
+                                  size="sm"
+                                  onClick={() => updateItemStatus(it.id, 'completed')}
+                                  className="bg-green-600 hover:bg-green-700 text-white"
+                                >
+                                  Complete
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  onClick={() => updateItemStatus(it.id, 'cancelled')}
+                                  className="bg-red-600 hover:bg-red-700 text-white"
+                                >
+                                  Cancel
+                                </Button>
+                              </div>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                      <div className="space-y-2">
+                        <p className="text-xs text-gray-500">Add extra service</p>
+                        <ReactSelect<ServiceSelectOption>
+                          className="text-sm"
+                          options={services.map(s => ({ value: s.id, label: `${s.categoryName} - ${s.name}` }))}
+                          value={
+                            selectedService[b.id]
+                              ? {
+                                  value: selectedService[b.id],
+                                  label: `${services.find(s => s.id === selectedService[b.id])?.categoryName} - ${
+                                    services.find(s => s.id === selectedService[b.id])?.name
+                                  }`,
+                                }
+                              : null
+                          }
+                          onChange={opt => {
+                            const val = opt?.value || ''
+                            setSelectedService(prev => ({ ...prev, [b.id]: val }))
+                            setSelectedVariant(prev => ({ ...prev, [b.id]: '' }))
+                          }}
+                          placeholder="Select service"
+                          isSearchable
+                        />
+                        {selectedService[b.id] && (
+                          <div className="flex gap-2">
+                            <Select
+                              value={selectedVariant[b.id] || ''}
+                              onValueChange={val => setSelectedVariant(prev => ({ ...prev, [b.id]: val }))}
+                              className="flex-1"
+                            >
+                              <SelectTrigger className="h-9">
+                                <SelectValue placeholder="Select variant" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {services
+                                  .find(s => s.id === selectedService[b.id])
+                                  ?.variants.map(v => (
+                                    <SelectItem key={v.id} value={v.id}>
+                                      {v.name} ({v.duration}m) - ₹
+                                      {v.currentPrice?.offerPrice ?? v.currentPrice?.actualPrice}
+                                    </SelectItem>
+                                  ))}
+                              </SelectContent>
+                            </Select>
+                            <Button
+                              onClick={() => addService(b.id)}
+                              className="bg-green-600 hover:bg-green-700"
+                              disabled={!selectedVariant[b.id]}
+                            >
+                              Add
+                            </Button>
+                          </div>
                         )}
-                        {it.status === 'cancelled' && (
-                          <XCircle className="h-4 w-4 text-red-600" />
-                        )}
-                        {it.status === 'pending' && (
-                          <Clock className="h-4 w-4 text-yellow-600" />
-                        )}
-                        <span className="text-sm">{it.name}</span>
                       </div>
-                      {it.status === 'pending' && (
-                        <div className="space-x-2">
+                      {(!b.customer || !b.phone) && (
+                        <div className="flex flex-col sm:flex-row gap-2">
+                          <Input
+                            placeholder="Name"
+                            defaultValue={b.customer || ''}
+                            id={`name-${b.id}`}
+                          />
+                          <Input
+                            placeholder="Phone"
+                            defaultValue={b.phone || ''}
+                            id={`phone-${b.id}`}
+                          />
                           <Button
-                            size="sm"
-                            onClick={() => updateItemStatus(it.id, 'completed')}
-                            className="bg-green-600 hover:bg-green-700 text-white"
+                            onClick={() => {
+                              const customer = (document.getElementById(`name-${b.id}`) as HTMLInputElement).value
+                              const phone = (document.getElementById(`phone-${b.id}`) as HTMLInputElement).value
+                              updateCustomer(b.id, customer, phone)
+                            }}
+                            className="bg-blue-600 hover:bg-blue-700 text-white"
                           >
-                            Complete
-                          </Button>
-                          <Button
-                            size="sm"
-                            onClick={() => updateItemStatus(it.id, 'cancelled')}
-                            className="bg-red-600 hover:bg-red-700 text-white"
-                          >
-                            Cancel
+                            Save
                           </Button>
                         </div>
                       )}
-                    </li>
-                  ))}
-                </ul>
-                <div className="mt-4 space-y-2">
-                  <p className="text-xs text-gray-500">Add extra service</p>
-                  <ReactSelect<ServiceSelectOption>
-                    className="text-sm"
-                    options={services.map(s => ({ value: s.id, label: `${s.categoryName} - ${s.name}` }))}
-                    value={
-                      selectedService[b.id]
-                        ? {
-                            value: selectedService[b.id],
-                            label: `${services.find(s => s.id === selectedService[b.id])?.categoryName} - ${
-                              services.find(s => s.id === selectedService[b.id])?.name
-                            }`,
-                          }
-                        : null
-                    }
-                    onChange={opt => {
-                      const val = opt?.value || ''
-                      setSelectedService(prev => ({ ...prev, [b.id]: val }))
-                      setSelectedVariant(prev => ({ ...prev, [b.id]: '' }))
-                    }}
-                    placeholder="Select service"
-                    isSearchable
-                  />
-                  {selectedService[b.id] && (
-                    <div className="flex gap-2">
-                      <Select
-                        value={selectedVariant[b.id] || ''}
-                        onValueChange={val => setSelectedVariant(prev => ({ ...prev, [b.id]: val }))}
-                        className="flex-1"
-                      >
-                        <SelectTrigger className="h-9">
-                          <SelectValue placeholder="Select variant" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {services
-                            .find(s => s.id === selectedService[b.id])
-                            ?.variants.map(v => (
-                              <SelectItem key={v.id} value={v.id}>
-                                {v.name} ({v.duration}m) - ₹
-                                {v.currentPrice?.offerPrice ?? v.currentPrice?.actualPrice}
-                              </SelectItem>
-                            ))}
-                        </SelectContent>
-                      </Select>
-                      <Button
-                        onClick={() => addService(b.id)}
-                        className="bg-green-600 hover:bg-green-700"
-                        disabled={!selectedVariant[b.id]}
-                      >
-                        Add
-                      </Button>
                     </div>
-                  )}
-                </div>
-                {(!b.customer || !b.phone) && (
-                  <div className="mt-4 flex flex-col sm:flex-row gap-2">
-                    <Input
-                      placeholder="Name"
-                      defaultValue={b.customer || ''}
-                      id={`name-${b.id}`}
-                    />
-                    <Input
-                      placeholder="Phone"
-                      defaultValue={b.phone || ''}
-                      id={`phone-${b.id}`}
-                    />
-                    <Button
-                      onClick={() => {
-                        const customer = (document.getElementById(`name-${b.id}`) as HTMLInputElement).value
-                        const phone = (document.getElementById(`phone-${b.id}`) as HTMLInputElement).value
-                        updateCustomer(b.id, customer, phone)
-                      }}
-                      className="bg-blue-600 hover:bg-blue-700 text-white"
-                    >
-                      Save
-                    </Button>
                   </div>
-                )}
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-      ))}
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/app/api/staff/assignments/[id]/items/route.ts
+++ b/src/app/api/staff/assignments/[id]/items/route.ts
@@ -4,21 +4,28 @@ import { prisma } from '@/lib/prisma'
 
 export async function POST(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   const session = await getServerSession(authOptions)
   const staffId = session?.user?.id
   if (!staffId) {
     return Response.json({ success: false, error: 'Unauthorized' }, { status: 401 })
   }
 
-  const booking = await prisma.booking.findUnique({ where: { id: params.id } })
+  const booking = await prisma.booking.findUnique({ where: { id } })
   if (!booking || booking.staffId !== staffId) {
     return Response.json({ success: false, error: 'Not found' }, { status: 404 })
   }
 
-  const { serviceId, name, price, duration } = await req.json()
-  if (!serviceId || !name || typeof price !== 'number' || typeof duration !== 'number') {
+  const { serviceId, tierId, name, price, duration } = await req.json()
+  if (
+    !serviceId ||
+    !tierId ||
+    !name ||
+    typeof price !== 'number' ||
+    typeof duration !== 'number'
+  ) {
     return Response.json({ success: false, error: 'Missing fields' }, { status: 400 })
   }
 
@@ -26,7 +33,17 @@ export async function POST(
   const time = start.toTimeString().slice(0, 5)
 
   await prisma.bookingItem.create({
-    data: { bookingId: params.id, serviceId, name, price, duration, staffId, start: time, status: 'pending' },
+    data: {
+      bookingId: id,
+      serviceId,
+      tierId,
+      name,
+      price,
+      duration,
+      staffId,
+      start: time,
+      status: 'pending',
+    },
   })
 
   return Response.json({ success: true })


### PR DESCRIPTION
## Summary
- await Next.js route params and validate required service fields
- include tierId when creating staff assignment items and from client add-service
- mask customer phone numbers and display assignments in a responsive grid layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interface declaring no members, unused vars, missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_689fe9d52530832587b973ec58790bbe