### PR TITLE
Fix staff reports listing

### DIFF
--- a/src/app/admin/staff/reports/page.tsx
+++ b/src/app/admin/staff/reports/page.tsx
@@ -3,10 +3,9 @@
 import { useEffect, useState } from 'react'
 
 interface ReportItem {
-  date: string
+  dateTime: string
   service: string
   category: string | null
-  price: number
 }
 
 export default function ReportsPage() {
@@ -14,6 +13,7 @@ export default function ReportsPage() {
   const [start, setStart] = useState(today)
   const [end, setEnd] = useState(today)
   const [items, setItems] = useState<ReportItem[]>([])
+  const [search, setSearch] = useState('')
 
   const load = async () => {
     const res = await fetch(`/api/staff/reports?start=${start}&end=${end}`)
@@ -22,52 +22,65 @@ export default function ReportsPage() {
     else setItems([])
   }
 
-  useEffect(() => { load() }, [])
+  useEffect(() => {
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-  const total = items.reduce((sum, i) => sum + i.price, 0)
+  const filtered = items.filter((i) =>
+    i.service.toLowerCase().includes(search.toLowerCase()) ||
+    (i.category || '').toLowerCase().includes(search.toLowerCase())
+  )
 
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Reports</h1>
       <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
-        <input type="date" value={start} onChange={(e) => setStart(e.target.value)} className="border rounded p-2" />
-        <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} className="border rounded p-2" />
-        <button onClick={load} className="px-4 py-2 bg-green-600 text-white rounded">Generate</button>
+        <input
+          type="date"
+          value={start}
+          onChange={(e) => setStart(e.target.value)}
+          className="border rounded p-2"
+        />
+        <input
+          type="date"
+          value={end}
+          onChange={(e) => setEnd(e.target.value)}
+          className="border rounded p-2"
+        />
+        <button onClick={load} className="px-4 py-2 bg-green-600 text-white rounded">
+          Generate
+        </button>
+        <input
+          type="text"
+          placeholder="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="border rounded p-2 flex-1"
+        />
       </div>
 
-      {items.length > 0 ? (
-        <>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="p-4 rounded shadow bg-blue-100 text-blue-800">
-              <div className="text-2xl font-bold">{items.length}</div>
-              <div className="text-sm">Services</div>
-            </div>
-            <div className="p-4 rounded shadow bg-green-100 text-green-800">
-              <div className="text-2xl font-bold">₹{total}</div>
-              <div className="text-sm">Revenue</div>
-            </div>
-          </div>
-          <table className="min-w-full border mt-4">
-            <thead>
-              <tr className="bg-gray-100">
-                <th className="border px-2 py-1 text-left">Date</th>
-                <th className="border px-2 py-1 text-left">Category</th>
-                <th className="border px-2 py-1 text-left">Service</th>
-                <th className="border px-2 py-1 text-right">Price</th>
+      {filtered.length > 0 ? (
+        <table className="min-w-full border mt-4">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="border px-2 py-1 text-left">Sl. No.</th>
+              <th className="border px-2 py-1 text-left">Date and time</th>
+              <th className="border px-2 py-1 text-left">Service category</th>
+              <th className="border px-2 py-1 text-left">Service Name</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((i, idx) => (
+              <tr key={idx}>
+                <td className="border px-2 py-1">{idx + 1}</td>
+                <td className="border px-2 py-1">{i.dateTime}</td>
+                <td className="border px-2 py-1">{i.category || '-'}</td>
+                <td className="border px-2 py-1">{i.service}</td>
               </tr>
-            </thead>
-            <tbody>
-              {items.map((i, idx) => (
-                <tr key={idx}>
-                  <td className="border px-2 py-1">{i.date}</td>
-                  <td className="border px-2 py-1">{i.category || '-'}</td>
-                  <td className="border px-2 py-1">{i.service}</td>
-                  <td className="border px-2 py-1 text-right">{i.price}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </>
+            ))}
+          </tbody>
+        </table>
       ) : (
         <p className="text-gray-500">No records for selected range.</p>
       )}

--- a/src/app/api/staff/reports/route.ts
+++ b/src/app/api/staff/reports/route.ts
@@ -16,24 +16,35 @@ export async function GET(req: Request) {
     return Response.json({ success: false, error: 'Missing date range' }, { status: 400 })
   }
 
-  const startDate = new Date(start)
-  const endDate = new Date(end)
-  endDate.setHours(23, 59, 59, 999)
-
   const items = await prisma.bookingItem.findMany({
     where: {
       staffId,
-      booking: { date: { gte: startDate, lte: endDate } },
+      status: 'completed',
+      booking: { date: { gte: start, lte: end } },
     },
-    include: { booking: true, service: true },
+    include: { booking: true },
     orderBy: { start: 'asc' },
   })
 
+  const serviceIds = Array.from(new Set(items.map((i) => i.serviceId)))
+  const [legacyServices, newServices] = await Promise.all([
+    prisma.service.findMany({
+      where: { id: { in: serviceIds } },
+      select: { id: true, category: { select: { name: true } } },
+    }),
+    prisma.serviceNew.findMany({
+      where: { id: { in: serviceIds } },
+      select: { id: true, category: { select: { name: true } } },
+    }),
+  ])
+  const serviceMap = new Map(
+    [...legacyServices, ...newServices].map((s) => [s.id, s.category?.name || null])
+  )
+
   const data = items.map((i) => ({
-    date: i.booking.date,
+    dateTime: `${i.booking.date} ${i.start}`,
     service: i.name,
-    category: i.service?.costCategory || null,
-    price: i.price,
+    category: serviceMap.get(i.serviceId) || null,
   }))
 
   return Response.json({ success: true, items: data })


### PR DESCRIPTION
## Summary
- fix service lookup in staff reports API to avoid invalid include
- map each booking's service category via the ServiceCategory relation
- pull service categories from both legacy and new service tables

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npx eslint src/app/api/staff/reports/route.ts src/app/admin/staff/reports/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689fefd7bb58832597c3dc1b7e464b74