### PR TITLE
Fix walk-in booking slot helper and surface DB health

### DIFF
--- a/src/app/admin/walk-in/BookingClient.tsx
+++ b/src/app/admin/walk-in/BookingClient.tsx
@@ -67,6 +67,7 @@ interface VariantFull {
 }
 
 interface Selected {
+  id?: string
   serviceId: string
   variantId: string
   name: string
@@ -95,6 +96,31 @@ interface Booking {
 }
 
 const COLORS = ["#f87171", "#60a5fa", "#34d399", "#fbbf24", "#c084fc", "#f472b6"]
+
+const getDefaultSlot = () => {
+  const now = new Date()
+  now.setSeconds(0, 0)
+  const minutes = now.getMinutes()
+  const roundedMinutes = Math.floor(minutes / 15) * 15
+  now.setMinutes(roundedMinutes)
+  return format(now, "HH:mm")
+}
+
+// Round "now" down to nearest 15-min slot, clamped to opening hour (09:00).
+const getRoundedDownSlot = (dateStr: string) => {
+  const d = new Date()
+  const todayStr = format(d, "yyyy-MM-dd")
+  d.setSeconds(0, 0)
+  const rounded = Math.floor(d.getMinutes() / 15) * 15
+  d.setMinutes(rounded)
+
+  if (dateStr === todayStr) {
+    const open = new Date()
+    open.setHours(9, 0, 0, 0)
+    if (d < open) return "09:00"
+  }
+  return format(d, "HH:mm")
+}
 
 export default function AdminBooking() {
   const { data: session, status } = useSession()
@@ -132,6 +158,7 @@ export default function AdminBooking() {
   const formRef = useRef<HTMLFormElement>(null)
   const [attemptSubmit, setAttemptSubmit] = useState(false)
   const [customerStats, setCustomerStats] = useState<{ totalAmount: number; billCount: number } | null>(null)
+  const [dbStatus, setDbStatus] = useState<"checking" | "connected" | "disconnected">("checking")
   const searchParams = useSearchParams()
 
   useEffect(() => {
@@ -210,6 +237,21 @@ export default function AdminBooking() {
 
   useEffect(() => {
     loadServices()
+  }, [])
+
+  useEffect(() => {
+    fetch("/api/health/db", { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error("Database health check failed")
+        return res.json()
+      })
+      .then((data: { connected?: boolean }) => {
+        setDbStatus(data.connected ? "connected" : "disconnected")
+      })
+      .catch((err) => {
+        console.error("Database health check failed", err)
+        setDbStatus("disconnected")
+      })
   }, [])
 
   useEffect(() => {
@@ -364,31 +406,6 @@ const timeOptionsFor = (duration: number) => {
     }
     return false
   }
-
-const getDefaultSlot = () => {
-  const now = new Date();
-  now.setSeconds(0, 0); // Clear seconds/milliseconds
-  const minutes = now.getMinutes();
-  const roundedMinutes = Math.floor(minutes / 15) * 15; // round down to nearest 15 min
-  now.setMinutes(roundedMinutes);
-  return format(now, "HH:mm");
-};
-// Round "now" down to nearest 15-min slot, clamped to opening hour (09:00)
-const getRoundedDownSlot = (dateStr: string) => {
-  const d = new Date();
-  const todayStr = format(d, "yyyy-MM-dd");
-  d.setSeconds(0, 0);
-  const rounded = Math.floor(d.getMinutes() / 15) * 15;
-  d.setMinutes(rounded);
-
-  // clamp to salon hours for today
-  if (dateStr === todayStr) {
-    const open = new Date();
-    open.setHours(9, 0, 0, 0);
-    if (d < open) return "09:00";
-  }
-  return format(d, "HH:mm");
-};
 
 // Find the best default: prefer current rounded slot; if busy, move forward by 15 mins.
 const getBestDefaultSlot = (
@@ -644,6 +661,18 @@ const getBestDefaultSlot = (
       <div className="flex items-center justify-between mb-6 pb-4 border-b border-gray-200">
         <h1 className="text-2xl font-bold text-gray-800">Greens Salon Admin: Walk-in Booking</h1>
         <div className="flex items-center gap-3">
+          <div
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              dbStatus === "connected"
+                ? "bg-green-100 text-green-700"
+                : dbStatus === "checking"
+                  ? "bg-yellow-100 text-yellow-700"
+                  : "bg-red-100 text-red-700"
+            }`}
+            title="Checks server database connectivity through /api/health/db"
+          >
+            DB: {dbStatus === "checking" ? "Checking" : dbStatus === "connected" ? "Connected" : "Disconnected"}
+          </div>
           <Label htmlFor="booking-date" className="sr-only">
             Booking Date
           </Label>

--- a/src/app/api/health/db/route.ts
+++ b/src/app/api/health/db/route.ts
@@ -1,0 +1,22 @@
+import { prisma } from "@/lib/prisma"
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`
+
+    return Response.json({
+      connected: true,
+      message: "Database connection is healthy.",
+    })
+  } catch (error) {
+    console.error("Database health check failed", error)
+
+    return Response.json(
+      {
+        connected: false,
+        message: "Database connection failed.",
+      },
+      { status: 503 },
+    )
+  }
+}


### PR DESCRIPTION
### Motivation
- Resolve a runtime/build error caused by `getDefaultSlot` being referenced before its declaration in the walk-in booking UI and make the default slot logic available to hooks and callbacks. 
- Make it possible to edit/cancel existing booking items by carrying their `id` in the client state. 
- Provide visible feedback in the admin UI when the server cannot reach the database so staff know whether DB operations are likely to succeed.

### Description
- Moved the helper functions `getDefaultSlot` and `getRoundedDownSlot` above the component so they are defined before any hooks or callbacks reference them in `src/app/admin/walk-in/BookingClient.tsx`. 
- Added an optional `id?: string` field to the `Selected` interface to allow editing/deleting existing booking items. 
- Added a lightweight health endpoint `GET /api/health/db` implemented in `src/app/api/health/db/route.ts` that performs a `SELECT 1` via Prisma and returns `{ connected: boolean }`. 
- The booking client now polls `/api/health/db` on mount and displays a small DB status badge in the walk-in header reflecting `checking/connected/disconnected`.

### Testing
- Ran `npm install` which completed successfully and generated the Prisma client. 
- Ran `git diff --check` which passed with no whitespace errors. 
- Attempted `npm run build` which reached compile but failed overall due to pre-existing lint and TypeScript errors elsewhere in the repository (unrelated to these changes). 
- Ran `npx eslint src/app/admin/walk-in/BookingClient.tsx src/app/api/health/db/route.ts` which flagged existing React hook lint issues present in the booking client file. 
- Ran `npx tsc --noEmit` which failed due to existing type errors in multiple unrelated files; the new files themselves do not introduce additional type failures beyond those pre-existing issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cb80728dc8325b1136889b1ed90da)