### PR TITLE
Refactor gallery pages to resolve errors

### DIFF
--- a/src/app/admin/gallery/page.tsx
+++ b/src/app/admin/gallery/page.tsx
@@ -14,6 +14,7 @@ import {
   FolderPlus,
   Copy,
 } from 'lucide-react'
+import Image from 'next/image'
 
 interface Image {
   id: string
@@ -392,11 +393,13 @@ export default function GalleryAdminPage() {
                   <div className="px-4 sm:px-6 pb-6">
                     <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
                       {g.images.map((img) => (
-                        <div key={img.id} className="group relative">
-                          <img
+                        <div key={img.id} className="group relative h-32 w-full">
+                          <Image
                             src={img.imageUrl}
                             alt=""
-                            className="h-32 w-full rounded-xl object-cover ring-1 ring-gray-200"
+                            fill
+                            className="rounded-xl object-cover ring-1 ring-gray-200"
+                            sizes="(max-width: 768px) 50vw, 33vw"
                           />
 
                           {/* Hover controls */}
@@ -485,7 +488,6 @@ export default function GalleryAdminPage() {
                 <path className="opacity-90" fill="currentColor" d="M4 12a8 8 0 018-8v4A4 4 0 008 12H4z"></path>
               </svg>
               <span className="text-sm text-gray-800">Processing...</span>
-</span>
             </div>
           </div>
         </div>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,22 +1,57 @@
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
+import Image from 'next/image'
 import { headers } from 'next/headers'
 
+interface GalleryImage {
+  id: string
+  imageUrl: string
+  caption?: string | null
+}
+
+interface Gallery {
+  id: string
+  title: string
+  images: GalleryImage[]
+}
+
+async function loadGalleries(baseUrl: string): Promise<Gallery[]> {
+  try {
+    const res = await fetch(`${baseUrl}/api/galleries`, { cache: 'no-store' })
+    if (!res.ok) return []
+    return (await res.json()) as Gallery[]
+  } catch {
+    return []
+  }
+}
+
 export default async function GalleryPage() {
-  const headersList = await headers()
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${headersList.get('host')}`
-  const res = await fetch(`${baseUrl}/api/galleries`, { cache: 'no-store' })
-  const galleries = await res.json()
+  const headerList = headers()
+  const host = headerList.get('host') ?? 'localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://${host}`
+  const galleries = await loadGalleries(baseUrl)
+
   return (
     <main className="bg-emerald-950 min-h-screen text-emerald-50 flex flex-col">
       <Header />
       <div className="container mx-auto max-w-6xl px-5 md:px-8 pt-24 md:pt-28 pb-10 md:pb-14 flex-1">
-        {galleries.map((g: any) => (
+        {galleries.length === 0 && (
+          <p className="text-center text-gray-300">No galleries found.</p>
+        )}
+        {galleries.map((g) => (
           <section key={g.id} className="mb-8">
             <h2 className="text-2xl font-bold mb-4 text-emerald-300">{g.title}</h2>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-              {g.images.map((img: any) => (
-                <img key={img.id} src={img.imageUrl} alt="" className="w-full h-40 object-cover rounded" />
+              {g.images.map((img) => (
+                <div key={img.id} className="relative w-full h-40">
+                  <Image
+                    src={img.imageUrl}
+                    alt={img.caption ?? ''}
+                    fill
+                    className="object-cover rounded"
+                    sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
+                  />
+                </div>
               ))}
             </div>
           </section>
@@ -26,3 +61,4 @@ export default async function GalleryPage() {
     </main>
   )
 }
+


### PR DESCRIPTION
## Summary
- refactor public gallery page with typed data loader, Next.js Image component, and graceful empty-state
- fix admin gallery overlay markup and use Next.js Image for thumbnails

## Testing
- `npx eslint src/app/gallery/page.tsx src/app/admin/gallery/page.tsx`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0495685dc8325ba1b57a336f0916a