### PR TITLE
Add public pages and admin management for info and gallery sections

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -293,3 +293,30 @@ model Offer {
   createdAt   DateTime @default(now()) @db.Timestamp(3)
   updatedAt   DateTime @default(now()) @updatedAt @db.Timestamp(3)
 }
+
+model StaticPage {
+  id        String   @id @default(uuid())
+  slug      String   @unique
+  title     String
+  content   String?  @db.LongText
+  createdAt DateTime @default(now()) @db.Timestamp(3)
+  updatedAt DateTime @default(now()) @updatedAt @db.Timestamp(3)
+}
+
+model Gallery {
+  id        String         @id @default(uuid())
+  title     String
+  images    GalleryImage[]
+  createdAt DateTime @default(now()) @db.Timestamp(3)
+  updatedAt DateTime @default(now()) @updatedAt @db.Timestamp(3)
+}
+
+model GalleryImage {
+  id        String   @id @default(uuid())
+  imageUrl  String
+  caption   String?
+  gallery   Gallery @relation(fields: [galleryId], references: [id], onDelete: Cascade)
+  galleryId String
+  createdAt DateTime @default(now()) @db.Timestamp(3)
+  updatedAt DateTime @default(now()) @updatedAt @db.Timestamp(3)
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,20 @@
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { headers } from 'next/headers'
+
+export default async function AboutPage() {
+  const headersList = await headers()
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
+  const res = await fetch(`${baseUrl}/api/static-pages/about-greens`, { cache: 'no-store' })
+  const page = await res.json()
+  return (
+    <main className="bg-emerald-950 min-h-screen text-emerald-50 flex flex-col">
+      <Header />
+      <div className="container mx-auto max-w-4xl px-5 md:px-8 pt-24 md:pt-28 pb-10 md:pb-14 flex-1">
+        <h1 className="text-3xl font-bold mb-6 text-emerald-300">{page?.title || 'About Greens'}</h1>
+        <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: page?.content || '' }} />
+      </div>
+      <Footer />
+    </main>
+  )
+}

--- a/src/app/admin/AdminClientLayout.tsx
+++ b/src/app/admin/AdminClientLayout.tsx
@@ -13,18 +13,22 @@ import {
   MdStore,
   MdCategory,
   MdDesignServices,
-  MdStar,
-  MdHistory,
-  MdPayment,
-  MdLogout,
-  MdEvent,
-  MdReceipt,
-  MdMenu,
-  MdViewCarousel,
-  MdQuestionAnswer,
-  MdLocalOffer,
-  MdWorkspacePremium,
-} from 'react-icons/md'
+    MdStar,
+    MdHistory,
+    MdPayment,
+    MdLogout,
+    MdEvent,
+    MdReceipt,
+    MdMenu,
+    MdViewCarousel,
+    MdQuestionAnswer,
+    MdLocalOffer,
+    MdWorkspacePremium,
+    MdInfo,
+    MdWork,
+    MdSchool,
+    MdPhoto,
+  } from 'react-icons/md'
 import type { IconType } from 'react-icons'
 
 const adminSections: {
@@ -52,18 +56,27 @@ const adminSections: {
       { href: '/admin/customers', label: 'Customers', icon: MdPeople },
     ],
   },
