### PR TITLE
feat: link header to dashboard and show admin user info

### DIFF
--- a/src/app/admin/AdminClientLayout.tsx
+++ b/src/app/admin/AdminClientLayout.tsx
@@ -96,6 +96,8 @@ export default function AdminClientLayout({ children }: { children: React.ReactN
   const { data: session } = useSession()
   const role = session?.user?.role
   const sections = role === 'admin' ? adminSections : staffSections
+  const formatRole = (r?: string) =>
+    r ? r.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') : ''
 
   const handleLogout = async () => {
     await fetch('/api/auth/set-role', {
@@ -126,12 +128,33 @@ export default function AdminClientLayout({ children }: { children: React.ReactN
               <span className="font-bold">{role === 'admin' ? 'Admin' : 'Staff'}</span>
             </Link>
           </div>
-          <button
-            onClick={handleLogout}
-            className="flex items-center gap-1 bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
-          >
-            <MdLogout className="text-lg" /> Logout
-          </button>
+          <div className="flex items-center gap-4">
+            {session?.user && (
+              <div className="flex items-center gap-2 bg-green-700/40 px-2 py-1 rounded">
+                {session.user.image ? (
+                  <img
+                    src={session.user.image}
+                    alt={session.user.name || 'avatar'}
+                    className="h-8 w-8 rounded-full object-cover"
+                  />
+                ) : (
+                  <span className="h-8 w-8 rounded-full bg-green-600 flex items-center justify-center text-sm">
+                    {session.user.name?.[0] || 'U'}
+                  </span>
+                )}
+                <div className="leading-tight">
+                  <div className="font-semibold">{session.user.name}</div>
+                  <div className="text-xs text-green-200">{formatRole(session.user.role)}</div>
+                </div>
+              </div>
+            )}
+            <button
+              onClick={handleLogout}
+              className="flex items-center gap-1 bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
+            >
+              <MdLogout className="text-lg" /> Logout
+            </button>
+          </div>
         </header>
 
         {/* Body */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,12 @@ export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const [isScrolled, setIsScrolled] = useState(false)
   const { data: session } = useSession()
+  const dashboardLink =
+    session?.user?.role === "customer"
+      ? "/customer"
+      : session?.user?.role === "staff" || session?.user?.role === "customer_staff"
+      ? "/admin/staff/assignments"
+      : "/admin/dashboard"
 
   useEffect(() => {
     const handleScroll = () => setIsScrolled(window.scrollY > 0)
@@ -53,7 +59,11 @@ export default function Header() {
 
       {session?.user ? (
         <>
-          <span className="flex items-center gap-2">
+          <Link
+            href={dashboardLink}
+            className="flex items-center gap-2"
+            onClick={closeMenus}
+          >
             {session.user.image ? (
               <Image
                 src={session.user.image}
@@ -68,16 +78,17 @@ export default function Header() {
               </span>
             )}
             <span>{session.user.name}</span>
-          </span>
+          </Link>
           <button
             onClick={() => {
               signOut()
               closeMenus()
             }}
-            className="hover:text-green-400 transition-colors"
+            className="flex items-center gap-1 hover:text-green-400 transition-colors"
             aria-label="Logout"
           >
             <LogOut size={18} />
+            <span>Logout</span>
           </button>
         </>
       ) : (


### PR DESCRIPTION
## Summary
- navigate to appropriate dashboard when clicking username in site header
- show logout text and improved user info in header
- display avatar, name, and role in admin pages

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: many lint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68a00c0ff5f48325bbd10f8dbebb9cad