### PR TITLE
feat: support multi section pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,17 +2,53 @@ import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import { headers } from 'next/headers'
 
+interface Section {
+  title?: string
+  content?: string
+  imageUrl?: string
+}
+
 export default async function AboutPage() {
   const headersList = await headers()
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
-  const res = await fetch(`${baseUrl}/api/static-pages/about-greens`, { cache: 'no-store' })
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
+  const res = await fetch(`${baseUrl}/api/static-pages/about-greens`, {
+    cache: 'no-store'
+  })
   const page = await res.json()
+  let sections: Section[] = []
+  try {
+    sections = JSON.parse(page?.content || '[]')
+  } catch {
+    // ignore
+  }
   return (
     <main className="bg-emerald-950 min-h-screen text-emerald-50 flex flex-col">
       <Header />
-      <div className="container mx-auto max-w-4xl px-5 md:px-8 pt-24 md:pt-28 pb-10 md:pb-14 flex-1">
-        <h1 className="text-3xl font-bold mb-6 text-emerald-300">{page?.title || 'About Greens'}</h1>
-        <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: page?.content || '' }} />
+      <div className="container mx-auto max-w-4xl px-5 md:px-8 pt-24 md:pt-28 pb-10 md:pb-14 flex-1 space-y-8">
+        <h1 className="text-3xl font-bold mb-6 text-emerald-300">
+          {page?.title || 'About Greens'}
+        </h1>
+        {sections.map((sec, i) => (
+          <div key={i} className="space-y-2">
+            {sec.title && (
+              <h2 className="text-xl font-semibold text-emerald-200">
+                {sec.title}
+              </h2>
+            )}
+            {sec.imageUrl && (
+              <img
+                src={sec.imageUrl}
+                alt=""
+                className="w-full rounded"
+              />
+            )}
+            <div
+              className="prose prose-invert max-w-none"
+              dangerouslySetInnerHTML={{ __html: sec.content || '' }}
+            />
+          </div>
+        ))}
       </div>
       <Footer />
     </main>

--- a/src/app/admin/gallery/page.tsx
+++ b/src/app/admin/gallery/page.tsx
@@ -49,18 +49,24 @@ export default function GalleryAdminPage() {
     load()
   }
 
-  const handlePhoto = async (e: React.ChangeEvent<HTMLInputElement>, galleryId: string) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    const fd = new FormData()
-    fd.append('file', file)
-    const up = await fetch('/api/upload', { method: 'POST', body: fd })
-    const { url } = await up.json()
-    await fetch('/api/admin/gallery-images', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ galleryId, imageUrl: url })
-    })
+  const handlePhoto = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+    galleryId: string
+  ) => {
+    const files = e.target.files
+    if (!files || files.length === 0) return
+    for (const file of Array.from(files)) {
+      const fd = new FormData()
+      fd.append('file', file)
+      const up = await fetch('/api/upload', { method: 'POST', body: fd })
+      const { url } = await up.json()
+      await fetch('/api/admin/gallery-images', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ galleryId, imageUrl: url })
+      })
+    }
+    e.target.value = ''
     load()
   }
 