-  {
-    heading: 'Location & Setup',
-    items: [
-      { href: '/admin/branches', label: 'Branches', icon: MdStore },
-      { href: '/admin/hero-tabs', label: 'Hero Banners', icon: MdViewCarousel },
-    ],
-  },
-  {
-    heading: 'Services',
-    items: [
-      { href: '/admin/service-categories', label: 'Categories', icon: MdCategory },
-      { href: '/admin/services', label: 'Services', icon: MdDesignServices },
+    {
+      heading: 'Location & Setup',
+      items: [
+        { href: '/admin/branches', label: 'Branches', icon: MdStore },
+        { href: '/admin/hero-tabs', label: 'Hero Banners', icon: MdViewCarousel },
+      ],
+    },
+    {
+      heading: 'Website',
+      items: [
+        { href: '/admin/about', label: 'About Greens', icon: MdInfo },
+        { href: '/admin/jobs', label: 'Jobs @ Greens', icon: MdWork },
+        { href: '/admin/beauty-education', label: 'Beauty Education', icon: MdSchool },
+        { href: '/admin/gallery', label: 'Gallery', icon: MdPhoto },
+      ],
+    },
+    {
+      heading: 'Services',
+      items: [
+        { href: '/admin/service-categories', label: 'Categories', icon: MdCategory },
+        { href: '/admin/services', label: 'Services', icon: MdDesignServices },
       { href: '/admin/featured-services', label: 'Featured Services', icon: MdStar },
       { href: '/admin/limited-time-offers', label: 'Offers', icon: MdLocalOffer },
       { href: '/admin/premium-services', label: 'Premium Services', icon: MdWorkspacePremium },

--- a/src/app/admin/about/page.tsx
+++ b/src/app/admin/about/page.tsx
@@ -1,0 +1,5 @@
+import StaticPageForm from '../components/StaticPageForm'
+
+export default function AdminAboutPage() {
+  return <StaticPageForm slug="about-greens" heading="About Greens" />
+}

--- a/src/app/admin/beauty-education/page.tsx
+++ b/src/app/admin/beauty-education/page.tsx
@@ -1,0 +1,5 @@
+import StaticPageForm from '../components/StaticPageForm'
+
+export default function AdminBeautyEducationPage() {
+  return <StaticPageForm slug="beauty-education" heading="Beauty Education" />
+}

--- a/src/app/admin/components/StaticPageForm.tsx
+++ b/src/app/admin/components/StaticPageForm.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import WysiwygEditor from '@/app/components/WysiwygEditor'
+
+interface Props {
+  slug: string
+  heading: string
+}
+
+export default function StaticPageForm({ slug, heading }: Props) {
+  const [form, setForm] = useState({ title: '', content: '' })
+  const [exists, setExists] = useState(false)
+
+  const load = async () => {
+    const res = await fetch(`/api/admin/static-pages?slug=${slug}`)
+    if (res.ok) {
+      const data = await res.json()
+      if (data) {
+        setForm({ title: data.title || '', content: data.content || '' })
+        setExists(true)
+      }
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [slug])
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const method = exists ? 'PUT' : 'POST'
+    await fetch('/api/admin/static-pages', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug, ...form }),
+    })
+    setExists(true)
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-green-700">{heading}</h1>
+      <form onSubmit={save} className="space-y-4 bg-white p-6 rounded shadow border">
+        <div>
+          <label className="block font-medium mb-1">Title</label>
+          <input
+            className="w-full p-2 rounded border"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Content</label>
+          <WysiwygEditor value={form.content} onChange={(v) => setForm({ ...form, content: v })} />
+        </div>
+        <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">
+          Save
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/admin/gallery/page.tsx
+++ b/src/app/admin/gallery/page.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Image {
+  id: string
+  imageUrl: string
+  galleryId: string
+}
+
+interface Gallery {
+  id: string
+  title: string
+  images: Image[]
+}
+
+export default function GalleryAdminPage() {
+  const [galleries, setGalleries] = useState<Gallery[]>([])
+  const [title, setTitle] = useState('')
+
+  const load = async () => {
+    const res = await fetch('/api/admin/galleries')
+    const data = await res.json()
+    setGalleries(data)
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const addGallery = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await fetch('/api/admin/galleries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title })
+    })
+    setTitle('')
+    load()
+  }
+
+  const deleteGallery = async (id: string) => {
+    if (!confirm('Delete this gallery?')) return
+    await fetch('/api/admin/galleries', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id })
+    })
+    load()
+  }
+
+  const handlePhoto = async (e: React.ChangeEvent<HTMLInputElement>, galleryId: string) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const fd = new FormData()
+    fd.append('file', file)
+    const up = await fetch('/api/upload', { method: 'POST', body: fd })
+    const { url } = await up.json()
+    await fetch('/api/admin/gallery-images', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ galleryId, imageUrl: url })
+    })
+    load()
+  }
+
+  const deletePhoto = async (id: string) => {
+    await fetch('/api/admin/gallery-images', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id })
+    })
+    load()
+  }
+
+  const movePhoto = async (id: string, galleryId: string) => {
+    await fetch('/api/admin/gallery-images', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, galleryId })
+    })
+    load()
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Gallery</h1>
+      <form onSubmit={addGallery} className="flex gap-2 mb-6">
+        <input className="flex-1 p-2 rounded border" value={title} onChange={e => setTitle(e.target.value)} placeholder="New gallery title" required />
+        <button className="bg-green-600 px-4 py-2 rounded text-white" type="submit">Add</button>
+      </form>
+      <div className="space-y-8">
+        {galleries.map(g => (
+          <div key={g.id} className="bg-white p-4 rounded shadow border">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-semibold">{g.title}</h2>
+              <button className="text-red-600" onClick={() => deleteGallery(g.id)}>Delete</button>
+            </div>
+            <div className="mb-4">
+              <label className="block font-medium mb-1">Add Photo</label>
+              <input type="file" accept="image/*" onChange={e => handlePhoto(e, g.id)} />
+            </div>
+            {g.images.length > 0 && (
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                {g.images.map(img => (
+                  <div key={img.id} className="relative group">
+                    <img src={img.imageUrl} alt="" className="w-full h-32 object-cover rounded" />
+                    <button className="absolute top-1 right-1 bg-red-600 text-white text-xs px-1 rounded" onClick={() => deletePhoto(img.id)}>X</button>
+                    <select value={g.id} onChange={e => movePhoto(img.id, e.target.value)} className="mt-1 w-full text-sm border rounded">
+                      {galleries.map(opt => (
+                        <option key={opt.id} value={opt.id}>{opt.title}</option>
+                      ))}
+                    </select>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/jobs/page.tsx
+++ b/src/app/admin/jobs/page.tsx
@@ -1,0 +1,5 @@
+import StaticPageForm from '../components/StaticPageForm'
+
+export default function AdminJobsPage() {
+  return <StaticPageForm slug="jobs" heading="Jobs @ Greens" />
+}

--- a/src/app/api/admin/galleries/route.ts
+++ b/src/app/api/admin/galleries/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET() {
+  const galleries = await prisma.gallery.findMany({ include: { images: true }, orderBy: { title: 'asc' } })
+  return NextResponse.json(galleries)
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const gallery = await prisma.gallery.create({ data: { title: data.title } })
+  return NextResponse.json(gallery)
+}
+
+export async function PUT(req: NextRequest) {
+  const data = await req.json()
+  const gallery = await prisma.gallery.update({ where: { id: data.id }, data: { title: data.title } })
+  return NextResponse.json(gallery)
+}
+
+export async function DELETE(req: NextRequest) {
+  const { id } = await req.json()
+  await prisma.gallery.delete({ where: { id } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/gallery-images/route.ts
+++ b/src/app/api/admin/gallery-images/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const img = await prisma.galleryImage.create({ data: { galleryId: data.galleryId, imageUrl: data.imageUrl, caption: data.caption } })
+  return NextResponse.json(img)
+}
+
+export async function PUT(req: NextRequest) {
+  const data = await req.json()
+  const img = await prisma.galleryImage.update({ where: { id: data.id }, data: { galleryId: data.galleryId, caption: data.caption } })
+  return NextResponse.json(img)
+}
+
+export async function DELETE(req: NextRequest) {
+  const { id } = await req.json()
+  await prisma.galleryImage.delete({ where: { id } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/static-pages/route.ts
+++ b/src/app/api/admin/static-pages/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const slug = searchParams.get('slug')
+  if (slug) {
+    const page = await prisma.staticPage.findUnique({ where: { slug } })
+    return NextResponse.json(page)
+  }
+  const pages = await prisma.staticPage.findMany()
+  return NextResponse.json(pages)
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const page = await prisma.staticPage.create({ data: { slug: data.slug, title: data.title, content: data.content } })
+  return NextResponse.json(page)
+}
+
+export async function PUT(req: NextRequest) {
+  const data = await req.json()
+  if (!data.slug) return NextResponse.json({ error: 'Missing slug' }, { status: 400 })
+  const page = await prisma.staticPage.update({ where: { slug: data.slug }, data: { title: data.title, content: data.content } })
+  return NextResponse.json(page)
+}
+
+export async function DELETE(req: NextRequest) {
+  const { slug } = await req.json()
+  if (!slug) return NextResponse.json({ error: 'Missing slug' }, { status: 400 })
+  await prisma.staticPage.delete({ where: { slug } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/galleries/route.ts
+++ b/src/app/api/galleries/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET() {
+  const galleries = await prisma.gallery.findMany({ include: { images: true }, orderBy: { title: 'asc' } })
+  return NextResponse.json(galleries)
+}

--- a/src/app/api/static-pages/[slug]/route.ts
+++ b/src/app/api/static-pages/[slug]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET(
+  req: Request,
+  { params }: { params: { slug: string } }
+) {
+  const page = await prisma.staticPage.findUnique({ where: { slug: params.slug } })
+  if (!page) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(page)
+}

--- a/src/app/beauty-education/page.tsx
+++ b/src/app/beauty-education/page.tsx
@@ -1,0 +1,20 @@
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { headers } from 'next/headers'
+
+export default async function BeautyEducationPage() {
+  const headersList = await headers()
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
+  const res = await fetch(`${baseUrl}/api/static-pages/beauty-education`, { cache: 'no-store' })
+  const page = await res.json()
+  return (
+    <main className="bg-emerald-950 min-h-screen text-emerald-50 flex flex-col">
+      <Header />
+      <div className="container mx-auto max-w-4xl px-5 md:px-8 pt-24 md:pt-28 pb-10 md:pb-14 flex-1">
+        <h1 className="text-3xl font-bold mb-6 text-emerald-300">{page?.title || 'Beauty Education'}</h1>
+        <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: page?.content || '' }} />
+      </div>
+      <Footer />
+    </main>
+  )
+}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,0 +1,28 @@
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { headers } from 'next/headers'
+
+export default async function GalleryPage() {
+  const headersList = await headers()
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
+  const res = await fetch(`${baseUrl}/api/galleries`, { cache: 'no-store' })
+  const galleries = await res.json()
+  return (
+    <main className="bg-emerald-950 min-h-screen text-emerald-50 flex flex-col">
+      <Header />
+      <div className="container mx-auto max-w-6xl px-5 md:px-8 pt-24 md:pt-28 pb-10 md:pb-14 flex-1">
+        {galleries.map((g: any) => (
+          <section key={g.id} className="mb-8">
+            <h2 className="text-2xl font-bold mb-4 text-emerald-300">{g.title}</h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+              {g.images.map((img: any) => (
+                <img key={img.id} src={img.imageUrl} alt="" className="w-full h-40 object-cover rounded" />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+      <Footer />
+    </main>
+  )
+}

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,0 +1,20 @@
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { headers } from 'next/headers'
+
+export default async function JobsPage() {
+  const headersList = await headers()
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
+  const res = await fetch(`${baseUrl}/api/static-pages/jobs`, { cache: 'no-store' })
+  const page = await res.json()
+  return (
+    <main className="bg-emerald-950 min-h-screen text-emerald-50 flex flex-col">
+      <Header />
+      <div className="container mx-auto max-w-4xl px-5 md:px-8 pt-24 md:pt-28 pb-10 md:pb-14 flex-1">
+        <h1 className="text-3xl font-bold mb-6 text-emerald-300">{page?.title || 'Jobs @ Greens'}</h1>
+        <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: page?.content || '' }} />
+      </div>
+      <Footer />
+    </main>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,20 +38,20 @@ export default function Header() {
       </Link>
 
     
-      <Link href="#academy" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
-        Beauty Education
-      </Link>
-      <Link href="#about" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
-        About Greens
-      </Link>
+        <Link href="/beauty-education" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
+          Beauty Education
+        </Link>
+        <Link href="/about" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
+          About Greens
+        </Link>
 
-        <Link href="#" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
-        Jobs @ Greens
-      </Link>
+        <Link href="/jobs" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
+          Jobs @ Greens
+        </Link>
 
-        <Link href="#" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
-        Gallery
-      </Link>
+        <Link href="/gallery" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
+          Gallery
+        </Link>
 
       <Link href="#contact" className="hover:text-green-400 transition-colors" onClick={closeMenus}>
         Contact Us


### PR DESCRIPTION
## Summary
- add StaticPage, Gallery and GalleryImage prisma models and API routes
- build admin forms to edit About, Jobs, Beauty Education and manage galleries
- expose new public pages and header links for info sections and gallery

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: multiple lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a019b3ca348325a45215980335bbe2