### PR TITLE
Allow assigning admin role and handle admin staff

### DIFF
--- a/src/app/admin/staff/StaffManagement.tsx
+++ b/src/app/admin/staff/StaffManagement.tsx
@@ -347,6 +347,9 @@ export default function StaffManagement() {
                 <option value="manager" className="text-black">
                   Manager
                 </option>
+                <option value="admin" className="text-black">
+                  Admin
+                </option>
               </select>
             </div>
 
@@ -616,6 +619,7 @@ export default function StaffManagement() {
                         <option value="staff">Staff</option>
                         <option value="customer_staff">Staff & Customer</option>
                         <option value="manager">Manager</option>
+        <option value="admin">Admin</option>
                       </select>
                     </div>
                     <div>
@@ -720,6 +724,7 @@ export default function StaffManagement() {
                       <option value="staff">Staff</option>
                       <option value="customer_staff">Staff & Customer</option>
                       <option value="manager">Manager</option>
+                      <option value="admin">Admin</option>
                     </select>
                   </div>
                   <div>

--- a/src/app/api/staff.ts
+++ b/src/app/api/staff.ts
@@ -6,7 +6,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method !== "GET") return res.status(405).end();
   try {
     const staff = await prisma.user.findMany({
-      where: { role: { in: ["staff", "customer_staff"] }, removed: false },
+      where: { role: { in: ["staff", "customer_staff", "admin"] }, removed: false },
       select: { id: true, name: true },
       orderBy: { name: "asc" },
     });

--- a/src/app/api/staff/route.ts
+++ b/src/app/api/staff/route.ts
@@ -8,7 +8,7 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const branchId = searchParams.get('branchId');
 
-    const where: any = { role: { in: ['staff', 'customer_staff'] } };
+    const where: any = { role: { in: ['staff', 'customer_staff', 'admin'] } };
     if (branchId) where.branchId = branchId;
 
     const staff = await prisma.user.findMany({


### PR DESCRIPTION
## Summary
- enable choosing Admin role when adding or editing staff
- include Admin in role filter options on staff management page
- fetch Admin users from staff API endpoints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-unused-vars, and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a17641d0ac8325ac145f516670ccd0