@@ -98,7 +104,12 @@ export default function GalleryAdminPage() {
             </div>
             <div className="mb-4">
               <label className="block font-medium mb-1">Add Photo</label>
-              <input type="file" accept="image/*" onChange={e => handlePhoto(e, g.id)} />
+              <input
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={e => handlePhoto(e, g.id)}
+              />
             </div>
             {g.images.length > 0 && (
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">

--- a/src/app/admin/jobs/page.tsx
+++ b/src/app/admin/jobs/page.tsx
@@ -1,5 +1,116 @@
-import StaticPageForm from '../components/StaticPageForm'
+'use client'
+import { useEffect, useState } from 'react'
+import WysiwygEditor from '@/app/components/WysiwygEditor'
+
+interface Section {
+  title: string
+  content: string
+}
 
 export default function AdminJobsPage() {
-  return <StaticPageForm slug="jobs" heading="Jobs @ Greens" />
+  const [pageTitle, setPageTitle] = useState('')
+  const [sections, setSections] = useState<Section[]>([{ title: '', content: '' }])
+  const [exists, setExists] = useState(false)
+
+  const load = async () => {
+    const res = await fetch('/api/admin/static-pages?slug=jobs')
+    if (res.ok) {
+      const data = await res.json()
+      if (data) {
+        setPageTitle(data.title || '')
+        try {
+          const parsed = JSON.parse(data.content || '[]')
+          if (Array.isArray(parsed) && parsed.length) setSections(parsed)
+        } catch {
+          if (data.content) setSections([{ title: '', content: data.content }])
+        }
+        setExists(true)
+      }
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const addSection = () => setSections([...sections, { title: '', content: '' }])
+  const updateSection = (idx: number, field: keyof Section, value: string) => {
+    const copy = [...sections]
+    copy[idx] = { ...copy[idx], [field]: value }
+    setSections(copy)
+  }
+  const removeSection = (idx: number) =>
+    setSections(sections.filter((_, i) => i !== idx))
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const method = exists ? 'PUT' : 'POST'
+    await fetch('/api/admin/static-pages', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        slug: 'jobs',
+        title: pageTitle,
+        content: JSON.stringify(sections)
+      })
+    })
+    setExists(true)
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-green-700">Jobs @ Greens</h1>
+      <form onSubmit={save} className="space-y-4 bg-white p-6 rounded shadow border">
+        <div>
+          <label className="block font-medium mb-1">Page Title</label>
+          <input
+            className="w-full p-2 rounded border"
+            value={pageTitle}
+            onChange={e => setPageTitle(e.target.value)}
+            required
+          />
+        </div>
+        {sections.map((sec, idx) => (
+          <div key={idx} className="border rounded p-4 space-y-2">
+            <div className="flex justify-between items-center">
+              <label className="font-medium">Section {idx + 1}</label>
+              {sections.length > 1 && (
+                <button
+                  type="button"
+                  className="text-red-600 text-sm"
+                  onClick={() => removeSection(idx)}
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+            <input
+              className="w-full p-2 rounded border"
+              value={sec.title}
+              onChange={e => updateSection(idx, 'title', e.target.value)}
+              placeholder="Title"
+              required
+            />
+            <WysiwygEditor
+              value={sec.content}
+              onChange={v => updateSection(idx, 'content', v)}
+            />
+          </div>
+        ))}
+        <button
+          type="button"
+          className="bg-blue-600 text-white px-3 py-1 rounded"
+          onClick={addSection}
+        >
+          Add Section
+        </button>
+        <button
+          className="bg-green-600 px-4 py-2 rounded text-white"
+          type="submit"
+        >
+          Save
+        </button>
+      </form>
+    </div>
+  )
 }

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -2,17 +2,45 @@ import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import { headers } from 'next/headers'
 
+interface Section {
+  title?: string
+  content?: string
+}
+
 export default async function JobsPage() {
   const headersList = await headers()
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
-  const res = await fetch(`${baseUrl}/api/static-pages/jobs`, { cache: 'no-store' })
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
+  const res = await fetch(`${baseUrl}/api/static-pages/jobs`, {
+    cache: 'no-store'
+  })
   const page = await res.json()
+  let sections: Section[] = []
+  try {
+    sections = JSON.parse(page?.content || '[]')
+  } catch {
+    // ignore
+  }
   return (
     <main className="bg-emerald-950 min-h-screen text-emerald-50 flex flex-col">
       <Header />
-      <div className="container mx-auto max-w-4xl px-5 md:px-8 pt-24 md:pt-28 pb-10 md:pb-14 flex-1">
-        <h1 className="text-3xl font-bold mb-6 text-emerald-300">{page?.title || 'Jobs @ Greens'}</h1>
-        <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: page?.content || '' }} />
+      <div className="container mx-auto max-w-4xl px-5 md:px-8 pt-24 md:pt-28 pb-10 md:pb-14 flex-1 space-y-8">
+        <h1 className="text-3xl font-bold mb-6 text-emerald-300">
+          {page?.title || 'Jobs @ Greens'}
+        </h1>
+        {sections.map((sec, i) => (
+          <div key={i} className="space-y-2">
+            {sec.title && (
+              <h2 className="text-xl font-semibold text-emerald-200">
+                {sec.title}
+              </h2>
+            )}
+            <div
+              className="prose prose-invert max-w-none"
+              dangerouslySetInnerHTML={{ __html: sec.content || '' }}
+            />
+          </div>
+        ))}
       </div>
       <Footer />
     </main>


### PR DESCRIPTION
## Summary
- allow uploading multiple images to galleries
- enable adding multiple jobs sections in admin
- manage about page sections with images
- render about and jobs sections on public pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many errors and warnings)*
- `npm run build` *(warn: compiled with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a0339203c4832583fdca81e28877ad